### PR TITLE
refactor: replace character-based token estimation with tiktoken

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ Configuration and data files follow XDG conventions:
 
 Models are identified by `provider/model-id` format (e.g., `github-copilot/gpt-4o`). The special model name `router-maestro` triggers auto-routing based on priority configuration.
 
+### Pre-Commit Workflow
+
+Run `/lint` and let Codex review the code before committing.
+
 ### Version Updates
 
 When releasing a new version, update these files:

--- a/src/router_maestro/utils/tokens.py
+++ b/src/router_maestro/utils/tokens.py
@@ -89,8 +89,9 @@ def estimate_tokens(text: str) -> int:
 def estimate_tokens_from_char_count(char_count: int) -> int:
     """Estimate token count from character count.
 
-    This is a legacy function kept for backward compatibility.
-    Prefer using count_tokens() with actual text when possible.
+    .. deprecated::
+        This function uses inaccurate character-based estimation.
+        Use count_tokens() with actual text for accurate results.
 
     Args:
         char_count: Number of characters


### PR DESCRIPTION
## Summary
- Replace manual character counting in `count_tokens` endpoint with centralized `count_anthropic_request_tokens` function
- Simplify implementation from ~80 lines to 5 lines using tiktoken-based accurate token counting
- Remove unused imports (`AnthropicToolResultBlock`, `AnthropicToolUseBlock`)
- Mark `estimate_tokens_from_char_count` as deprecated
- Add pre-commit workflow note to CLAUDE.md

## Test plan
- [x] All 268 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff linter passes (`uv run ruff check src/`)
- [x] Code formatted (`uv run ruff format src/`)
- [ ] Manual test of `/v1/messages/count_tokens` endpoint

🤖 Generated with [Claude Code](https://claude.ai/claude-code)