### PR TITLE
fix: sanitize lone surrogate characters to prevent 500 errors

### DIFF
--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -133,6 +133,30 @@ class CopilotProvider(BaseProvider):
             )
         return self._client
 
+    @staticmethod
+    def _sanitize_surrogates(text: str) -> str:
+        """Remove lone surrogate characters that cannot be encoded as UTF-8."""
+        return text.encode("utf-8", errors="replace").decode("utf-8")
+
+    def _sanitize_content(self, content: str | list) -> str | list:
+        """Sanitize message content to remove lone surrogate characters."""
+        if isinstance(content, str):
+            return self._sanitize_surrogates(content)
+        if isinstance(content, list):
+            result = []
+            for part in content:
+                is_text = (
+                    isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and isinstance(part.get("text"), str)
+                )
+                if is_text:
+                    result.append({**part, "text": self._sanitize_surrogates(part["text"])})
+                else:
+                    result.append(part)
+            return result
+        return content
+
     def _build_messages_payload(self, request: ChatRequest) -> tuple[list[dict], bool]:
         """Build messages payload and detect if images are present.
 
@@ -146,7 +170,7 @@ class CopilotProvider(BaseProvider):
         has_images = False
 
         for m in request.messages:
-            msg: dict = {"role": m.role, "content": m.content}
+            msg: dict = {"role": m.role, "content": self._sanitize_content(m.content)}
             if m.tool_call_id:
                 msg["tool_call_id"] = m.tool_call_id
             if m.tool_calls:


### PR DESCRIPTION
## Summary
- Requests containing lone UTF-16 surrogate characters (e.g. `\udc8d`) crash httpx with `UnicodeEncodeError` when serializing JSON
- Added `_sanitize_surrogates` and `_sanitize_content` to `CopilotProvider` to clean message content before forwarding upstream
- Handles both plain string and multimodal (list) content formats

## Root Cause
Client requests (Claude Code via Anthropic API) occasionally contain lone surrogate characters from JavaScript's UTF-16 string handling. Python's `str.encode('utf-8')` in httpx rejects these, causing unhandled 500s.

## Test plan
- [x] All 575 existing tests pass
- [x] Manual verification: lone surrogates are replaced, normal text passes through unchanged
- [ ] Deploy to OpenClaw and verify no more 500s in logs