### PR TITLE
feat: provider-aware token counting configuration

### DIFF
--- a/src/router_maestro/utils/__init__.py
+++ b/src/router_maestro/utils/__init__.py
@@ -2,6 +2,15 @@
 
 from router_maestro.utils.logging import get_logger, setup_logging
 from router_maestro.utils.model_sort import ParsedModelId, parse_model_id, sort_models
+from router_maestro.utils.token_config import (
+    ANTHROPIC_CONFIG,
+    COPILOT_CONFIG,
+    DEFAULT_CONFIG,
+    OPENAI_CONFIG,
+    TokenCountingConfig,
+    count_tokens_via_anthropic_api,
+    get_config_for_provider,
+)
 from router_maestro.utils.tokens import (
     BASE_TOOL_TOKENS,
     TOKENS_PER_COMPLETION,
@@ -21,7 +30,11 @@ from router_maestro.utils.tokens import (
 )
 
 __all__ = [
+    "ANTHROPIC_CONFIG",
     "BASE_TOOL_TOKENS",
+    "COPILOT_CONFIG",
+    "DEFAULT_CONFIG",
+    "OPENAI_CONFIG",
     "ParsedModelId",
     "TOKENS_PER_COMPLETION",
     "TOKENS_PER_MESSAGE",
@@ -29,13 +42,16 @@ __all__ = [
     "TOKENS_PER_TOOL",
     "TOOL_CALLS_MULTIPLIER",
     "TOOL_DEFINITION_MULTIPLIER",
+    "TokenCountingConfig",
     "calculate_image_token_cost",
     "calibrate_tokens",
     "count_anthropic_request_tokens",
     "count_tokens",
+    "count_tokens_via_anthropic_api",
     "estimate_anthropic_request_tokens",
     "estimate_tokens",
     "estimate_tokens_from_char_count",
+    "get_config_for_provider",
     "get_logger",
     "map_openai_stop_reason_to_anthropic",
     "parse_model_id",

--- a/src/router_maestro/utils/token_config.py
+++ b/src/router_maestro/utils/token_config.py
@@ -1,0 +1,175 @@
+"""Provider-aware token counting configuration.
+
+Different providers have different tokenization overhead and context window
+sizes. The constants in this module parameterize the token counting logic
+per provider so that estimates are accurate regardless of which upstream
+provider serves the request.
+
+- Copilot config: calibrated to match VS Code Copilot Chat's inflated counts
+  (128k context, higher safety multipliers).
+- Anthropic config: native Anthropic API with no inflation (200k context).
+- OpenAI config: standard OpenAI overhead (no inflated multipliers).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("router_maestro.utils.token_config")
+
+
+@dataclass(frozen=True)
+class TokenCountingConfig:
+    """Parameterises the token counting constants by provider.
+
+    Each field corresponds to a constant previously hardcoded in ``tokens.py``.
+    Frozen for thread-safety and to prevent accidental mutation.
+    """
+
+    # Per-message overhead: special tokens like <|im_start|>role<|im_sep|>
+    tokens_per_message: int = 3
+
+    # Extra token cost when a message has a 'name' field
+    tokens_per_name: int = 1
+
+    # Base tokens for the assistant reply priming
+    tokens_per_completion: int = 3
+
+    # Base overhead when any tools are present in the request
+    base_tool_tokens: int = 16
+
+    # Per-tool overhead for each tool definition
+    tokens_per_tool: int = 8
+
+    # Safety multiplier for tool definition token counts
+    tool_definition_multiplier: float = 1.1
+
+    # Safety multiplier for tool_calls content blocks
+    tool_calls_multiplier: float = 1.5
+
+
+# ---------------------------------------------------------------------------
+# Pre-built configs per provider
+# ---------------------------------------------------------------------------
+
+COPILOT_CONFIG = TokenCountingConfig(
+    tokens_per_message=3,
+    tokens_per_name=1,
+    tokens_per_completion=3,
+    base_tool_tokens=16,
+    tokens_per_tool=8,
+    tool_definition_multiplier=1.1,
+    tool_calls_multiplier=1.5,
+)
+
+ANTHROPIC_CONFIG = TokenCountingConfig(
+    tokens_per_message=3,
+    tokens_per_name=1,
+    tokens_per_completion=3,
+    base_tool_tokens=0,
+    tokens_per_tool=8,
+    tool_definition_multiplier=1.0,
+    tool_calls_multiplier=1.0,
+)
+
+OPENAI_CONFIG = TokenCountingConfig(
+    tokens_per_message=3,
+    tokens_per_name=1,
+    tokens_per_completion=3,
+    base_tool_tokens=8,
+    tokens_per_tool=8,
+    tool_definition_multiplier=1.0,
+    tool_calls_multiplier=1.0,
+)
+
+# Default config preserves backward compatibility (= Copilot-aligned)
+DEFAULT_CONFIG = COPILOT_CONFIG
+
+# Mapping from provider name prefix to config
+_PROVIDER_CONFIG_MAP: dict[str, TokenCountingConfig] = {
+    "github-copilot": COPILOT_CONFIG,
+    "anthropic": ANTHROPIC_CONFIG,
+    "openai": OPENAI_CONFIG,
+}
+
+
+def get_config_for_provider(provider_name: str | None) -> TokenCountingConfig:
+    """Return the appropriate ``TokenCountingConfig`` for a provider.
+
+    Args:
+        provider_name: Provider name (e.g. ``"github-copilot"``, ``"anthropic"``).
+            When ``None``, returns ``DEFAULT_CONFIG`` (Copilot-aligned).
+
+    Returns:
+        The matching config, falling back to ``DEFAULT_CONFIG`` for unknown providers.
+    """
+    if provider_name is None:
+        return DEFAULT_CONFIG
+    return _PROVIDER_CONFIG_MAP.get(provider_name, DEFAULT_CONFIG)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic upstream token counting API
+# ---------------------------------------------------------------------------
+
+
+async def count_tokens_via_anthropic_api(
+    base_url: str,
+    api_key: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    system: str | list[dict[str, Any]] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+) -> int:
+    """Call Anthropic's ``/messages/count_tokens`` API for an exact count.
+
+    Args:
+        base_url: Anthropic API base URL (e.g. ``"https://api.anthropic.com/v1"``).
+            This should include the ``/v1`` path segment, matching the provider's
+            ``base_url`` attribute.
+        api_key: Anthropic API key.
+        model: Model identifier (e.g. ``"claude-sonnet-4-20250514"``).
+        messages: List of message dicts in Anthropic format.
+        system: Optional system prompt (string or list of text blocks).
+        tools: Optional list of tool definition dicts.
+
+    Returns:
+        The exact input token count from Anthropic's API.
+
+    Raises:
+        httpx.HTTPStatusError: On non-2xx response.
+        httpx.RequestError: On connection failures.
+    """
+    url = f"{base_url.rstrip('/')}/messages/count_tokens"
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+    }
+    if system is not None:
+        payload["system"] = system
+    if tools is not None:
+        payload["tools"] = tools
+
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+    input_tokens: int = data["input_tokens"]
+    logger.debug(
+        "Anthropic API count_tokens returned %d for model=%s",
+        input_tokens,
+        model,
+    )
+    return input_tokens

--- a/tests/test_token_config.py
+++ b/tests/test_token_config.py
@@ -1,0 +1,318 @@
+"""Tests for provider-aware token counting configuration."""
+
+from dataclasses import FrozenInstanceError
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from router_maestro.server.schemas.anthropic import (
+    AnthropicTool,
+    AnthropicUserMessage,
+)
+from router_maestro.utils.token_config import (
+    ANTHROPIC_CONFIG,
+    COPILOT_CONFIG,
+    DEFAULT_CONFIG,
+    OPENAI_CONFIG,
+    TokenCountingConfig,
+    count_tokens_via_anthropic_api,
+    get_config_for_provider,
+)
+from router_maestro.utils.tokens import count_anthropic_request_tokens
+
+
+class TestTokenCountingConfig:
+    """Tests for TokenCountingConfig dataclass."""
+
+    def test_default_values(self):
+        config = TokenCountingConfig()
+        assert config.tokens_per_message == 3
+        assert config.tokens_per_name == 1
+        assert config.tokens_per_completion == 3
+        assert config.base_tool_tokens == 16
+        assert config.tokens_per_tool == 8
+        assert config.tool_definition_multiplier == 1.1
+        assert config.tool_calls_multiplier == 1.5
+
+    def test_immutability(self):
+        config = TokenCountingConfig()
+        with pytest.raises(FrozenInstanceError):
+            config.tokens_per_message = 99  # type: ignore[misc]
+
+    def test_custom_values(self):
+        config = TokenCountingConfig(
+            tokens_per_message=5,
+            base_tool_tokens=0,
+            tool_definition_multiplier=1.0,
+            tool_calls_multiplier=1.0,
+        )
+        assert config.tokens_per_message == 5
+        assert config.base_tool_tokens == 0
+        assert config.tool_definition_multiplier == 1.0
+        assert config.tool_calls_multiplier == 1.0
+
+    def test_equality(self):
+        a = TokenCountingConfig()
+        b = TokenCountingConfig()
+        assert a == b
+
+    def test_inequality(self):
+        a = COPILOT_CONFIG
+        b = ANTHROPIC_CONFIG
+        assert a != b
+
+
+class TestPrebuiltConfigs:
+    """Tests for pre-built provider configs."""
+
+    def test_copilot_config_has_inflation(self):
+        assert COPILOT_CONFIG.tool_definition_multiplier == 1.1
+        assert COPILOT_CONFIG.tool_calls_multiplier == 1.5
+        assert COPILOT_CONFIG.base_tool_tokens == 16
+
+    def test_anthropic_config_no_inflation(self):
+        assert ANTHROPIC_CONFIG.tool_definition_multiplier == 1.0
+        assert ANTHROPIC_CONFIG.tool_calls_multiplier == 1.0
+        assert ANTHROPIC_CONFIG.base_tool_tokens == 0
+
+    def test_openai_config_no_inflation(self):
+        assert OPENAI_CONFIG.tool_definition_multiplier == 1.0
+        assert OPENAI_CONFIG.tool_calls_multiplier == 1.0
+        assert OPENAI_CONFIG.base_tool_tokens == 8
+
+    def test_default_is_copilot(self):
+        assert DEFAULT_CONFIG is COPILOT_CONFIG
+
+
+class TestGetConfigForProvider:
+    """Tests for get_config_for_provider() mapping."""
+
+    def test_github_copilot(self):
+        assert get_config_for_provider("github-copilot") is COPILOT_CONFIG
+
+    def test_anthropic(self):
+        assert get_config_for_provider("anthropic") is ANTHROPIC_CONFIG
+
+    def test_openai(self):
+        assert get_config_for_provider("openai") is OPENAI_CONFIG
+
+    def test_none_returns_default(self):
+        assert get_config_for_provider(None) is DEFAULT_CONFIG
+
+    def test_unknown_provider_returns_default(self):
+        assert get_config_for_provider("some-custom-provider") is DEFAULT_CONFIG
+
+    def test_empty_string_returns_default(self):
+        assert get_config_for_provider("") is DEFAULT_CONFIG
+
+
+class TestConfigNoneEquivalence:
+    """Verify that config=None produces the same results as config=COPILOT_CONFIG."""
+
+    def test_simple_message(self):
+        messages = [AnthropicUserMessage(content="Hello, how are you?")]
+        result_none = count_anthropic_request_tokens(system=None, messages=messages, config=None)
+        result_copilot = count_anthropic_request_tokens(
+            system=None, messages=messages, config=COPILOT_CONFIG
+        )
+        assert result_none == result_copilot
+
+    def test_with_tools(self):
+        messages = [AnthropicUserMessage(content="Use a tool")]
+        tools = [
+            AnthropicTool(
+                name="get_weather",
+                description="Get weather for a location",
+                input_schema={
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            )
+        ]
+        result_none = count_anthropic_request_tokens(
+            system=None, messages=messages, tools=tools, config=None
+        )
+        result_copilot = count_anthropic_request_tokens(
+            system=None, messages=messages, tools=tools, config=COPILOT_CONFIG
+        )
+        assert result_none == result_copilot
+
+    def test_with_system(self):
+        messages = [AnthropicUserMessage(content="Hi")]
+        result_none = count_anthropic_request_tokens(
+            system="You are helpful.", messages=messages, config=None
+        )
+        result_copilot = count_anthropic_request_tokens(
+            system="You are helpful.", messages=messages, config=COPILOT_CONFIG
+        )
+        assert result_none == result_copilot
+
+
+class TestAnthropicConfigLowerCounts:
+    """Verify that ANTHROPIC_CONFIG produces lower counts due to no inflation."""
+
+    def test_with_tools_anthropic_lower(self):
+        messages = [AnthropicUserMessage(content="Use a tool")]
+        tools = [
+            AnthropicTool(
+                name="get_weather",
+                description="Get weather for a location",
+                input_schema={
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            )
+        ]
+        copilot = count_anthropic_request_tokens(
+            system=None, messages=messages, tools=tools, config=COPILOT_CONFIG
+        )
+        anthropic = count_anthropic_request_tokens(
+            system=None, messages=messages, tools=tools, config=ANTHROPIC_CONFIG
+        )
+        # Anthropic config has no inflation multipliers -> lower count
+        assert anthropic < copilot
+
+    def test_with_tool_use_block_anthropic_lower(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool_123",
+                        "name": "get_weather",
+                        "input": {"location": "San Francisco"},
+                    }
+                ],
+            },
+        ]
+        copilot = count_anthropic_request_tokens(
+            system=None, messages=messages, config=COPILOT_CONFIG
+        )
+        anthropic = count_anthropic_request_tokens(
+            system=None, messages=messages, config=ANTHROPIC_CONFIG
+        )
+        # tool_calls_multiplier=1.5 vs 1.0 -> copilot should be higher
+        assert anthropic < copilot
+
+    def test_simple_text_no_difference(self):
+        """Without tools or tool_calls, configs should produce the same count."""
+        messages = [AnthropicUserMessage(content="Hello, how are you?")]
+        copilot = count_anthropic_request_tokens(
+            system=None, messages=messages, config=COPILOT_CONFIG
+        )
+        anthropic = count_anthropic_request_tokens(
+            system=None, messages=messages, config=ANTHROPIC_CONFIG
+        )
+        # tokens_per_message/name/completion are the same -> equal
+        assert copilot == anthropic
+
+
+class TestCountTokensViaAnthropicApi:
+    """Tests for count_tokens_via_anthropic_api() with mocked HTTP."""
+
+    @pytest.mark.asyncio
+    async def test_basic_call(self):
+        mock_response = httpx.Response(
+            200,
+            json={"input_tokens": 42},
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages/count_tokens"),
+        )
+
+        with patch("router_maestro.utils.token_config.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await count_tokens_via_anthropic_api(
+                base_url="https://api.anthropic.com/v1",
+                api_key="test-key",
+                model="claude-sonnet-4-20250514",
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+
+        assert result == 42
+        mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args
+        assert "x-api-key" in call_kwargs.kwargs["headers"]
+        assert call_kwargs.kwargs["headers"]["x-api-key"] == "test-key"
+
+    @pytest.mark.asyncio
+    async def test_with_system_and_tools(self):
+        mock_response = httpx.Response(
+            200,
+            json={"input_tokens": 100},
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages/count_tokens"),
+        )
+
+        with patch("router_maestro.utils.token_config.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await count_tokens_via_anthropic_api(
+                base_url="https://api.anthropic.com/v1",
+                api_key="test-key",
+                model="claude-sonnet-4-20250514",
+                messages=[{"role": "user", "content": "Hello"}],
+                system="You are helpful.",
+                tools=[{"name": "test", "description": "A test tool", "input_schema": {}}],
+            )
+
+        assert result == 100
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert "system" in payload
+        assert "tools" in payload
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(self):
+        mock_response = httpx.Response(
+            400,
+            json={"error": "bad request"},
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages/count_tokens"),
+        )
+
+        with patch("router_maestro.utils.token_config.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await count_tokens_via_anthropic_api(
+                    base_url="https://api.anthropic.com/v1",
+                    api_key="test-key",
+                    model="claude-sonnet-4-20250514",
+                    messages=[{"role": "user", "content": "Hello"}],
+                )
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_stripped(self):
+        mock_response = httpx.Response(
+            200,
+            json={"input_tokens": 10},
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages/count_tokens"),
+        )
+
+        with patch("router_maestro.utils.token_config.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await count_tokens_via_anthropic_api(
+                base_url="https://api.anthropic.com/v1/",
+                api_key="test-key",
+                model="claude-sonnet-4-20250514",
+                messages=[{"role": "user", "content": "Hello"}],
+            )
+
+        url_arg = mock_client.post.call_args.args[0]
+        assert url_arg == "https://api.anthropic.com/v1/messages/count_tokens"


### PR DESCRIPTION
## Summary

- Introduce `TokenCountingConfig` frozen dataclass that parameterizes token counting constants per provider, replacing hardcoded Copilot-calibrated values
- Add pre-built configs: `COPILOT_CONFIG` (1.1x/1.5x inflated), `ANTHROPIC_CONFIG` (no inflation), `OPENAI_CONFIG` (standard overhead)
- Route handlers now resolve which provider handles a model and automatically select the appropriate config
- For native Anthropic provider, the `count_tokens` endpoint calls the upstream `/messages/count_tokens` API for exact counts, falling back to local estimation on failure
- All existing callers use `config=None` which defaults to `COPILOT_CONFIG` — zero breaking changes

## Test plan

- [x] All 372 existing tests pass unchanged (`uv run pytest tests/ -v`)
- [x] 25 new tests in `tests/test_token_config.py` (config immutability, provider mapping, API mocking, count equivalence)
- [x] 18 new parameterized tests in `tests/test_tokens.py` (config threading, cross-provider comparisons)
- [x] Ruff lint and format clean
- [ ] Manual: start server, send `/v1/messages/count_tokens` with Copilot model vs Anthropic model, verify different counts
- [ ] Manual: verify Anthropic upstream API returns exact count when authenticated