### PR TITLE
chore: release v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.1.36 (2026-04-23)
+
+### Features
+
+- **Catalog-driven `reasoning_effort` dispatch on Copilot.** Read each model's `capabilities.supports.reasoning_effort` allowlist from Copilot's `/models` response and use it as the source of truth when picking which effort tier to send. When the desired tier isn't offered, step to the nearest available (prefer next higher, else next lower). The old hardcoded heuristic stays as a fallback when the catalog is silent. As a side effect, `gemini-3*` / `gpt-5-mini` / `gpt-5.4-mini` get correct reasoning routing without further code changes — and any future tier opened upstream (e.g. `high` on opus-4.7) will be picked up automatically.
+
+---
+
 ## v0.1.35 (2026-04-23)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.1.35"
+version = "0.1.36"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.1.35"
+__version__ = "0.1.36"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.1.35"
+version = "0.1.36"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump version 0.1.35 → 0.1.36
- CHANGELOG entry for catalog-driven `reasoning_effort` dispatch (PR #51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)