### PR TITLE
fix(copilot): per-model reasoning dispatch on chat endpoint (v0.1.34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.1.34 (2026-04-23)
+
+### Fixes
+
+- Per-model reasoning dispatch on Copilot's `/chat/completions` endpoint
+  - Previously the chat path blindly forwarded `thinking_budget`, which the Copilot gateway rejects with `400 invalid_thinking_budget` for OpenAI reasoning models (`gpt-5*`, `o1`, `o3`, `o4`). This broke clients that send Anthropic-style `thinking` (e.g. Cherry Studio → `gpt-5.x`).
+  - New `apply_copilot_chat_reasoning()` routes by model family: Claude keeps `thinking_budget`, GPT-5 / o-series get `reasoning_effort` (with `xhigh` preserved natively — Copilot accepts it), GPT-4 / Gemini omit both fields.
+  - `gpt-5.4*` requires `max_completion_tokens` instead of `max_tokens`; the helper rewrites the field automatically.
+
+### Logging
+
+- Copilot chat / streaming now log `thinking_budget` and `reasoning_effort` (both incoming `ChatRequest` values and the resolved outbound payload values) at DEBUG, so operators can verify what was actually sent to the gateway.
+
+---
+
 ## v0.1.33 (2026-04-20)
 
 ### Chores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.1.33"
+version = "0.1.34"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.1.33"
+__version__ = "0.1.34"

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -25,7 +25,7 @@ from router_maestro.providers.base import (
 from router_maestro.providers.tool_parsing import recover_tool_calls_from_content
 from router_maestro.utils import get_logger
 from router_maestro.utils.cache import TTLCache
-from router_maestro.utils.reasoning import downgrade_for_upstream
+from router_maestro.utils.reasoning import budget_to_effort, downgrade_for_upstream
 
 logger = get_logger("providers.copilot")
 
@@ -33,6 +33,54 @@ COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_CHAT_URL = f"{COPILOT_BASE_URL}/chat/completions"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_RESPONSES_URL = f"{COPILOT_BASE_URL}/responses"
+
+
+def apply_copilot_chat_reasoning(
+    payload: dict,
+    model: str,
+    thinking_budget: int | None,
+    reasoning_effort: str | None,
+) -> None:
+    """Inject reasoning fields into a Copilot ``/chat/completions`` payload.
+
+    Copilot's gateway exposes a different control surface per model family:
+
+    * ``claude-*`` accepts the gateway's ``thinking_budget`` integer field.
+      ``reasoning_effort`` is also accepted on some Claude versions but with
+      per-model enum allowlists (e.g. opus-4.7 only allows ``medium``).
+      Sticking to ``thinking_budget`` keeps the request portable.
+    * ``gpt-5*``/``o1``/``o3``/``o4`` reasoning models accept
+      ``reasoning_effort`` (``low``/``medium``/``high``/``xhigh``) but reject
+      ``thinking_budget`` outright (``invalid_thinking_budget``).
+    * ``gpt-4*``, ``gpt-3.5*``, ``gemini-*`` reject both fields, so we omit them.
+
+    For ``gpt-5.4*`` the gateway also requires ``max_completion_tokens`` instead
+    of ``max_tokens``; this function performs that rewrite when present.
+    """
+    bare = model.split("/", 1)[1] if "/" in model else model
+    bare_lower = bare.lower()
+
+    is_claude = bare_lower.startswith("claude-")
+    is_openai_reasoning = (
+        bare_lower.startswith("gpt-5")
+        or bare_lower.startswith("o1")
+        or bare_lower.startswith("o3")
+        or bare_lower.startswith("o4")
+    )
+
+    if is_claude:
+        if thinking_budget is not None:
+            payload["thinking_budget"] = thinking_budget
+    elif is_openai_reasoning:
+        effort = reasoning_effort or budget_to_effort(thinking_budget)
+        # Copilot's gpt-5* line natively accepts xhigh (verified against the
+        # gateway's supported_values list), so don't downgrade here.
+        if effort in ("low", "medium", "high", "xhigh"):
+            payload["reasoning_effort"] = effort
+
+    if bare_lower.startswith("gpt-5.4") and "max_tokens" in payload:
+        payload["max_completion_tokens"] = payload.pop("max_tokens")
+
 
 # Model cache TTL in seconds (5 minutes)
 MODELS_CACHE_TTL = 300
@@ -205,10 +253,22 @@ class CopilotProvider(BaseProvider):
             payload["tools"] = request.tools
         if request.tool_choice:
             payload["tool_choice"] = request.tool_choice
-        if request.thinking_budget is not None:
-            payload["thinking_budget"] = request.thinking_budget
+        apply_copilot_chat_reasoning(
+            payload,
+            request.model,
+            request.thinking_budget,
+            request.reasoning_effort,
+        )
 
-        logger.debug("Copilot chat completion: model=%s", request.model)
+        logger.debug(
+            "Copilot chat completion: model=%s thinking_budget=%s reasoning_effort=%s "
+            "payload_thinking_budget=%s payload_reasoning_effort=%s",
+            request.model,
+            request.thinking_budget,
+            request.reasoning_effort,
+            payload.get("thinking_budget"),
+            payload.get("reasoning_effort"),
+        )
         client = self._get_client()
         try:
             response = await client.post(
@@ -297,10 +357,22 @@ class CopilotProvider(BaseProvider):
             payload["tools"] = request.tools
         if request.tool_choice:
             payload["tool_choice"] = request.tool_choice
-        if request.thinking_budget is not None:
-            payload["thinking_budget"] = request.thinking_budget
+        apply_copilot_chat_reasoning(
+            payload,
+            request.model,
+            request.thinking_budget,
+            request.reasoning_effort,
+        )
 
-        logger.debug("Copilot streaming chat: model=%s", request.model)
+        logger.debug(
+            "Copilot streaming chat: model=%s thinking_budget=%s reasoning_effort=%s "
+            "payload_thinking_budget=%s payload_reasoning_effort=%s",
+            request.model,
+            request.thinking_budget,
+            request.reasoning_effort,
+            payload.get("thinking_budget"),
+            payload.get("reasoning_effort"),
+        )
         client = self._get_client()
         try:
             async with client.stream(

--- a/tests/test_copilot_chat_reasoning.py
+++ b/tests/test_copilot_chat_reasoning.py
@@ -1,0 +1,86 @@
+"""Tests for per-model reasoning dispatch on Copilot's chat endpoint."""
+
+from router_maestro.providers.copilot import apply_copilot_chat_reasoning
+
+
+def _base_payload(extra: dict | None = None) -> dict:
+    payload = {"model": "x", "messages": [], "max_tokens": 100}
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def test_claude_uses_thinking_budget_not_reasoning_effort():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "claude-opus-4.7", 32000, None)
+    assert p.get("thinking_budget") == 32000
+    assert "reasoning_effort" not in p
+
+
+def test_claude_with_provider_prefix():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "github-copilot/claude-sonnet-4.6", 8192, "high")
+    assert p.get("thinking_budget") == 8192
+    assert "reasoning_effort" not in p
+
+
+def test_gpt5_uses_reasoning_effort_not_thinking_budget():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-5.2", 16384, "high")
+    assert p.get("reasoning_effort") == "high"
+    assert "thinking_budget" not in p
+
+
+def test_gpt5_derives_effort_from_budget_when_effort_missing():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-5.2", 16384, None)
+    assert p.get("reasoning_effort") == "high"
+    assert "thinking_budget" not in p
+
+
+def test_gpt5_preserves_xhigh():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-5.4", 24000, "xhigh")
+    assert p.get("reasoning_effort") == "xhigh"
+
+
+def test_gpt5_4_rewrites_max_tokens():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-5.4", None, "low")
+    assert "max_tokens" not in p
+    assert p.get("max_completion_tokens") == 100
+
+
+def test_gpt5_2_keeps_max_tokens():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-5.2", None, "low")
+    assert p.get("max_tokens") == 100
+    assert "max_completion_tokens" not in p
+
+
+def test_gpt4o_omits_both_fields():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-4o", 8192, "medium")
+    assert "thinking_budget" not in p
+    assert "reasoning_effort" not in p
+
+
+def test_gemini_omits_both_fields():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gemini-2.5-pro", 8192, "medium")
+    assert "thinking_budget" not in p
+    assert "reasoning_effort" not in p
+
+
+def test_no_reasoning_inputs_emits_nothing():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "gpt-5.2", None, None)
+    assert "thinking_budget" not in p
+    assert "reasoning_effort" not in p
+
+
+def test_o_series_treated_as_reasoning():
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "o3-mini", None, "medium")
+    assert p.get("reasoning_effort") == "medium"
+    assert "thinking_budget" not in p

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.1.33"
+version = "0.1.34"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Fix `400 invalid_thinking_budget` from Copilot gateway when Anthropic-style `thinking` is forwarded to OpenAI reasoning models (`gpt-5.x`, `o1`, `o3`, `o4`). Reproduced live against `api.githubcopilot.com` — the gateway maintains a per-model allowlist for reasoning fields:
  - **Claude on Copilot**: accepts `thinking_budget` (any int); `reasoning_effort` enum varies per version (e.g. opus-4.7 only allows `medium`, opus-4.5 / haiku-4.5 / sonnet-4.5 reject all efforts).
  - **GPT-5 / o-series**: rejects `thinking_budget` outright; accepts `reasoning_effort` ∈ `{low, medium, high, xhigh}` (Copilot accepts `xhigh` natively — no downgrade needed).
  - **GPT-4 / Gemini**: rejects both fields.
  - **gpt-5.4***: also requires `max_completion_tokens` instead of `max_tokens`.
- New `apply_copilot_chat_reasoning()` helper centralises the dispatch and is called from both `chat_completion` and `chat_completion_stream`.
- DEBUG logging upgraded to record both incoming `ChatRequest` reasoning fields and resolved outbound payload values, so operators can verify what was actually sent to the gateway.

## Test plan

- [x] 11 new unit tests in `tests/test_copilot_chat_reasoning.py` (per-family dispatch, xhigh preserved, max_tokens rewrite, opus-4.7 effort suppression)
- [x] Full suite: `uv run pytest tests/ -q` → 630 passed
- [x] End-to-end live verification against `api.githubcopilot.com` for gpt-5.2 / gpt-5.4 / claude-opus-4.7 / claude-sonnet-4.6 / gpt-4o / gemini-2.5-pro — all 200 OK with the helper applied
- [ ] Deploy to OpenClaw, set `ROUTER_MAESTRO_LOG_LEVEL=DEBUG`, replay the original Cherry Studio + gpt-5.x request and confirm the gateway returns 200