### PR TITLE
fix: drop Codex CLI namespace tools before sending to Copilot

### DIFF
--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -441,8 +441,16 @@ class CopilotProvider(BaseProvider):
             logger.error("Failed to list Copilot models: %s", e)
             raise ProviderError(f"Failed to list models: {e}", retryable=True)
 
-    # Tools that are not supported by Copilot Responses API
-    UNSUPPORTED_TOOL_TYPES = {"web_search", "web_search_preview", "code_interpreter"}
+    # Tools that are not supported by Copilot Responses API.
+    # ``namespace`` is emitted by Codex CLI to group MCP servers behind a
+    # tool-search facade; Copilot rejects it with
+    # ``Missing required parameter: 'tools[N].tools'``.
+    UNSUPPORTED_TOOL_TYPES = {
+        "web_search",
+        "web_search_preview",
+        "code_interpreter",
+        "namespace",
+    }
 
     def _filter_unsupported_tools(self, tools: list[dict] | None) -> list[dict] | None:
         """Filter out tools that are not supported by Copilot API.

--- a/tests/test_copilot_tool_filter.py
+++ b/tests/test_copilot_tool_filter.py
@@ -1,0 +1,50 @@
+"""Tests for Copilot tool-type filtering."""
+
+from router_maestro.providers import CopilotProvider
+
+
+class TestFilterUnsupportedTools:
+    def setup_method(self):
+        self.provider = CopilotProvider()
+
+    def test_returns_none_for_empty(self):
+        assert self.provider._filter_unsupported_tools(None) is None
+        assert self.provider._filter_unsupported_tools([]) is None
+
+    def test_keeps_function_tools(self):
+        tools = [
+            {"type": "function", "name": "foo", "parameters": {}},
+            {"type": "function", "name": "bar", "parameters": {}},
+        ]
+        assert self.provider._filter_unsupported_tools(tools) == tools
+
+    def test_drops_namespace_tools(self):
+        # Codex CLI emits these to group MCP servers; Copilot rejects with
+        # "Missing required parameter: 'tools[N].tools'".
+        tools = [
+            {"type": "function", "name": "foo"},
+            {
+                "type": "namespace",
+                "name": "mcp__chrome_devtools__",
+                "description": "Tools in the mcp__chrome_devtools__ namespace.",
+            },
+            {"type": "function", "name": "bar"},
+        ]
+        result = self.provider._filter_unsupported_tools(tools)
+        assert result is not None
+        assert all(t["type"] == "function" for t in result)
+        assert [t["name"] for t in result] == ["foo", "bar"]
+
+    def test_drops_web_search_and_code_interpreter(self):
+        tools = [
+            {"type": "web_search"},
+            {"type": "web_search_preview"},
+            {"type": "code_interpreter"},
+        ]
+        assert self.provider._filter_unsupported_tools(tools) is None
+
+    def test_keeps_unknown_non_function_types(self):
+        # denylist semantics: anything not in UNSUPPORTED_TOOL_TYPES passes through
+        tools = [{"type": "local_shell", "name": "shell"}]
+        result = self.provider._filter_unsupported_tools(tools)
+        assert result == tools


### PR DESCRIPTION
## Summary
- Codex CLI emits MCP server groups as `tools[].type="namespace"` entries (deferred behind tool_search). Copilot's Responses API rejects them with `Missing required parameter: 'tools[N].tools'`, breaking every Codex turn.
- Add `"namespace"` to `CopilotProvider.UNSUPPORTED_TOOL_TYPES` so the existing `_filter_unsupported_tools` strips them. Side effect: Codex's MCP servers are not exposed to Copilot until we add a real MCP proxy.
- Reproduced locally against `codex exec` → fix verified end-to-end.

## Test plan
- [x] `uv run pytest tests/` (600 passed)
- [x] `uv run ruff check src/ tests/`
- [x] Local `codex exec` against patched router-maestro returns successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)