### PR TITLE
feat: add CLAUDE_CODE_ENABLE_LSP to config generator

### DIFF
--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -191,6 +191,7 @@ def claude_code_config() -> None:
         "ANTHROPIC_MODEL": main_model,
         "ANTHROPIC_SMALL_FAST_MODEL": fast_model,
         "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        "CLAUDE_CODE_ENABLE_LSP": "1",
     }
 
     # Load existing settings to preserve other sections (e.g., MCP servers)


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_ENABLE_LSP=1` to the `env_config` dict in `config claude-code` command
- Enables LSP support by default when generating Claude Code settings

## Test plan
- [x] `uv run ruff check src/router_maestro/cli/config.py` passes
- [x] `uv run pytest tests/ -v -k config` — 96 passed