### PR TITLE
fix: accept Anthropic document content blocks (PDFs)

### DIFF
--- a/src/router_maestro/server/schemas/anthropic.py
+++ b/src/router_maestro/server/schemas/anthropic.py
@@ -29,12 +29,32 @@ class AnthropicImageBlock(BaseModel):
     source: AnthropicImageSource
 
 
-class AnthropicToolResultContentBlock(BaseModel):
-    """Content block within tool result (text, image, or tool_reference)."""
+class AnthropicDocumentSource(BaseModel):
+    """Document source — supports base64, url, text, or nested content."""
 
-    type: Literal["text", "image", "tool_reference"]
+    type: Literal["base64", "url", "text", "content"]
+    media_type: str | None = None
+    data: str | None = None
+    url: str | None = None
+    content: str | list | None = None
+
+
+class AnthropicDocumentBlock(BaseModel):
+    """Document content block (e.g. PDF, plain text)."""
+
+    type: Literal["document"] = "document"
+    source: AnthropicDocumentSource
+    title: str | None = None
+    context: str | None = None
+    citations: dict | None = None
+
+
+class AnthropicToolResultContentBlock(BaseModel):
+    """Content block within tool result (text, image, document, or tool_reference)."""
+
+    type: Literal["text", "image", "document", "tool_reference"]
     text: str | None = None
-    source: AnthropicImageSource | None = None
+    source: AnthropicImageSource | AnthropicDocumentSource | None = None
     tool_name: str | None = None  # For tool_reference type (Claude Code MCP metadata)
 
 
@@ -63,7 +83,9 @@ class AnthropicThinkingBlock(BaseModel):
     thinking: str
 
 
-AnthropicUserContentBlock = AnthropicTextBlock | AnthropicImageBlock | AnthropicToolResultBlock
+AnthropicUserContentBlock = (
+    AnthropicTextBlock | AnthropicImageBlock | AnthropicDocumentBlock | AnthropicToolResultBlock
+)
 AnthropicAssistantContentBlock = AnthropicTextBlock | AnthropicToolUseBlock | AnthropicThinkingBlock
 
 

--- a/src/router_maestro/server/translation.py
+++ b/src/router_maestro/server/translation.py
@@ -32,6 +32,30 @@ def _get_block_type(block) -> str | None:
     return _get_block_field(block, "type")
 
 
+def _document_block_to_dict(block) -> dict | None:
+    """Convert an Anthropic document block to a plain dict for passthrough.
+
+    Returned in Anthropic-native shape so AnthropicProvider forwards it verbatim.
+    """
+    source = _get_block_field(block, "source")
+    if source is None:
+        return None
+    src_type = _get_block_field(source, "type")
+    if src_type is None:
+        return None
+    src_dict: dict = {"type": src_type}
+    for f in ("media_type", "data", "url", "content"):
+        v = _get_block_field(source, f)
+        if v is not None:
+            src_dict[f] = v
+    doc: dict = {"type": "document", "source": src_dict}
+    for f in ("title", "context", "citations"):
+        v = _get_block_field(block, f)
+        if v is not None:
+            doc[f] = v
+    return doc
+
+
 def translate_anthropic_to_openai(request: AnthropicMessagesRequest) -> ChatRequest:
     """Translate Anthropic Messages request to OpenAI ChatCompletion request."""
     messages = _translate_messages(request.messages, request.system)
@@ -239,6 +263,8 @@ def _handle_user_message(message: AnthropicUserMessage | dict) -> list[Message]:
                     text_parts.append(_get_block_field(item, "text", ""))
                 elif item_type == "image":
                     all_image_blocks.append(item)
+                elif item_type == "document":
+                    all_image_blocks.append(item)
                 elif item_type == "tool_reference":
                     logger.debug(
                         "Skipping tool_reference block: %s",
@@ -355,6 +381,10 @@ def _extract_multimodal_content(blocks: list) -> str | list:
                         "image_url": {"url": f"data:{media_type};base64,{data}"},
                     }
                 )
+        elif block_type == "document":
+            doc_part = _document_block_to_dict(block)
+            if doc_part is not None:
+                image_parts.append(doc_part)
 
     # If no images, return simple text string
     if not image_parts:

--- a/tests/test_translation_advanced.py
+++ b/tests/test_translation_advanced.py
@@ -221,6 +221,32 @@ class TestExtractMultimodalContent:
         assert result[0]["type"] == "image_url"
         assert "image/jpeg" in result[0]["image_url"]["url"]
 
+    def test_document_block_passes_through(self):
+        """Document blocks should be preserved in Anthropic-native shape."""
+        blocks = [
+            {"type": "text", "text": "Summarize this:"},
+            {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": "JVBERi0xLjQK",
+                },
+                "title": "spec.pdf",
+            },
+        ]
+        result = _extract_multimodal_content(blocks)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] == {"type": "text", "text": "Summarize this:"}
+        assert result[1]["type"] == "document"
+        assert result[1]["source"] == {
+            "type": "base64",
+            "media_type": "application/pdf",
+            "data": "JVBERi0xLjQK",
+        }
+        assert result[1]["title"] == "spec.pdf"
+
 
 class TestHandleUserMessage:
     """Tests for user message handling."""
@@ -403,6 +429,70 @@ class TestHandleUserMessage:
         result = _handle_user_message(msg)
         assert len(result) == 1
         assert result[0].role == "tool"
+
+    def test_tool_result_with_document_injects_user_message(self):
+        """Documents in tool_result should be carried in a follow-up user message."""
+        msg = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tc-doc",
+                    "content": [
+                        {"type": "text", "text": "PDF file read: spec.pdf (2KB)"},
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "application/pdf",
+                                "data": "JVBERi0xLjQK",
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+        result = _handle_user_message(msg)
+        assert len(result) == 2
+        assert result[0].role == "tool"
+        assert result[0].tool_call_id == "tc-doc"
+        assert result[0].content == "PDF file read: spec.pdf (2KB)"
+        assert result[1].role == "user"
+        assert isinstance(result[1].content, list)
+        assert result[1].content[0]["type"] == "document"
+        assert result[1].content[0]["source"]["data"] == "JVBERi0xLjQK"
+
+    def test_user_message_with_document_block_parses(self):
+        """AnthropicMessagesRequest should accept user messages containing document blocks."""
+        from router_maestro.server.schemas.anthropic import AnthropicMessagesRequest
+
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-5",
+                "max_tokens": 100,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What does this PDF say?"},
+                            {
+                                "type": "document",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "application/pdf",
+                                    "data": "JVBERi0xLjQK",
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+        assert len(req.messages) == 1
+        blocks = req.messages[0].content
+        assert isinstance(blocks, list)
+        assert blocks[1].type == "document"
+        assert blocks[1].source.media_type == "application/pdf"
 
 
 class TestHandleAssistantMessage:


### PR DESCRIPTION
## Summary
- Add `AnthropicDocumentBlock` / `AnthropicDocumentSource` and include them in `AnthropicUserContentBlock` and `AnthropicToolResultContentBlock` unions, fixing a 422 when Claude Code sends PDF attachments.
- Translate document blocks through `_extract_multimodal_content` in Anthropic-native shape so `AnthropicProvider` forwards them verbatim; also handle documents nested inside `tool_result.content` by injecting them as a follow-up user message (mirrors existing image behaviour).
- Add 3 tests covering schema parsing, multimodal passthrough, and tool_result document injection.

## Test plan
- [x] `uv run pytest tests/test_translation_advanced.py -v` (49 passed, including 3 new)
- [x] `uv run pytest tests/ -q` (595 passed)
- [x] `uv run ruff check src/ tests/` clean
- [ ] End-to-end: replay the failing Claude Code PDF request against a Claude provider and confirm 200 instead of 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)