### PR TITLE
fix(cli): honor ROUTER_MAESTRO_LOG_LEVEL env + bump to 0.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.1.37 (2026-04-24)
+
+### Fixes
+
+- **`ROUTER_MAESTRO_LOG_LEVEL` is no longer silently clobbered by the CLI.** `router-maestro server start --log-level` previously hardcoded its default to `INFO` and then wrote that default into `ROUTER_MAESTRO_LOG_LEVEL` before the FastAPI app read it. Setting the env var (e.g. in `docker-compose.yml`) had no effect unless you also passed the flag. The CLI option now defaults to whatever `ROUTER_MAESTRO_LOG_LEVEL` already contains, so Docker / systemd users can flip the level via env without changing the launch command.
+
+---
+
 ## v0.1.36 (2026-04-23)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.1.36"
+version = "0.1.37"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.1.36"
+__version__ = "0.1.37"

--- a/src/router_maestro/cli/server.py
+++ b/src/router_maestro/cli/server.py
@@ -27,10 +27,11 @@ def start(
     api_key: str | None = typer.Option(None, "--api-key", "-k", help="API key for authentication"),
     reload: bool = typer.Option(False, "--reload", help="Enable auto-reload (development)"),
     log_level: str = typer.Option(
-        "INFO",
+        os.environ.get("ROUTER_MAESTRO_LOG_LEVEL", "INFO"),
         "--log-level",
         "-l",
-        help="Log level (DEBUG, INFO, WARNING, ERROR)",
+        help="Log level (DEBUG, INFO, WARNING, ERROR). "
+        "Defaults to $ROUTER_MAESTRO_LOG_LEVEL when set, else INFO.",
         case_sensitive=False,
     ),
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.1.36"
+version = "0.1.37"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- `server start --log-level` no longer hardcodes its default to `INFO` — it now reads `ROUTER_MAESTRO_LOG_LEVEL` first, falling back to `INFO`
- Previously the typer default would silently overwrite `os.environ["ROUTER_MAESTRO_LOG_LEVEL"]` before FastAPI's lifespan ran `setup_logging()`, so `ROUTER_MAESTRO_LOG_LEVEL=DEBUG` set in `docker-compose.yml` had no effect
- Bumps to v0.1.37

## How to verify
- Set `ROUTER_MAESTRO_LOG_LEVEL=DEBUG` in env, run `router-maestro server start` (no flag), and confirm `Copilot chat completion: ...` debug lines appear

## Test plan
- [x] `uv run pytest tests/ -q` — 642 pass
- [x] `uv run ruff check src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)