### PR TITLE
feat: pass reasoning_effort through OpenAI/Responses entrypoints

### DIFF
--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -36,6 +36,8 @@ class ChatRequest:
     tool_choice: str | dict | None = None
     thinking_budget: int | None = None
     thinking_type: str | None = None  # "enabled", "adaptive", "disabled"
+    # OpenAI-style effort: "low" | "medium" | "high" | "xhigh" (Router-Maestro extension)
+    reasoning_effort: str | None = None
     extra: dict = field(default_factory=dict)
 
     def with_thinking(
@@ -55,6 +57,7 @@ class ChatRequest:
             tool_choice=self.tool_choice,
             thinking_budget=thinking_budget,
             thinking_type=thinking_type,
+            reasoning_effort=self.reasoning_effort,
             extra=self.extra,
         )
 
@@ -144,6 +147,7 @@ class ResponsesRequest:
     tools: list[dict] | None = None
     tool_choice: str | dict | None = None
     parallel_tool_calls: bool | None = None
+    reasoning_effort: str | None = None
 
 
 @dataclass

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -25,6 +25,7 @@ from router_maestro.providers.base import (
 from router_maestro.providers.tool_parsing import recover_tool_calls_from_content
 from router_maestro.utils import get_logger
 from router_maestro.utils.cache import TTLCache
+from router_maestro.utils.reasoning import downgrade_for_upstream
 
 logger = get_logger("providers.copilot")
 
@@ -497,6 +498,14 @@ class CopilotProvider(BaseProvider):
             payload["tool_choice"] = request.tool_choice
         if request.parallel_tool_calls is not None:
             payload["parallel_tool_calls"] = request.parallel_tool_calls
+        upstream_effort = downgrade_for_upstream(request.reasoning_effort)
+        if upstream_effort is not None:
+            if request.reasoning_effort == "xhigh":
+                logger.warning(
+                    "Copilot Responses does not accept reasoning_effort=xhigh; "
+                    "downgrading to high"
+                )
+            payload["reasoning"] = {"effort": upstream_effort}
         return payload
 
     def _extract_response_content(self, data: dict) -> str:

--- a/src/router_maestro/providers/openai_base.py
+++ b/src/router_maestro/providers/openai_base.py
@@ -16,6 +16,7 @@ from router_maestro.providers.base import (
     ChatStreamChunk,
 )
 from router_maestro.providers.tool_parsing import recover_tool_calls_from_content
+from router_maestro.utils.reasoning import budget_to_effort, downgrade_for_upstream
 
 
 class OpenAIChatProvider(BaseProvider, ABC):
@@ -60,6 +61,20 @@ class OpenAIChatProvider(BaseProvider, ABC):
             payload["tools"] = request.tools
         if request.tool_choice:
             payload["tool_choice"] = request.tool_choice
+
+        # Forward OpenAI-style reasoning_effort. Fall back to deriving it from
+        # thinking_budget when only the Anthropic-style budget is set. xhigh is
+        # downgraded to "high" since vanilla OpenAI/Copilot reject it.
+        effort = request.reasoning_effort or budget_to_effort(request.thinking_budget)
+        upstream_effort = downgrade_for_upstream(effort)
+        if upstream_effort is not None:
+            if effort == "xhigh":
+                self._logger.warning(
+                    "%s does not accept reasoning_effort=xhigh; downgrading to high",
+                    self._error_label(),
+                )
+            payload["reasoning_effort"] = upstream_effort
+
         payload.update(self._get_payload_extra(request))
         return payload
 

--- a/src/router_maestro/server/routes/chat.py
+++ b/src/router_maestro/server/routes/chat.py
@@ -23,6 +23,7 @@ from router_maestro.server.schemas import (
 )
 from router_maestro.server.streaming import sse_streaming_response
 from router_maestro.utils import get_logger
+from router_maestro.utils.reasoning import VALID_EFFORTS, effort_to_budget
 
 logger = get_logger("server.routes.chat")
 
@@ -63,6 +64,22 @@ async def chat_completions(request: ChatCompletionRequest):
         tools=request.tools,
         tool_choice=request.tool_choice,
     )
+
+    # Reasoning / thinking passthrough.
+    # Prefer OpenAI-style ``reasoning_effort``; also accept Anthropic-style
+    # ``thinking`` for SDKs that forward it via the OpenAI endpoint.
+    effort = (request.reasoning_effort or "").lower() or None
+    if effort and effort in VALID_EFFORTS:
+        chat_request.reasoning_effort = effort
+        chat_request.thinking_budget = effort_to_budget(effort)
+        chat_request.thinking_type = "enabled"
+    elif request.thinking:
+        t_type = request.thinking.get("type")
+        t_budget = request.thinking.get("budget_tokens")
+        if t_type:
+            chat_request.thinking_type = t_type
+        if isinstance(t_budget, int):
+            chat_request.thinking_budget = t_budget
 
     if request.stream:
         return sse_streaming_response(stream_response(model_router, chat_request))

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -20,6 +20,7 @@ from router_maestro.server.schemas import (
 )
 from router_maestro.server.streaming import sse_streaming_response
 from router_maestro.utils import get_logger
+from router_maestro.utils.reasoning import VALID_EFFORTS
 
 logger = get_logger("server.routes.responses")
 
@@ -237,6 +238,11 @@ async def create_response(request: ResponsesRequest):
         tool_choice=convert_tool_choice_to_internal(request.tool_choice),
         parallel_tool_calls=request.parallel_tool_calls,
     )
+
+    if request.reasoning:
+        effort = str(request.reasoning.get("effort", "")).lower() or None
+        if effort and effort in VALID_EFFORTS:
+            internal_request.reasoning_effort = effort
 
     if request.stream:
         return sse_streaming_response(

--- a/src/router_maestro/server/schemas/openai.py
+++ b/src/router_maestro/server/schemas/openai.py
@@ -44,6 +44,11 @@ class ChatCompletionRequest(BaseModel):
     user: str | None = None
     tools: list[dict[str, Any]] | None = None
     tool_choice: str | dict[str, Any] | None = None
+    # OpenAI-style reasoning effort: "low" | "medium" | "high"
+    # Router-Maestro additionally accepts "xhigh" (downgraded for upstream).
+    reasoning_effort: str | None = None
+    # Anthropic-style passthrough; some SDKs forward {"type": "...", "budget_tokens": N}
+    thinking: dict[str, Any] | None = None
 
 
 class ChatCompletionChoice(BaseModel):

--- a/src/router_maestro/server/schemas/responses.py
+++ b/src/router_maestro/server/schemas/responses.py
@@ -108,6 +108,9 @@ class ResponsesRequest(BaseModel):
     tools: list[ResponsesFunctionTool | dict[str, Any]] | None = None
     tool_choice: str | ResponsesToolChoiceFunction | dict[str, Any] | None = None
     parallel_tool_calls: bool | None = None
+    # OpenAI Responses native shape: {"effort": "low"|"medium"|"high"}
+    # Router-Maestro additionally accepts "xhigh" (downgraded for upstream).
+    reasoning: dict[str, Any] | None = None
 
 
 # ============================================================================

--- a/src/router_maestro/utils/reasoning.py
+++ b/src/router_maestro/utils/reasoning.py
@@ -1,0 +1,57 @@
+"""Reasoning effort ↔ thinking budget mapping.
+
+OpenAI-style ``reasoning_effort`` (``"low"``/``"medium"``/``"high"``) and
+Anthropic-style ``thinking.budget_tokens`` (integer) are normalised through
+this module so that every entry-route and every provider speaks the same
+language.
+
+``"xhigh"`` is a Router-Maestro extension above OpenAI's spec — when sent to
+an upstream that does not accept it, providers should downgrade to ``"high"``.
+"""
+
+from __future__ import annotations
+
+EFFORT_TO_BUDGET: dict[str, int] = {
+    "low": 4096,
+    "medium": 8192,
+    "high": 16384,
+    "xhigh": 24000,
+}
+
+VALID_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+
+# Effort levels that vanilla OpenAI / Copilot upstreams accept directly.
+UPSTREAM_NATIVE_EFFORTS: tuple[str, ...] = ("low", "medium", "high")
+
+
+def effort_to_budget(effort: str | None) -> int | None:
+    if effort is None:
+        return None
+    return EFFORT_TO_BUDGET.get(effort.lower())
+
+
+def budget_to_effort(budget: int | None) -> str | None:
+    """Approximate inverse mapping.
+
+    Picks the highest defined effort whose budget is ≤ the requested one.
+    Returns ``None`` when ``budget`` is ``None`` or below the smallest tier.
+    """
+    if budget is None:
+        return None
+    best: str | None = None
+    best_val = -1
+    for name, val in EFFORT_TO_BUDGET.items():
+        if val <= budget and val > best_val:
+            best, best_val = name, val
+    return best
+
+
+def downgrade_for_upstream(effort: str | None) -> str | None:
+    """Map ``xhigh`` → ``high`` for upstreams that reject the extension."""
+    if effort is None:
+        return None
+    if effort in UPSTREAM_NATIVE_EFFORTS:
+        return effort
+    if effort == "xhigh":
+        return "high"
+    return None

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -1,0 +1,158 @@
+"""Tests for reasoning_effort end-to-end passthrough."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from router_maestro.providers.base import ChatRequest, Message, ResponsesRequest
+from router_maestro.providers.copilot import CopilotProvider
+from router_maestro.providers.openai_base import OpenAIChatProvider
+from router_maestro.utils.reasoning import (
+    EFFORT_TO_BUDGET,
+    budget_to_effort,
+    downgrade_for_upstream,
+    effort_to_budget,
+)
+
+
+class _StubOpenAIProvider(OpenAIChatProvider):
+    name = "stub"
+
+    def _get_headers(self) -> dict[str, str]:
+        return {}
+
+    async def list_models(self):  # pragma: no cover - unused
+        return []
+
+    def is_authenticated(self) -> bool:  # pragma: no cover - unused
+        return True
+
+
+def _stub_request(**kwargs) -> ChatRequest:
+    return ChatRequest(
+        model="stub-model",
+        messages=[Message(role="user", content="hi")],
+        **kwargs,
+    )
+
+
+class TestEffortMapping:
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("low", 4096),
+            ("medium", 8192),
+            ("high", 16384),
+            ("xhigh", 24000),
+            ("HIGH", 16384),
+            (None, None),
+            ("bogus", None),
+        ],
+    )
+    def test_effort_to_budget(self, effort, expected):
+        assert effort_to_budget(effort) == expected
+
+    def test_budget_to_effort_picks_highest_fitting(self):
+        assert budget_to_effort(None) is None
+        assert budget_to_effort(100) is None
+        assert budget_to_effort(4096) == "low"
+        assert budget_to_effort(8192) == "medium"
+        assert budget_to_effort(20000) == "high"
+        assert budget_to_effort(EFFORT_TO_BUDGET["xhigh"]) == "xhigh"
+
+    def test_downgrade_for_upstream(self):
+        assert downgrade_for_upstream(None) is None
+        assert downgrade_for_upstream("low") == "low"
+        assert downgrade_for_upstream("xhigh") == "high"
+        assert downgrade_for_upstream("garbage") is None
+
+
+class TestOpenAIPayloadEffort:
+    def _provider(self) -> _StubOpenAIProvider:
+        return _StubOpenAIProvider(base_url="http://stub", logger=logging.getLogger("stub"))
+
+    def test_payload_includes_native_effort(self):
+        payload = self._provider()._build_payload(
+            _stub_request(reasoning_effort="medium"), stream=False
+        )
+        assert payload["reasoning_effort"] == "medium"
+
+    def test_xhigh_downgraded_with_warning(self, caplog):
+        provider = self._provider()
+        with caplog.at_level(logging.WARNING, logger="stub"):
+            payload = provider._build_payload(
+                _stub_request(reasoning_effort="xhigh"), stream=False
+            )
+        assert payload["reasoning_effort"] == "high"
+        assert any("xhigh" in rec.message for rec in caplog.records)
+
+    def test_payload_derives_effort_from_budget(self):
+        payload = self._provider()._build_payload(
+            _stub_request(thinking_budget=16384), stream=False
+        )
+        assert payload["reasoning_effort"] == "high"
+
+    def test_payload_omits_effort_when_unset(self):
+        payload = self._provider()._build_payload(_stub_request(), stream=False)
+        assert "reasoning_effort" not in payload
+
+
+class TestCopilotResponsesPayloadEffort:
+    def test_responses_payload_writes_reasoning(self):
+        provider = CopilotProvider()
+        req = ResponsesRequest(
+            model="gpt-5", input="hi", reasoning_effort="high"
+        )
+        payload = provider._build_responses_payload(req)
+        assert payload["reasoning"] == {"effort": "high"}
+
+    def test_responses_payload_downgrades_xhigh(self):
+        provider = CopilotProvider()
+        req = ResponsesRequest(
+            model="gpt-5", input="hi", reasoning_effort="xhigh"
+        )
+        payload = provider._build_responses_payload(req)
+        assert payload["reasoning"] == {"effort": "high"}
+
+    def test_responses_payload_omits_when_unset(self):
+        provider = CopilotProvider()
+        payload = provider._build_responses_payload(
+            ResponsesRequest(model="gpt-5", input="hi")
+        )
+        assert "reasoning" not in payload
+
+
+class TestChatRouteSchemaPassthrough:
+    """The OpenAI Chat schema must accept reasoning_effort and thinking."""
+
+    def test_schema_accepts_reasoning_effort(self):
+        from router_maestro.server.schemas.openai import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="high",
+        )
+        assert req.reasoning_effort == "high"
+
+    def test_schema_accepts_thinking_passthrough(self):
+        from router_maestro.server.schemas.openai import ChatCompletionRequest
+
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "enabled", "budget_tokens": 12000},
+        )
+        assert req.thinking == {"type": "enabled", "budget_tokens": 12000}
+
+
+class TestResponsesSchemaPassthrough:
+    def test_schema_accepts_reasoning(self):
+        from router_maestro.server.schemas.responses import (
+            ResponsesRequest as ResponsesSchema,
+        )
+
+        req = ResponsesSchema(model="m", input="hi", reasoning={"effort": "xhigh"})
+        assert req.reasoning == {"effort": "xhigh"}


### PR DESCRIPTION
## Summary
- OpenAI Chat (`/api/openai/v1/chat/completions`) now accepts `reasoning_effort` (and Anthropic-style `thinking` passthrough) and forwards it to Copilot/OpenAI/Anthropic providers.
- Responses API (`/api/openai/v1/responses`, used by Codex) now accepts `reasoning: {"effort": ...}` and forwards it to Copilot's responses payload.
- OpenAI native provider's `_build_payload` now writes `reasoning_effort` (deriving from `thinking_budget` when only the Anthropic-style budget is set).
- New `xhigh` extension level (24000 budget) is supported end-to-end, with a downgrade-to-`high` shim for upstreams that don't accept it.
- Anthropic entrypoint behavior is unchanged — it was already correct.

## Why
`reasoning_effort` from the OpenAI Chat schema and `reasoning` from the Responses schema were being silently dropped, and `OpenAIChatProvider._build_payload` never forwarded `thinking_budget`. Only the Anthropic→Copilot path worked. Clients like Claude Code's `/effort` command had no effect on non-Anthropic upstreams.

## Test plan
- [x] 19 new tests in `tests/test_reasoning_effort.py` cover effort↔budget mapping, xhigh downgrade with warning, OpenAI payload writes, Copilot Responses payload writes, and schema acceptance
- [x] Full `uv run pytest tests/` — 614 passed
- [x] `uv run ruff check src/ tests/` clean
- [ ] Smoke test against live VPS deployment with Codex sending `reasoning.effort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)