### PR TITLE
feat(copilot): pass through Claude reasoning as thinking blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
         run: uv python install 3.12
@@ -40,10 +40,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.12
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.12
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     name: Check Branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-branch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
         run: uv python install 3.12
@@ -77,7 +77,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       docker_tags: ${{ steps.docker.outputs.tags }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine version
         id: version
@@ -114,10 +114,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
         run: uv python install 3.12
@@ -146,7 +146,7 @@ jobs:
     needs: prepare
     if: ${{ !inputs.skip_docker }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -178,7 +178,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ The API key is configured via `ROUTER_MAESTRO_API_KEY` env var. For VS Code debu
 
 ### Docker Deployment
 
-Production deployment uses `docker-compose.yml` with Traefik reverse proxy. The OpenClaw server runs the production instance at `https://likanwen.xyz/api/`. Use `make build-multiarch` to build for both amd64 and arm64 (requires the `multiarch` buildx builder).
+Production deployment uses `docker-compose.yml` with Traefik reverse proxy. Use `make build-multiarch` to build for both amd64 and arm64 (requires the `multiarch` buildx builder).
 
 ## Architecture Overview
 

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -8,7 +8,7 @@ from typing import NoReturn
 
 import httpx
 
-TIMEOUT_NON_STREAMING = httpx.Timeout(connect=30.0, read=120.0, write=30.0, pool=30.0)
+TIMEOUT_NON_STREAMING = httpx.Timeout(connect=30.0, read=240.0, write=30.0, pool=30.0)
 TIMEOUT_STREAMING = httpx.Timeout(connect=30.0, read=600.0, write=30.0, pool=30.0)
 
 
@@ -71,6 +71,9 @@ class ChatResponse:
     finish_reason: str = "stop"
     usage: dict | None = None  # {"prompt_tokens": X, "completion_tokens": Y, "total_tokens": Z}
     tool_calls: list[dict] | None = None  # OpenAI-format tool calls from assistant
+    # Reasoning trace (Anthropic "thinking" / OpenAI "reasoning_text" / Copilot "cot_summary")
+    thinking: str | None = None
+    thinking_signature: str | None = None
 
 
 @dataclass
@@ -81,6 +84,8 @@ class ChatStreamChunk:
     finish_reason: str | None = None
     usage: dict | None = None  # Token usage info (typically in final chunk)
     tool_calls: list[dict] | None = None  # Tool call deltas for streaming
+    thinking: str | None = None  # Incremental reasoning text delta
+    thinking_signature: str | None = None  # Opaque/encrypted reasoning id, if provided
 
 
 @dataclass

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -168,8 +168,6 @@ def _extract_reasoning_from_chunk(part: dict | None) -> tuple[str, str | None]:
     return text, sig
 
 
-
-
 class CopilotProvider(BaseProvider):
     """GitHub Copilot provider."""
 
@@ -383,11 +381,7 @@ class CopilotProvider(BaseProvider):
                 # asked for thinking on a known reasoning model — otherwise a
                 # malformed upstream response would silently look like a blank
                 # assistant message.
-                if (
-                    completion_tokens > 0
-                    and reasoning_capable
-                    and _thinking_requested(request)
-                ):
+                if completion_tokens > 0 and reasoning_capable and _thinking_requested(request):
                     logger.warning(
                         "Copilot returned empty choices but completion_tokens=%d; "
                         "treating as thinking-only response",

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -35,6 +35,20 @@ COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_RESPONSES_URL = f"{COPILOT_BASE_URL}/responses"
 
 
+def _claude_supports_reasoning(bare_lower: str) -> bool:
+    """Whether a Claude model on Copilot exposes any reasoning control.
+
+    Per the Copilot model picker (vscode-copilot-chat), the 4.6+ generations
+    accept ``reasoning_effort``. Older models (sonnet-4, sonnet-4.5,
+    opus-4.5, haiku-4.5) have no reasoning control surface.
+    """
+    return (
+        bare_lower.startswith("claude-opus-4.7")
+        or bare_lower.startswith("claude-opus-4.6")
+        or bare_lower.startswith("claude-sonnet-4.6")
+    )
+
+
 def apply_copilot_chat_reasoning(
     payload: dict,
     model: str,
@@ -69,8 +83,31 @@ def apply_copilot_chat_reasoning(
     )
 
     if is_claude:
-        if thinking_budget is not None:
-            payload["thinking_budget"] = thinking_budget
+        if not _claude_supports_reasoning(bare_lower):
+            # Older Claudes (sonnet-4 / sonnet-4.5 / opus-4.5 / haiku-4.5)
+            # have no reasoning control on Copilot.
+            pass
+        else:
+            # Claude 4.6+/4.7 on Copilot exposes reasoning_effort. Be aggressive:
+            # if the client asked for thinking but didn't give us enough budget
+            # to map cleanly, default to "high" — the user wants more reasoning,
+            # not less.
+            effort = reasoning_effort or budget_to_effort(thinking_budget)
+            if effort == "xhigh":
+                effort = "high"  # Claude effort enum tops out at high
+            if effort is None and thinking_budget is not None:
+                effort = "high"
+            # opus-4.7's gateway only accepts "medium" (per Copilot's
+            # supported_values check). Clamp anything else to medium so the
+            # request doesn't fail.
+            if bare_lower.startswith("claude-opus-4.7") and effort in (
+                "low",
+                "medium",
+                "high",
+            ):
+                effort = "medium"
+            if effort in ("low", "medium", "high"):
+                payload["reasoning_effort"] = effort
     elif is_openai_reasoning:
         effort = reasoning_effort or budget_to_effort(thinking_budget)
         # Copilot's gpt-5* line natively accepts xhigh (verified against the
@@ -84,6 +121,42 @@ def apply_copilot_chat_reasoning(
 
 # Model cache TTL in seconds (5 minutes)
 MODELS_CACHE_TTL = 300
+
+
+def _extract_reasoning_from_chunk(part: dict | None) -> tuple[str, str | None]:
+    """Pull reasoning text/signature out of a Copilot message or delta.
+
+    Mirrors vscode-copilot-chat's ``extractThinkingDeltaFromChoice``: Copilot
+    streams reasoning under several legacy field names depending on the
+    upstream model family.
+
+    Returns ``(text, signature)`` where either may be empty/None.
+    """
+    if not part:
+        return "", None
+
+    text = ""
+    for key in ("reasoning_text", "cot_summary", "thinking"):
+        val = part.get(key)
+        if isinstance(val, str) and val:
+            text = val
+            break
+        if isinstance(val, dict):
+            inner = val.get("text") or val.get("content")
+            if isinstance(inner, str) and inner:
+                text = inner
+                break
+
+    sig: str | None = None
+    for key in ("reasoning_opaque", "cot_id", "signature"):
+        val = part.get(key)
+        if isinstance(val, str) and val:
+            sig = val
+            break
+
+    return text, sig
+
+
 
 
 class CopilotProvider(BaseProvider):
@@ -281,7 +354,27 @@ class CopilotProvider(BaseProvider):
             data = response.json()
 
             choices = data.get("choices", [])
+            usage = data.get("usage") or {}
+            completion_tokens = usage.get("completion_tokens") or 0
+
             if not choices:
+                # Some Copilot/Claude reasoning models can finish their thinking
+                # budget without producing visible text — they return empty
+                # choices but a non-zero completion_tokens. Treat that as a
+                # legitimate empty response instead of a 500 error.
+                if completion_tokens > 0:
+                    logger.warning(
+                        "Copilot returned empty choices but completion_tokens=%d; "
+                        "treating as thinking-only response",
+                        completion_tokens,
+                    )
+                    return ChatResponse(
+                        content="",
+                        model=data.get("model", request.model),
+                        finish_reason="stop",
+                        usage=usage or None,
+                        tool_calls=None,
+                    )
                 logger.error("Copilot API returned empty choices: %s", json.dumps(data)[:500])
                 raise ProviderError(
                     f"Copilot API returned empty choices: {json.dumps(data)[:500]}",
@@ -296,6 +389,8 @@ class CopilotProvider(BaseProvider):
             content = None
             tool_calls = []
             finish_reason = "stop"
+            thinking_text = ""
+            thinking_signature: str | None = None
 
             for choice in choices:
                 msg = choice.get("message", {})
@@ -309,6 +404,12 @@ class CopilotProvider(BaseProvider):
                 fr = choice.get("finish_reason")
                 if fr:
                     finish_reason = fr
+                # Collect reasoning text/signature
+                t, sig = _extract_reasoning_from_chunk(msg)
+                if t:
+                    thinking_text += t
+                if sig and thinking_signature is None:
+                    thinking_signature = sig
 
             if len(choices) > 1:
                 logger.info(
@@ -331,6 +432,8 @@ class CopilotProvider(BaseProvider):
                 finish_reason=finish_reason,
                 usage=data.get("usage"),
                 tool_calls=tool_calls,
+                thinking=thinking_text or None,
+                thinking_signature=thinking_signature,
             )
         except httpx.HTTPStatusError as e:
             self._raise_http_status_error("Copilot", e, logger, include_body=True)
@@ -405,13 +508,23 @@ class CopilotProvider(BaseProvider):
                         content = delta.get("content", "")
                         finish_reason = data["choices"][0].get("finish_reason")
                         tool_calls = delta.get("tool_calls")
+                        thinking_text, thinking_sig = _extract_reasoning_from_chunk(delta)
 
-                        if content or finish_reason or usage or tool_calls:
+                        if (
+                            content
+                            or finish_reason
+                            or usage
+                            or tool_calls
+                            or thinking_text
+                            or thinking_sig
+                        ):
                             yield ChatStreamChunk(
                                 content=content,
                                 finish_reason=finish_reason,
                                 usage=usage,
                                 tool_calls=tool_calls,
+                                thinking=thinking_text or None,
+                                thinking_signature=thinking_sig,
                             )
 
                         # Mark stream as finished after receiving finish_reason

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -123,6 +123,17 @@ def apply_copilot_chat_reasoning(
 MODELS_CACHE_TTL = 300
 
 
+def _thinking_requested(request: ChatRequest) -> bool:
+    """Whether the client opted into reasoning passthrough.
+
+    We only surface upstream chain-of-thought to clients that explicitly asked
+    for it. Reasoning traces can leak prompt fragments, hidden instructions,
+    and tool-planning state, so emitting them by default would be a
+    sensitive-data exposure surface.
+    """
+    return request.thinking_type in ("enabled", "adaptive")
+
+
 def _extract_reasoning_from_chunk(part: dict | None) -> tuple[str, str | None]:
     """Pull reasoning text/signature out of a Copilot message or delta.
 
@@ -357,12 +368,26 @@ class CopilotProvider(BaseProvider):
             usage = data.get("usage") or {}
             completion_tokens = usage.get("completion_tokens") or 0
 
+            bare_lower = (
+                request.model.split("/", 1)[1] if "/" in request.model else request.model
+            ).lower()
+            reasoning_capable = bare_lower.startswith("claude-") and _claude_supports_reasoning(
+                bare_lower
+            )
+
             if not choices:
-                # Some Copilot/Claude reasoning models can finish their thinking
-                # budget without producing visible text — they return empty
-                # choices but a non-zero completion_tokens. Treat that as a
-                # legitimate empty response instead of a 500 error.
-                if completion_tokens > 0:
+                # Reasoning-capable Claude models can spend their whole budget
+                # on hidden reasoning and finish without emitting visible text.
+                # That comes back as choices=[] with completion_tokens>0. Only
+                # absorb it as an empty success when the client explicitly
+                # asked for thinking on a known reasoning model — otherwise a
+                # malformed upstream response would silently look like a blank
+                # assistant message.
+                if (
+                    completion_tokens > 0
+                    and reasoning_capable
+                    and _thinking_requested(request)
+                ):
                     logger.warning(
                         "Copilot returned empty choices but completion_tokens=%d; "
                         "treating as thinking-only response",
@@ -404,12 +429,13 @@ class CopilotProvider(BaseProvider):
                 fr = choice.get("finish_reason")
                 if fr:
                     finish_reason = fr
-                # Collect reasoning text/signature
-                t, sig = _extract_reasoning_from_chunk(msg)
-                if t:
-                    thinking_text += t
-                if sig and thinking_signature is None:
-                    thinking_signature = sig
+                # Collect reasoning text/signature only if the client opted in
+                if _thinking_requested(request):
+                    t, sig = _extract_reasoning_from_chunk(msg)
+                    if t:
+                        thinking_text += t
+                    if sig and thinking_signature is None:
+                        thinking_signature = sig
 
             if len(choices) > 1:
                 logger.info(
@@ -508,7 +534,10 @@ class CopilotProvider(BaseProvider):
                         content = delta.get("content", "")
                         finish_reason = data["choices"][0].get("finish_reason")
                         tool_calls = delta.get("tool_calls")
-                        thinking_text, thinking_sig = _extract_reasoning_from_chunk(delta)
+                        if _thinking_requested(request):
+                            thinking_text, thinking_sig = _extract_reasoning_from_chunk(delta)
+                        else:
+                            thinking_text, thinking_sig = "", None
 
                         if (
                             content

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -19,6 +19,7 @@ from router_maestro.server.schemas.anthropic import (
     AnthropicModelList,
     AnthropicStreamState,
     AnthropicTextBlock,
+    AnthropicThinkingBlock,
     AnthropicToolUseBlock,
     AnthropicUsage,
 )
@@ -248,8 +249,17 @@ async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIReques
             response.finish_reason,
         )
 
-        # Build Anthropic response
+        # Build Anthropic response. Per spec, thinking blocks must come
+        # BEFORE the text block they reasoned about.
         content = []
+        if response.thinking:
+            content.append(
+                AnthropicThinkingBlock(
+                    type="thinking",
+                    thinking=response.thinking,
+                    signature=response.thinking_signature,
+                )
+            )
         if response.content:
             content.append(AnthropicTextBlock(type="text", text=response.content))
 
@@ -393,15 +403,21 @@ async def stream_response(
         state = AnthropicStreamState(estimated_input_tokens=estimated_input_tokens)
 
         async for chunk in stream:
-            # Build OpenAI-style chunk for translation
+            # Build OpenAI-style chunk for translation. Forward reasoning
+            # under both legacy field names so the translator can pick it up.
+            delta: dict = {
+                "content": chunk.content if chunk.content else None,
+                "tool_calls": chunk.tool_calls,
+            }
+            if chunk.thinking:
+                delta["reasoning_text"] = chunk.thinking
+            if chunk.thinking_signature:
+                delta["reasoning_opaque"] = chunk.thinking_signature
             openai_chunk = {
                 "id": response_id,
                 "choices": [
                     {
-                        "delta": {
-                            "content": chunk.content if chunk.content else None,
-                            "tool_calls": chunk.tool_calls,
-                        },
+                        "delta": delta,
                         "finish_reason": chunk.finish_reason,
                     }
                 ],

--- a/src/router_maestro/server/schemas/anthropic.py
+++ b/src/router_maestro/server/schemas/anthropic.py
@@ -81,6 +81,7 @@ class AnthropicThinkingBlock(BaseModel):
 
     type: Literal["thinking"] = "thinking"
     thinking: str
+    signature: str | None = None
 
 
 AnthropicUserContentBlock = (
@@ -263,6 +264,7 @@ class AnthropicStreamState(BaseModel):
     message_start_sent: bool = False
     content_block_index: int = 0
     content_block_open: bool = False
+    thinking_block_open: bool = False  # True while a thinking content_block is open
     tool_calls: dict[int, dict] = Field(default_factory=dict)
     estimated_input_tokens: int = 0  # Estimated input tokens from request
     last_usage: dict | None = None  # Track the latest usage from stream chunks

--- a/src/router_maestro/server/translation.py
+++ b/src/router_maestro/server/translation.py
@@ -11,6 +11,7 @@ from router_maestro.server.schemas.anthropic import (
     AnthropicMessagesResponse,
     AnthropicStreamState,
     AnthropicTextBlock,
+    AnthropicThinkingBlock,
     AnthropicToolUseBlock,
     AnthropicUsage,
     AnthropicUserMessage,
@@ -413,8 +414,35 @@ def translate_openai_to_anthropic(
     if "choices" in openai_response:
         for choice in openai_response["choices"]:
             message = choice.get("message", {})
-            msg_content = message.get("content")
 
+            # Reasoning trace, if any, comes before text per Anthropic ordering
+            think_text = ""
+            think_sig: str | None = None
+            for key in ("reasoning_text", "cot_summary", "thinking"):
+                val = message.get(key)
+                if isinstance(val, str) and val:
+                    think_text = val
+                    break
+                if isinstance(val, dict):
+                    inner = val.get("text") or val.get("content")
+                    if isinstance(inner, str) and inner:
+                        think_text = inner
+                        break
+            for key in ("reasoning_opaque", "cot_id", "signature"):
+                val = message.get(key)
+                if isinstance(val, str) and val:
+                    think_sig = val
+                    break
+            if think_text or think_sig:
+                content.append(
+                    AnthropicThinkingBlock(
+                        type="thinking",
+                        thinking=think_text,
+                        signature=think_sig,
+                    )
+                )
+
+            msg_content = message.get("content")
             if msg_content:
                 content.append(AnthropicTextBlock(type="text", text=msg_content))
 
@@ -525,6 +553,89 @@ def translate_openai_chunk_to_anthropic_events(
         )
         state.message_start_sent = True
 
+    # Handle reasoning / thinking deltas. Copilot streams reasoning under
+    # several legacy field names (reasoning_text / cot_summary / thinking).
+    # Anthropic streaming requires a thinking content_block to be opened
+    # before its deltas are emitted, and closed before any text/tool block.
+    thinking_text = ""
+    for key in ("reasoning_text", "cot_summary", "thinking"):
+        val = delta.get(key)
+        if isinstance(val, str) and val:
+            thinking_text = val
+            break
+        if isinstance(val, dict):
+            inner = val.get("text") or val.get("content")
+            if isinstance(inner, str) and inner:
+                thinking_text = inner
+                break
+    thinking_signature = None
+    for key in ("reasoning_opaque", "cot_id", "signature"):
+        val = delta.get(key)
+        if isinstance(val, str) and val:
+            thinking_signature = val
+            break
+
+    if thinking_text or thinking_signature:
+        # Open thinking block if one isn't already open
+        if not state.thinking_block_open:
+            # Close any other open block (text/tool) first
+            if state.content_block_open:
+                events.append(
+                    {
+                        "type": "content_block_stop",
+                        "index": state.content_block_index,
+                    }
+                )
+                state.content_block_index += 1
+                state.content_block_open = False
+            events.append(
+                {
+                    "type": "content_block_start",
+                    "index": state.content_block_index,
+                    "content_block": {
+                        "type": "thinking",
+                        "thinking": "",
+                    },
+                }
+            )
+            state.thinking_block_open = True
+            state.content_block_open = True
+
+        if thinking_text:
+            events.append(
+                {
+                    "type": "content_block_delta",
+                    "index": state.content_block_index,
+                    "delta": {
+                        "type": "thinking_delta",
+                        "thinking": thinking_text,
+                    },
+                }
+            )
+        if thinking_signature:
+            events.append(
+                {
+                    "type": "content_block_delta",
+                    "index": state.content_block_index,
+                    "delta": {
+                        "type": "signature_delta",
+                        "signature": thinking_signature,
+                    },
+                }
+            )
+
+    # Close any open thinking block before text/tool content arrives
+    if state.thinking_block_open and (delta.get("content") or delta.get("tool_calls")):
+        events.append(
+            {
+                "type": "content_block_stop",
+                "index": state.content_block_index,
+            }
+        )
+        state.content_block_index += 1
+        state.content_block_open = False
+        state.thinking_block_open = False
+
     # Handle text content
     if delta.get("content"):
         # Close tool block if open
@@ -627,6 +738,7 @@ def translate_openai_chunk_to_anthropic_events(
                 }
             )
             state.content_block_open = False
+            state.thinking_block_open = False
 
         # Get usage from accumulated values, chunk, or tracked last_usage
         prompt_tokens = state.accumulated_prompt_tokens or (

--- a/src/router_maestro/utils/reasoning.py
+++ b/src/router_maestro/utils/reasoning.py
@@ -12,10 +12,10 @@ an upstream that does not accept it, providers should downgrade to ``"high"``.
 from __future__ import annotations
 
 EFFORT_TO_BUDGET: dict[str, int] = {
-    "low": 4096,
-    "medium": 8192,
-    "high": 16384,
-    "xhigh": 24000,
+    "low": 1024,
+    "medium": 4096,
+    "high": 8192,
+    "xhigh": 16384,
 }
 
 VALID_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")

--- a/tests/test_copilot_chat_reasoning.py
+++ b/tests/test_copilot_chat_reasoning.py
@@ -10,18 +10,59 @@ def _base_payload(extra: dict | None = None) -> dict:
     return payload
 
 
-def test_claude_uses_thinking_budget_not_reasoning_effort():
+def test_claude_47_clamped_to_medium():
+    """opus-4.7 gateway only accepts 'medium' — anything else gets clamped."""
+    for input_effort in ("low", "high", None):
+        for budget in (1024, 16000, None):
+            if input_effort is None and budget is None:
+                continue
+            p = _base_payload()
+            apply_copilot_chat_reasoning(p, "claude-opus-4.7", budget, input_effort)
+            assert p.get("reasoning_effort") == "medium", (input_effort, budget)
+            assert "thinking_budget" not in p
+
+
+def test_claude_46_uses_reasoning_effort_not_thinking_budget():
+    """opus-4.6 / sonnet-4.6 / opus-4.6-1m on Copilot expose effort, not budget."""
+    for model in ("claude-opus-4.6", "claude-opus-4.6-1m", "claude-sonnet-4.6"):
+        p = _base_payload()
+        apply_copilot_chat_reasoning(p, model, 16000, None)
+        assert "thinking_budget" not in p, model
+        assert p.get("reasoning_effort") == "high", model
+
+
+def test_claude_46_explicit_effort_wins_and_xhigh_clamped():
     p = _base_payload()
-    apply_copilot_chat_reasoning(p, "claude-opus-4.7", 32000, None)
-    assert p.get("thinking_budget") == 32000
-    assert "reasoning_effort" not in p
+    apply_copilot_chat_reasoning(p, "claude-sonnet-4.6", 1024, "xhigh")
+    assert p.get("reasoning_effort") == "high"
+    assert "thinking_budget" not in p
+
+
+def test_claude_46_thinking_requested_with_tiny_budget_defaults_to_high():
+    """Client asked for thinking but budget too small to map — be aggressive."""
+    p = _base_payload()
+    apply_copilot_chat_reasoning(p, "claude-opus-4.6", 100, None)
+    assert p.get("reasoning_effort") == "high"
+
+
+def test_claude_old_models_send_no_reasoning_field():
+    for model in (
+        "claude-opus-4.5",
+        "claude-sonnet-4.5",
+        "claude-sonnet-4",
+        "claude-haiku-4.5",
+    ):
+        p = _base_payload()
+        apply_copilot_chat_reasoning(p, model, 16000, "high")
+        assert "thinking_budget" not in p, model
+        assert "reasoning_effort" not in p, model
 
 
 def test_claude_with_provider_prefix():
     p = _base_payload()
     apply_copilot_chat_reasoning(p, "github-copilot/claude-sonnet-4.6", 8192, "high")
-    assert p.get("thinking_budget") == 8192
-    assert "reasoning_effort" not in p
+    assert p.get("reasoning_effort") == "high"
+    assert "thinking_budget" not in p
 
 
 def test_gpt5_uses_reasoning_effort_not_thinking_budget():
@@ -34,7 +75,7 @@ def test_gpt5_uses_reasoning_effort_not_thinking_budget():
 def test_gpt5_derives_effort_from_budget_when_effort_missing():
     p = _base_payload()
     apply_copilot_chat_reasoning(p, "gpt-5.2", 16384, None)
-    assert p.get("reasoning_effort") == "high"
+    assert p.get("reasoning_effort") == "xhigh"
     assert "thinking_budget" not in p
 
 

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -42,11 +42,11 @@ class TestEffortMapping:
     @pytest.mark.parametrize(
         "effort,expected",
         [
-            ("low", 4096),
-            ("medium", 8192),
-            ("high", 16384),
-            ("xhigh", 24000),
-            ("HIGH", 16384),
+            ("low", 1024),
+            ("medium", 4096),
+            ("high", 8192),
+            ("xhigh", 16384),
+            ("HIGH", 8192),
             (None, None),
             ("bogus", None),
         ],
@@ -57,9 +57,11 @@ class TestEffortMapping:
     def test_budget_to_effort_picks_highest_fitting(self):
         assert budget_to_effort(None) is None
         assert budget_to_effort(100) is None
-        assert budget_to_effort(4096) == "low"
-        assert budget_to_effort(8192) == "medium"
-        assert budget_to_effort(20000) == "high"
+        assert budget_to_effort(1024) == "low"
+        assert budget_to_effort(4096) == "medium"
+        assert budget_to_effort(8000) == "medium"
+        assert budget_to_effort(8192) == "high"
+        assert budget_to_effort(16000) == "high"
         assert budget_to_effort(EFFORT_TO_BUDGET["xhigh"]) == "xhigh"
 
     def test_downgrade_for_upstream(self):

--- a/tests/test_thinking_passthrough.py
+++ b/tests/test_thinking_passthrough.py
@@ -87,7 +87,7 @@ class TestCopilotPayloadThinking:
 
     @pytest.mark.asyncio
     async def test_copilot_payload_includes_thinking_budget(self):
-        """Verify payload contains thinking_budget when set."""
+        """Verify Claude payload contains reasoning_effort when client requests thinking."""
         from router_maestro.providers.copilot import CopilotProvider
 
         provider = CopilotProvider()
@@ -95,7 +95,7 @@ class TestCopilotPayloadThinking:
         provider._token_expires = 9999999999
 
         request = ChatRequest(
-            model="claude-opus-4.6",
+            model="claude-opus-4.7",
             messages=[Message(role="user", content="Hello")],
             thinking_budget=16000,
         )
@@ -114,7 +114,7 @@ class TestCopilotPayloadThinking:
                         "finish_reason": "stop",
                     }
                 ],
-                "model": "claude-opus-4.6",
+                "model": "claude-opus-4.7",
                 "usage": {"prompt_tokens": 10, "completion_tokens": 5},
             }
             return mock_response
@@ -127,8 +127,9 @@ class TestCopilotPayloadThinking:
         with patch.object(provider, "ensure_token", new_callable=AsyncMock):
             await provider.chat_completion(request)
 
-        assert "thinking_budget" in captured_payload
-        assert captured_payload["thinking_budget"] == 16000
+        assert "thinking_budget" not in captured_payload
+        # opus-4.7's gateway only accepts "medium" — anything else clamps.
+        assert captured_payload.get("reasoning_effort") == "medium"
 
     @pytest.mark.asyncio
     async def test_copilot_payload_omits_thinking_when_none(self):

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -18,7 +18,7 @@ class TestTimeoutConstants:
 
     def test_non_streaming_timeout_values(self):
         assert TIMEOUT_NON_STREAMING.connect == 30.0
-        assert TIMEOUT_NON_STREAMING.read == 120.0
+        assert TIMEOUT_NON_STREAMING.read == 240.0
         assert TIMEOUT_NON_STREAMING.write == 30.0
         assert TIMEOUT_NON_STREAMING.pool == 30.0
 


### PR DESCRIPTION
## Summary

- Per-Claude-family reasoning dispatch on Copilot's chat endpoint:
  opus-4.7 / opus-4.6* / sonnet-4.6 use `reasoning_effort` (gateway
  rejects `thinking_budget`); opus-4.7 only accepts `medium` so we
  clamp. Older models (4.5 / sonnet-4 / haiku) send neither field.
- Lower effort thresholds (`low=1024, medium=4096, high=8192, xhigh=16384`)
  so it's easier to hit higher tiers — Copilot is free unlimited.
- Surface upstream reasoning back as Anthropic `thinking` content blocks
  (with `thinking_delta` + `signature_delta` SSE events for streaming).
  Mirrors vscode-copilot-chat's field discovery (`reasoning_text` /
  `cot_summary` / `thinking` for text, `reasoning_opaque` / `cot_id` /
  `signature` for the signature).
- Gate the passthrough behind explicit `thinking_type ∈ {enabled, adaptive}`
  so reasoning traces don't leak to clients that didn't ask for them.
- Tolerate `choices=[]` with `completion_tokens>0` as a thinking-only
  success — but only on a reasoning-capable Claude AND when the client
  opted into thinking. Otherwise keep the 500 path so malformed
  upstream responses stay visible.
- Bump non-streaming read timeout 120s → 240s — opus-4.6 / sonnet-4.6
  at high effort regularly take >2min on Copilot's side.
- Drop hardcoded production domain from CLAUDE.md.

## Test plan

- [x] `uv run pytest tests/ -q` — 634 passed
- [x] `uv run ruff check src/` — clean
- [x] Local E2E: 8 Claude models × 4 budgets; opus-4.7/4.6/4.6-1m/sonnet-4.6 emit `['thinking','text']` blocks; older models emit `['text']` only.
- [x] Gating verified: opus-4.7 without `thinking` → text-only; with `thinking={enabled,b=4096}` → thinking+text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)