### PR TITLE
feat(copilot): experimental Anthropic/Gemini → /responses bridge

### DIFF
--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -38,6 +38,11 @@ class ChatRequest:
     thinking_type: str | None = None  # "enabled", "adaptive", "disabled"
     # OpenAI-style effort: "low" | "medium" | "high" | "xhigh" (Router-Maestro extension)
     reasoning_effort: str | None = None
+    # Experimental: when True, eligible providers (currently Copilot+gpt-5.x)
+    # should fulfil this chat request via the /responses endpoint instead of
+    # /chat/completions. Set by entry routes (Anthropic, Gemini) when the
+    # ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API flag is on.
+    use_responses_api: bool = False
     extra: dict = field(default_factory=dict)
 
     def with_thinking(
@@ -58,6 +63,7 @@ class ChatRequest:
             thinking_budget=thinking_budget,
             thinking_type=thinking_type,
             reasoning_effort=self.reasoning_effort,
+            use_responses_api=self.use_responses_api,
             extra=self.extra,
         )
 
@@ -169,6 +175,13 @@ class ResponsesResponse:
     model: str
     usage: dict | None = None
     tool_calls: list[ResponsesToolCall] | None = None
+    # Reasoning summary text aggregated from /responses' "reasoning" output items.
+    thinking: str | None = None
+    thinking_signature: str | None = None
+    # Upstream completion status mapped to chat-style finish reason
+    # ("stop" | "length" | "content_filter" | "tool_calls"). None means
+    # the bridge should pick a default based on tool_calls presence.
+    finish_reason: str | None = None
 
 
 @dataclass
@@ -180,6 +193,10 @@ class ResponsesStreamChunk:
     usage: dict | None = None
     # Tool call support
     tool_call: ResponsesToolCall | None = None  # A complete tool call
+    # Incremental reasoning summary text delta (from
+    # ``response.reasoning_summary_text.delta`` events).
+    thinking: str | None = None
+    thinking_signature: str | None = None
 
 
 class ProviderError(Exception):

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -1012,9 +1012,7 @@ class CopilotProvider(BaseProvider):
                         if not stream_finished:
                             yield ResponsesStreamChunk(
                                 content="",
-                                finish_reason=(
-                                    "tool_calls" if emitted_tool_call else "stop"
-                                ),
+                                finish_reason=("tool_calls" if emitted_tool_call else "stop"),
                                 usage=final_usage,
                             )
                             stream_finished = True
@@ -1042,9 +1040,7 @@ class CopilotProvider(BaseProvider):
                     elif event_type == "response.reasoning_summary_text.done":
                         item_id = data.get("item_id")
                         if item_id:
-                            yield ResponsesStreamChunk(
-                                content="", thinking_signature=item_id
-                            )
+                            yield ResponsesStreamChunk(content="", thinking_signature=item_id)
 
                     # Handle function call output_item.added - start of a new function call
                     elif event_type == "response.output_item.added":
@@ -1118,8 +1114,7 @@ class CopilotProvider(BaseProvider):
                             )
                         incomplete = resp.get("incomplete_details") or {}
                         finish = (
-                            map_responses_status_to_chat(status, incomplete.get("reason"))
-                            or "stop"
+                            map_responses_status_to_chat(status, incomplete.get("reason")) or "stop"
                         )
                         if emitted_tool_call and finish == "stop":
                             finish = "tool_calls"
@@ -1150,8 +1145,7 @@ class CopilotProvider(BaseProvider):
                             )
                         incomplete = resp.get("incomplete_details") or {}
                         finish = (
-                            map_responses_status_to_chat(status, incomplete.get("reason"))
-                            or "stop"
+                            map_responses_status_to_chat(status, incomplete.get("reason")) or "stop"
                         )
                         if emitted_tool_call and finish == "stop":
                             finish = "tool_calls"

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -385,6 +385,24 @@ class CopilotProvider(BaseProvider):
 
     async def chat_completion(self, request: ChatRequest) -> ChatResponse:
         """Generate a chat completion via Copilot."""
+        # Experimental: route GPT-5.x ChatRequests through /responses when the
+        # entry route opted in. Anthropic/Gemini set use_responses_api=True
+        # under the ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API flag.
+        from router_maestro.utils.responses_bridge import (
+            chat_request_to_responses_request,
+            responses_response_to_chat_response,
+            should_use_responses_for_chat,
+        )
+
+        if should_use_responses_for_chat(request, self.name):
+            logger.info(
+                "Routing chat request via /responses (experimental): model=%s",
+                request.model,
+            )
+            responses_req = chat_request_to_responses_request(request)
+            responses_resp = await self.responses_completion(responses_req)
+            return responses_response_to_chat_response(responses_resp, request.model)
+
         await self.ensure_token()
 
         messages, has_images = self._build_messages_payload(request)
@@ -531,6 +549,22 @@ class CopilotProvider(BaseProvider):
 
     async def chat_completion_stream(self, request: ChatRequest) -> AsyncIterator[ChatStreamChunk]:
         """Generate a streaming chat completion via Copilot."""
+        from router_maestro.utils.responses_bridge import (
+            chat_request_to_responses_request,
+            responses_chunk_to_chat_chunk,
+            should_use_responses_for_chat,
+        )
+
+        if should_use_responses_for_chat(request, self.name):
+            logger.info(
+                "Streaming chat request via /responses (experimental): model=%s",
+                request.model,
+            )
+            responses_req = chat_request_to_responses_request(request)
+            async for resp_chunk in self.responses_completion_stream(responses_req):
+                yield responses_chunk_to_chat_chunk(resp_chunk)
+            return
+
         await self.ensure_token()
 
         messages, has_images = self._build_messages_payload(request)
@@ -796,7 +830,9 @@ class CopilotProvider(BaseProvider):
                 logger.warning(
                     "Copilot Responses does not accept reasoning_effort=xhigh; downgrading to high"
                 )
-            payload["reasoning"] = {"effort": upstream_effort}
+            # ``summary: auto`` opts in to reasoning_summary_text events so we
+            # can forward chain-of-thought as Anthropic thinking blocks.
+            payload["reasoning"] = {"effort": upstream_effort, "summary": "auto"}
         return payload
 
     def _extract_response_content(self, data: dict) -> str:
@@ -815,6 +851,26 @@ class CopilotProvider(BaseProvider):
                     if content_item.get("type") == "output_text":
                         content += content_item.get("text", "")
         return content
+
+    def _extract_reasoning(self, data: dict) -> tuple[str | None, str | None]:
+        """Extract aggregated reasoning summary text and signature.
+
+        Returns ``(thinking_text, thinking_signature)``. Both are ``None``
+        when the response has no reasoning output.
+        """
+        text_parts: list[str] = []
+        signature: str | None = None
+        for output in data.get("output", []):
+            if output.get("type") != "reasoning":
+                continue
+            if signature is None:
+                signature = output.get("id")
+            for summary in output.get("summary", []) or []:
+                if isinstance(summary, dict):
+                    chunk = summary.get("text") or ""
+                    if chunk:
+                        text_parts.append(chunk)
+        return ("".join(text_parts) or None, signature)
 
     def _extract_tool_calls(self, data: dict) -> list[ResponsesToolCall]:
         """Extract tool calls from Responses API response.
@@ -857,10 +913,31 @@ class CopilotProvider(BaseProvider):
 
             content = self._extract_response_content(data)
             tool_calls = self._extract_tool_calls(data)
+            thinking, thinking_sig = self._extract_reasoning(data)
 
             usage = None
             if "usage" in data:
                 usage = data["usage"]
+
+            from router_maestro.utils.responses_bridge import map_responses_status_to_chat
+
+            status = data.get("status")
+            incomplete_reason = None
+            incomplete = data.get("incomplete_details")
+            if isinstance(incomplete, dict):
+                incomplete_reason = incomplete.get("reason")
+
+            # Surface terminal upstream failures as provider errors instead of
+            # silently returning a blank successful completion.
+            if status in ("failed", "cancelled"):
+                err = data.get("error") or {}
+                msg = err.get("message") if isinstance(err, dict) else None
+                raise ProviderError(
+                    f"Copilot /responses {status}: {msg or 'no error message'}",
+                    status_code=502,
+                )
+
+            finish_reason = map_responses_status_to_chat(status, incomplete_reason)
 
             logger.debug("Copilot responses completion successful")
             return ResponsesResponse(
@@ -868,6 +945,9 @@ class CopilotProvider(BaseProvider):
                 model=data.get("model", request.model),
                 usage=usage,
                 tool_calls=tool_calls if tool_calls else None,
+                thinking=thinking,
+                thinking_signature=thinking_sig,
+                finish_reason=finish_reason,
             )
         except httpx.HTTPStatusError as e:
             self._raise_http_status_error("Copilot", e, logger, include_body=True)
@@ -914,6 +994,7 @@ class CopilotProvider(BaseProvider):
 
                 stream_finished = False
                 final_usage = None
+                emitted_tool_call = False
                 # Track pending function calls being streamed, keyed by output_index
                 # (Copilot obfuscates item IDs differently across events, so we can't match by ID)
                 pending_fcs: dict[int, dict] = {}
@@ -931,7 +1012,9 @@ class CopilotProvider(BaseProvider):
                         if not stream_finished:
                             yield ResponsesStreamChunk(
                                 content="",
-                                finish_reason="stop",
+                                finish_reason=(
+                                    "tool_calls" if emitted_tool_call else "stop"
+                                ),
                                 usage=final_usage,
                             )
                             stream_finished = True
@@ -945,6 +1028,23 @@ class CopilotProvider(BaseProvider):
                         delta_text = data.get("delta", "")
                         if delta_text:
                             yield ResponsesStreamChunk(content=delta_text)
+
+                    # Reasoning summary (chain-of-thought) deltas — surfaced so
+                    # entry routes (Anthropic, Gemini) can forward them as
+                    # thinking blocks. The opaque ``item_id`` is sent once on
+                    # the closing ``done`` event so the translator can attach
+                    # a single signature_delta rather than one per text delta.
+                    elif event_type == "response.reasoning_summary_text.delta":
+                        delta = data.get("delta", "")
+                        if delta:
+                            yield ResponsesStreamChunk(content="", thinking=delta)
+
+                    elif event_type == "response.reasoning_summary_text.done":
+                        item_id = data.get("item_id")
+                        if item_id:
+                            yield ResponsesStreamChunk(
+                                content="", thinking_signature=item_id
+                            )
 
                     # Handle function call output_item.added - start of a new function call
                     elif event_type == "response.output_item.added":
@@ -972,6 +1072,7 @@ class CopilotProvider(BaseProvider):
                         if fc:
                             fc["arguments"] = data.get("arguments", fc["arguments"])
                             # Emit complete tool call
+                            emitted_tool_call = True
                             yield ResponsesStreamChunk(
                                 content="",
                                 tool_call=ResponsesToolCall(
@@ -989,6 +1090,7 @@ class CopilotProvider(BaseProvider):
                             # Only emit if not already done via function_call_arguments.done
                             fc = pending_fcs.pop(output_idx, None)
                             if fc is not None:
+                                emitted_tool_call = True
                                 yield ResponsesStreamChunk(
                                     content="",
                                     tool_call=ResponsesToolCall(
@@ -1000,24 +1102,62 @@ class CopilotProvider(BaseProvider):
 
                     # Handle done event to get final usage
                     elif event_type == "response.done":
+                        from router_maestro.utils.responses_bridge import (
+                            map_responses_status_to_chat,
+                        )
+
                         resp = data.get("response", {})
                         final_usage = resp.get("usage")
+                        status = resp.get("status")
+                        if status in ("failed", "cancelled"):
+                            err = resp.get("error") or {}
+                            msg = err.get("message") if isinstance(err, dict) else None
+                            raise ProviderError(
+                                f"Copilot /responses {status}: {msg or 'no error message'}",
+                                status_code=502,
+                            )
+                        incomplete = resp.get("incomplete_details") or {}
+                        finish = (
+                            map_responses_status_to_chat(status, incomplete.get("reason"))
+                            or "stop"
+                        )
+                        if emitted_tool_call and finish == "stop":
+                            finish = "tool_calls"
                         yield ResponsesStreamChunk(
                             content="",
-                            finish_reason="stop",
+                            finish_reason=finish,
                             usage=final_usage,
                         )
                         stream_finished = True
 
                     # Handle completed events
                     elif event_type == "response.completed":
+                        from router_maestro.utils.responses_bridge import (
+                            map_responses_status_to_chat,
+                        )
+
                         # Final response received - emit finish chunk
                         resp = data.get("response", {})
                         if not final_usage:
                             final_usage = resp.get("usage")
+                        status = resp.get("status")
+                        if status in ("failed", "cancelled"):
+                            err = resp.get("error") or {}
+                            msg = err.get("message") if isinstance(err, dict) else None
+                            raise ProviderError(
+                                f"Copilot /responses {status}: {msg or 'no error message'}",
+                                status_code=502,
+                            )
+                        incomplete = resp.get("incomplete_details") or {}
+                        finish = (
+                            map_responses_status_to_chat(status, incomplete.get("reason"))
+                            or "stop"
+                        )
+                        if emitted_tool_call and finish == "stop":
+                            finish = "tool_calls"
                         yield ResponsesStreamChunk(
                             content="",
-                            finish_reason="stop",
+                            finish_reason=finish,
                             usage=final_usage,
                         )
                         stream_finished = True
@@ -1027,7 +1167,7 @@ class CopilotProvider(BaseProvider):
                     logger.debug("Stream ended without completion event, emitting final chunk")
                     yield ResponsesStreamChunk(
                         content="",
-                        finish_reason="stop",
+                        finish_reason="tool_calls" if emitted_tool_call else "stop",
                         usage=final_usage,
                     )
 

--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -323,6 +323,8 @@ class Router:
             tool_choice=original_request.tool_choice,
             thinking_budget=original_request.thinking_budget,
             thinking_type=original_request.thinking_type,
+            reasoning_effort=original_request.reasoning_effort,
+            use_responses_api=original_request.use_responses_api,
             extra=original_request.extra,
         )
 

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -34,6 +34,9 @@ from router_maestro.utils import (
     map_openai_stop_reason_to_anthropic,
 )
 from router_maestro.utils.context_window import resolve_thinking_budget
+from router_maestro.utils.responses_bridge import (
+    is_experimental_responses_enabled,
+)
 from router_maestro.utils.token_config import (
     count_tokens_via_anthropic_api,
     get_config_for_provider,
@@ -224,11 +227,33 @@ async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIReques
             tool_choice=chat_request.tool_choice,
             thinking_budget=chat_request.thinking_budget,
             thinking_type=chat_request.thinking_type,
+            reasoning_effort=chat_request.reasoning_effort,
+            use_responses_api=chat_request.use_responses_api,
             extra=chat_request.extra,
         )
 
     # Resolve thinking budget from server config if needed
     chat_request = await _apply_thinking_budget(model_router, chat_request, effective_model)
+
+    # Experimental: opt this request into Copilot's /responses endpoint when
+    # the flag is on. The Copilot provider gates on the resolved provider +
+    # model and falls back to /chat/completions for ineligible models, so we
+    # don't pre-filter on the entry-route model string here.
+    if is_experimental_responses_enabled():
+        chat_request = ChatRequest(
+            model=chat_request.model,
+            messages=chat_request.messages,
+            temperature=chat_request.temperature,
+            max_tokens=chat_request.max_tokens,
+            stream=chat_request.stream,
+            tools=chat_request.tools,
+            tool_choice=chat_request.tool_choice,
+            thinking_budget=chat_request.thinking_budget,
+            thinking_type=chat_request.thinking_type,
+            reasoning_effort=chat_request.reasoning_effort,
+            use_responses_api=True,
+            extra=chat_request.extra,
+        )
 
     if request.stream:
         # Resolve provider for accurate token estimation

--- a/src/router_maestro/server/routes/gemini.py
+++ b/src/router_maestro/server/routes/gemini.py
@@ -23,6 +23,9 @@ from router_maestro.server.translation_gemini import (
     translate_openai_to_gemini,
 )
 from router_maestro.utils import get_logger
+from router_maestro.utils.responses_bridge import (
+    is_experimental_responses_enabled,
+)
 
 logger = get_logger("server.routes.gemini")
 
@@ -52,6 +55,35 @@ def _estimate_input_tokens(request: GeminiGenerateContentRequest) -> int:
         return 0
 
 
+def _maybe_enable_responses_api(request: ChatRequest, model: str) -> ChatRequest:
+    """Opt this ChatRequest into Copilot /responses when the env flag is on.
+
+    The Copilot provider is the authoritative gate
+    (``should_use_responses_for_chat``): it checks the resolved provider name
+    and model eligibility and falls through to ``/chat/completions`` when
+    either fails. Setting the flag here is a no-op for non-Copilot or
+    non-GPT-5 backends — we don't pre-filter on the raw path model so
+    aliases/fuzzy matches resolve through the router instead of the entry
+    route.
+    """
+    if not is_experimental_responses_enabled():
+        return request
+    return ChatRequest(
+        model=request.model,
+        messages=request.messages,
+        temperature=request.temperature,
+        max_tokens=request.max_tokens,
+        stream=request.stream,
+        tools=request.tools,
+        tool_choice=request.tool_choice,
+        thinking_budget=request.thinking_budget,
+        thinking_type=request.thinking_type,
+        reasoning_effort=request.reasoning_effort,
+        use_responses_api=True,
+        extra=request.extra,
+    )
+
+
 # ============================================================================
 # POST /api/gemini/v1beta/models/{model}:generateContent
 # ============================================================================
@@ -72,6 +104,7 @@ async def generate_content(
 
     model_router = get_router()
     chat_request = translate_gemini_to_openai(request, model)
+    chat_request = _maybe_enable_responses_api(chat_request, model)
 
     try:
         response, _provider_name = await model_router.chat_completion(chat_request)
@@ -121,7 +154,8 @@ async def stream_generate_content(
     #     len(chat_request.tools) if chat_request.tools else 0,
     #     chat_request.max_tokens,
     # )
-    # Enable streaming
+    # Enable streaming, preserving every other ChatRequest field so reasoning
+    # metadata and the experimental flag survive into the provider call.
     chat_request = ChatRequest(
         model=chat_request.model,
         messages=chat_request.messages,
@@ -130,7 +164,13 @@ async def stream_generate_content(
         stream=True,
         tools=chat_request.tools,
         tool_choice=chat_request.tool_choice,
+        thinking_budget=chat_request.thinking_budget,
+        thinking_type=chat_request.thinking_type,
+        reasoning_effort=chat_request.reasoning_effort,
+        use_responses_api=chat_request.use_responses_api,
+        extra=chat_request.extra,
     )
+    chat_request = _maybe_enable_responses_api(chat_request, model)
 
     estimated_tokens = _estimate_input_tokens(request)
     return sse_streaming_response(

--- a/src/router_maestro/utils/responses_bridge.py
+++ b/src/router_maestro/utils/responses_bridge.py
@@ -182,9 +182,7 @@ def _chat_tool_choice_to_responses(tool_choice: str | dict | None) -> str | dict
     if isinstance(tool_choice, str):
         return tool_choice
     if isinstance(tool_choice, dict):
-        if tool_choice.get("type") == "function" and isinstance(
-            tool_choice.get("function"), dict
-        ):
+        if tool_choice.get("type") == "function" and isinstance(tool_choice.get("function"), dict):
             return {"type": "function", "name": tool_choice["function"].get("name", "")}
         return tool_choice
     return None

--- a/src/router_maestro/utils/responses_bridge.py
+++ b/src/router_maestro/utils/responses_bridge.py
@@ -1,0 +1,423 @@
+"""Experimental: route ChatRequest through Copilot's /responses endpoint.
+
+Background: Copilot exposes two completion endpoints — ``/chat/completions``
+(OpenAI Chat) and ``/responses`` (OpenAI Responses). Probe results show that
+only the GPT-5 family supports ``/responses`` on Copilot; Claude and Gemini
+models reject it. This module gates an opt-in path where the Anthropic and
+Gemini entry routes ask the Copilot provider to fulfil their request via
+``/responses`` when (a) the env flag is on and (b) the resolved model is
+eligible.
+
+The experiment is controlled by ``ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API``
+(values: ``1``/``true``/``yes``/``on``, case-insensitive). Default off.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from router_maestro.providers.base import (
+    ChatRequest,
+    ChatResponse,
+    ChatStreamChunk,
+    Message,
+    ResponsesRequest,
+    ResponsesResponse,
+    ResponsesStreamChunk,
+)
+
+ENV_FLAG = "ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API"
+
+# Models confirmed by direct probing of api.githubcopilot.com/responses to
+# accept the Responses API. Anything else returns 400 unsupported_api_for_model.
+# Match by suffix after stripping optional ``provider/`` prefix.
+RESPONSES_ELIGIBLE_MODELS: frozenset[str] = frozenset(
+    {
+        "gpt-5.2",
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.5",
+        "gpt-5-mini",
+    }
+)
+
+
+def is_experimental_responses_enabled() -> bool:
+    """Return True if the experimental env flag is set to a truthy value."""
+    raw = os.environ.get(ENV_FLAG, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _bare_model(model: str) -> str:
+    return model.split("/", 1)[1] if "/" in model else model
+
+
+def is_model_responses_eligible(model: str) -> bool:
+    """Whether the upstream serves this model via /responses."""
+    return _bare_model(model) in RESPONSES_ELIGIBLE_MODELS
+
+
+def _message_has_non_text_content(content) -> bool:
+    """True if a Message.content list contains any non-plain-text block.
+
+    The Responses bridge only forwards plain text (string content or
+    ``{"type": "text", ...}`` blocks). Anything else — image_url, image,
+    input_image, audio, file, **document** (Anthropic), and any future
+    structured block — must force fallback to /chat/completions so we
+    don't silently drop modalities the user actually sent.
+    """
+    if not isinstance(content, list):
+        return False
+    for block in content:
+        if isinstance(block, str):
+            continue
+        if not isinstance(block, dict):
+            # Unknown shape — treat as non-text to be safe.
+            return True
+        btype = block.get("type")
+        if btype == "text":
+            continue
+        # Anything other than a text block (or an undecorated dict that just
+        # carries text) is structured and unsafe to drop silently.
+        if btype is None and isinstance(block.get("text"), str):
+            continue
+        return True
+    return False
+
+
+def request_has_non_text_content(request: ChatRequest) -> bool:
+    """True if any message in the request carries non-text content blocks."""
+    return any(_message_has_non_text_content(m.content) for m in request.messages)
+
+
+def should_use_responses_for_chat(request: ChatRequest, provider_name: str) -> bool:
+    """Decide whether a ChatRequest should be fulfilled via /responses.
+
+    Requires:
+    - the experimental env flag (kill-switch enforced here, not just at the
+      entry routes, so any caller setting ``use_responses_api=True`` is still
+      gated by ops);
+    - the per-request opt-in flag;
+    - the Copilot provider (others have no /responses endpoint we target);
+    - an eligible model;
+    - text-only content (multimodal requests fall back to /chat/completions).
+    """
+    if not is_experimental_responses_enabled():
+        return False
+    if not request.use_responses_api:
+        return False
+    if provider_name != "github-copilot":
+        return False
+    if not is_model_responses_eligible(request.model):
+        return False
+    if request_has_non_text_content(request):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# ChatRequest -> ResponsesRequest
+# ---------------------------------------------------------------------------
+
+
+def _content_to_text(content: str | list) -> str:
+    """Flatten a Message.content (str or list of OpenAI-style blocks) to text.
+
+    Multi-block text content is joined with a blank line separator to match
+    other translators in this codebase and avoid silently merging block
+    boundaries (e.g., ``"foo"`` + ``"bar"`` becoming ``"foobar"``).
+    Multimodal blocks are ignored here — callers should have already
+    short-circuited via ``request_has_non_text_content`` before reaching
+    this point.
+    """
+    if isinstance(content, str):
+        return content
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict):
+            if block.get("type") == "text":
+                parts.append(block.get("text", ""))
+            elif "text" in block and isinstance(block["text"], str):
+                parts.append(block["text"])
+        elif isinstance(block, str):
+            parts.append(block)
+    return "\n\n".join(p for p in parts if p)
+
+
+def _chat_tools_to_responses_tools(tools: list[dict] | None) -> list[dict] | None:
+    """Convert OpenAI Chat tool definitions to Responses tool definitions.
+
+    Chat shape:    ``{"type": "function", "function": {"name", "description", "parameters"}}``
+    Responses shape: ``{"type": "function", "name", "description", "parameters"}``
+    """
+    if not tools:
+        return None
+    out: list[dict] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            fn = tool["function"]
+            entry: dict = {"type": "function", "name": fn.get("name", "")}
+            if fn.get("description") is not None:
+                entry["description"] = fn["description"]
+            if fn.get("parameters") is not None:
+                entry["parameters"] = fn["parameters"]
+            if fn.get("strict") is not None:
+                entry["strict"] = fn["strict"]
+            out.append(entry)
+        else:
+            # Already in Responses shape or unknown — pass through.
+            out.append(tool)
+    return out or None
+
+
+def _chat_tool_choice_to_responses(tool_choice: str | dict | None) -> str | dict | None:
+    """Translate Chat tool_choice to Responses tool_choice."""
+    if tool_choice is None:
+        return None
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if isinstance(tool_choice, dict):
+        if tool_choice.get("type") == "function" and isinstance(
+            tool_choice.get("function"), dict
+        ):
+            return {"type": "function", "name": tool_choice["function"].get("name", "")}
+        return tool_choice
+    return None
+
+
+def _messages_to_responses_input(
+    messages: list[Message],
+) -> tuple[str | None, list[dict]]:
+    """Convert a list of OpenAI Chat Messages into (instructions, input_items).
+
+    System messages collapse into the ``instructions`` field. Assistant tool_calls
+    become ``function_call`` items; tool messages become ``function_call_output``
+    items. Plain user/assistant text become ``message`` items.
+    """
+    instructions_parts: list[str] = []
+    items: list[dict] = []
+
+    for msg in messages:
+        role = msg.role
+        if role == "system":
+            text = _content_to_text(msg.content)
+            if text:
+                instructions_parts.append(text)
+            continue
+
+        if role == "tool":
+            output = msg.content if isinstance(msg.content, str) else _content_to_text(msg.content)
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.tool_call_id or "",
+                    "output": output if isinstance(output, str) else json.dumps(output),
+                }
+            )
+            continue
+
+        if role == "assistant":
+            text = _content_to_text(msg.content) if msg.content else ""
+            if text:
+                items.append(
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        # Replayed assistant turns are *input* to the next call,
+                        # so use input_text (matches the project schema and what
+                        # Copilot's /responses accepts as request-history).
+                        "content": [{"type": "input_text", "text": text}],
+                    }
+                )
+            for tc in msg.tool_calls or []:
+                fn = tc.get("function") or {}
+                args = fn.get("arguments", "{}")
+                if not isinstance(args, str):
+                    args = json.dumps(args)
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tc.get("id", ""),
+                        "name": fn.get("name", ""),
+                        "arguments": args,
+                    }
+                )
+            continue
+
+        # user (or unknown role treated as user)
+        text = _content_to_text(msg.content)
+        items.append(
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            }
+        )
+
+    instructions = "\n\n".join(p for p in instructions_parts if p) or None
+    return instructions, items
+
+
+def chat_request_to_responses_request(request: ChatRequest) -> ResponsesRequest:
+    """Convert a ChatRequest into a ResponsesRequest preserving reasoning effort.
+
+    ``thinking_budget`` is left to the provider's reasoning resolver — we only
+    forward the already-resolved ``reasoning_effort`` (or pass ``None`` and let
+    the Copilot provider derive it from the budget).
+    """
+    instructions, input_items = _messages_to_responses_input(request.messages)
+    tools = _chat_tools_to_responses_tools(request.tools)
+    tool_choice = _chat_tool_choice_to_responses(request.tool_choice)
+
+    # Derive reasoning_effort from thinking_budget if the entry route only
+    # provided a budget (Anthropic Messages API uses budget_tokens).
+    effort = request.reasoning_effort
+    if effort is None and request.thinking_budget is not None:
+        from router_maestro.utils.reasoning import budget_to_effort
+
+        effort = budget_to_effort(request.thinking_budget)
+
+    return ResponsesRequest(
+        model=request.model,
+        input=input_items,
+        stream=request.stream,
+        instructions=instructions,
+        temperature=request.temperature,
+        max_output_tokens=request.max_tokens,
+        tools=tools,
+        tool_choice=tool_choice,
+        parallel_tool_calls=None,
+        reasoning_effort=effort,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ResponsesResponse -> ChatResponse
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Finish-reason mapping
+# ---------------------------------------------------------------------------
+
+
+def map_responses_status_to_chat(
+    status: str | None,
+    incomplete_reason: str | None = None,
+) -> str | None:
+    """Map a Responses API response status to an OpenAI Chat finish_reason.
+
+    - ``completed`` -> ``stop``
+    - ``incomplete`` + ``max_output_tokens`` -> ``length``
+    - ``incomplete`` + ``content_filter`` -> ``content_filter``
+    - ``incomplete`` (other reasons) -> ``stop`` (closest neutral mapping)
+    - ``failed`` / ``cancelled`` -> ``None`` (callers must surface as an error,
+      never as a normal finish)
+    Returns None if status is unrecognised so callers can apply their own
+    default (typically "stop" or "tool_calls").
+    """
+    if status is None:
+        return None
+    if status == "completed":
+        return "stop"
+    if status == "incomplete":
+        if incomplete_reason == "max_output_tokens":
+            return "length"
+        if incomplete_reason == "content_filter":
+            return "content_filter"
+        return "stop"
+    if status in ("failed", "cancelled"):
+        return None
+    return None
+
+
+def responses_response_to_chat_response(
+    resp: ResponsesResponse, requested_model: str
+) -> ChatResponse:
+    """Convert a non-streaming ResponsesResponse back into a ChatResponse.
+
+    Tool calls are reshaped into OpenAI Chat ``tool_calls`` shape so that the
+    downstream Anthropic/Gemini translators don't need to know about Responses.
+    Upstream ``finish_reason`` (already mapped from Responses ``status``) is
+    preserved when present; otherwise it defaults to ``tool_calls`` when tool
+    calls are emitted, else ``stop``.
+    """
+    tool_calls: list[dict] | None = None
+    if resp.tool_calls:
+        tool_calls = [
+            {
+                "id": tc.call_id,
+                "type": "function",
+                "function": {"name": tc.name, "arguments": tc.arguments},
+            }
+            for tc in resp.tool_calls
+        ]
+
+    # Map Responses usage (input/output) to Chat usage (prompt/completion).
+    usage: dict | None = None
+    if resp.usage:
+        prompt = resp.usage.get("input_tokens", 0)
+        completion = resp.usage.get("output_tokens", 0)
+        usage = {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": resp.usage.get("total_tokens", prompt + completion),
+        }
+
+    finish_reason = resp.finish_reason
+    if tool_calls and finish_reason in (None, "stop"):
+        # A "completed" status with tool calls is a tool-use turn, not a normal
+        # stop — Anthropic/Gemini translators key tool execution off this.
+        finish_reason = "tool_calls"
+    elif finish_reason is None:
+        finish_reason = "stop"
+
+    return ChatResponse(
+        content=resp.content or None,
+        model=resp.model or requested_model,
+        finish_reason=finish_reason,
+        usage=usage,
+        tool_calls=tool_calls,
+        thinking=getattr(resp, "thinking", None),
+        thinking_signature=getattr(resp, "thinking_signature", None),
+    )
+
+
+def responses_chunk_to_chat_chunk(chunk: ResponsesStreamChunk) -> ChatStreamChunk:
+    """Convert a streaming ResponsesStreamChunk into a ChatStreamChunk."""
+    tool_calls: list[dict] | None = None
+    if chunk.tool_call:
+        tool_calls = [
+            {
+                "id": chunk.tool_call.call_id,
+                "type": "function",
+                "function": {
+                    "name": chunk.tool_call.name,
+                    "arguments": chunk.tool_call.arguments,
+                },
+            }
+        ]
+
+    usage: dict | None = None
+    if chunk.usage:
+        prompt = chunk.usage.get("input_tokens", 0)
+        completion = chunk.usage.get("output_tokens", 0)
+        usage = {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": chunk.usage.get("total_tokens", prompt + completion),
+        }
+
+    return ChatStreamChunk(
+        content=chunk.content or "",
+        finish_reason=chunk.finish_reason,
+        usage=usage,
+        tool_calls=tool_calls,
+        thinking=getattr(chunk, "thinking", None),
+        thinking_signature=getattr(chunk, "thinking_signature", None),
+    )

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -104,13 +104,13 @@ class TestCopilotResponsesPayloadEffort:
         provider = CopilotProvider()
         req = ResponsesRequest(model="gpt-5", input="hi", reasoning_effort="high")
         payload = provider._build_responses_payload(req)
-        assert payload["reasoning"] == {"effort": "high"}
+        assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
 
     def test_responses_payload_downgrades_xhigh(self):
         provider = CopilotProvider()
         req = ResponsesRequest(model="gpt-5", input="hi", reasoning_effort="xhigh")
         payload = provider._build_responses_payload(req)
-        assert payload["reasoning"] == {"effort": "high"}
+        assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
 
     def test_responses_payload_omits_when_unset(self):
         provider = CopilotProvider()

--- a/tests/test_responses_bridge.py
+++ b/tests/test_responses_bridge.py
@@ -207,9 +207,7 @@ class TestRequestHasNonTextContent:
     def test_audio_block_detected(self):
         req = ChatRequest(
             model="m",
-            messages=[
-                Message(role="user", content=[{"type": "input_audio", "input_audio": {}}])
-            ],
+            messages=[Message(role="user", content=[{"type": "input_audio", "input_audio": {}}])],
         )
         assert request_has_non_text_content(req) is True
 
@@ -575,9 +573,7 @@ class TestCopilotResponsesFailureRaises:
             patch.object(provider, "_get_client", return_value=mock_client),
         ):
             with pytest.raises(ProviderError) as exc:
-                await provider.responses_completion(
-                    ResponsesRequest(model="gpt-5.4", input="hi")
-                )
+                await provider.responses_completion(ResponsesRequest(model="gpt-5.4", input="hi"))
             assert status in str(exc.value)
             assert "upstream" in str(exc.value)
 
@@ -612,9 +608,7 @@ class TestCopilotResponsesFailureRaises:
             patch.object(provider, "_get_headers", return_value={}),
             patch.object(provider, "_get_client", return_value=mock_client),
         ):
-            out = await provider.responses_completion(
-                ResponsesRequest(model="gpt-5.4", input="hi")
-            )
+            out = await provider.responses_completion(ResponsesRequest(model="gpt-5.4", input="hi"))
         assert out.content == "ok"
         assert out.finish_reason == "stop"
 

--- a/tests/test_responses_bridge.py
+++ b/tests/test_responses_bridge.py
@@ -1,0 +1,668 @@
+"""Tests for the experimental ChatRequest -> /responses bridge."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from router_maestro.providers.base import (
+    ChatRequest,
+    Message,
+    ProviderError,
+    ResponsesRequest,
+    ResponsesResponse,
+    ResponsesStreamChunk,
+    ResponsesToolCall,
+)
+from router_maestro.utils.responses_bridge import (
+    ENV_FLAG,
+    chat_request_to_responses_request,
+    is_experimental_responses_enabled,
+    is_model_responses_eligible,
+    map_responses_status_to_chat,
+    request_has_non_text_content,
+    responses_chunk_to_chat_chunk,
+    responses_response_to_chat_response,
+    should_use_responses_for_chat,
+)
+
+
+class TestEnvFlag:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "ON"])
+    def test_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv(ENV_FLAG, value)
+        assert is_experimental_responses_enabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "anything"])
+    def test_falsy_values(self, monkeypatch, value):
+        monkeypatch.setenv(ENV_FLAG, value)
+        assert is_experimental_responses_enabled() is False
+
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv(ENV_FLAG, raising=False)
+        assert is_experimental_responses_enabled() is False
+
+
+class TestModelEligibility:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5.2",
+            "gpt-5.4",
+            "gpt-5.5",
+            "gpt-5-mini",
+            "gpt-5.4-mini",
+            "gpt-5.2-codex",
+            "gpt-5.3-codex",
+            "github-copilot/gpt-5.4",  # provider prefix
+        ],
+    )
+    def test_eligible(self, model):
+        assert is_model_responses_eligible(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4.7",
+            "claude-sonnet-4.6",
+            "gemini-3.1-pro-preview",
+            "gpt-4.1",
+            "gpt-4o",
+            "github-copilot/claude-opus-4.6",
+        ],
+    )
+    def test_ineligible(self, model):
+        assert is_model_responses_eligible(model) is False
+
+
+class TestShouldUseResponses:
+    @pytest.fixture(autouse=True)
+    def _enable_flag(self, monkeypatch):
+        monkeypatch.setenv(ENV_FLAG, "1")
+
+    def _req(self, model: str, *, opt_in: bool) -> ChatRequest:
+        return ChatRequest(
+            model=model,
+            messages=[Message(role="user", content="hi")],
+            use_responses_api=opt_in,
+        )
+
+    def test_requires_opt_in(self):
+        req = self._req("gpt-5.4", opt_in=False)
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_requires_copilot_provider(self):
+        req = self._req("gpt-5.4", opt_in=True)
+        assert should_use_responses_for_chat(req, "openai") is False
+
+    def test_requires_eligible_model(self):
+        req = self._req("claude-opus-4.7", opt_in=True)
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_happy_path(self):
+        req = self._req("gpt-5.4", opt_in=True)
+        assert should_use_responses_for_chat(req, "github-copilot") is True
+
+    def test_env_flag_disabled_blocks_even_with_opt_in(self, monkeypatch):
+        """Kill-switch: env off must block even if a caller set use_responses_api."""
+        monkeypatch.delenv(ENV_FLAG, raising=False)
+        req = self._req("gpt-5.4", opt_in=True)
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_env_flag_off_value_blocks(self, monkeypatch):
+        monkeypatch.setenv(ENV_FLAG, "off")
+        req = self._req("gpt-5.4", opt_in=True)
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_falls_back_when_image_block_present(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "describe"},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,xxx"}},
+                    ],
+                )
+            ],
+            use_responses_api=True,
+        )
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_falls_back_when_input_image_present(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(
+                    role="user",
+                    content=[{"type": "input_image", "image_url": "https://x/y.png"}],
+                )
+            ],
+            use_responses_api=True,
+        )
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_falls_back_when_document_block_present(self):
+        """Anthropic document blocks must force /chat fallback (regression)."""
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "summarise"},
+                        {"type": "document", "source": {"type": "base64", "data": "xxx"}},
+                    ],
+                )
+            ],
+            use_responses_api=True,
+        )
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_falls_back_for_unknown_structured_block(self):
+        """Unknown structured types are conservatively rejected."""
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(
+                    role="user",
+                    content=[{"type": "future_modality_xyz", "data": "x"}],
+                )
+            ],
+            use_responses_api=True,
+        )
+        assert should_use_responses_for_chat(req, "github-copilot") is False
+
+    def test_text_only_list_content_still_eligible(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(role="user", content=[{"type": "text", "text": "hi"}]),
+            ],
+            use_responses_api=True,
+        )
+        assert should_use_responses_for_chat(req, "github-copilot") is True
+
+
+class TestRequestHasNonTextContent:
+    def test_pure_string_is_text(self):
+        req = ChatRequest(model="m", messages=[Message(role="user", content="hi")])
+        assert request_has_non_text_content(req) is False
+
+    def test_image_url_block_detected(self):
+        req = ChatRequest(
+            model="m",
+            messages=[
+                Message(
+                    role="user",
+                    content=[{"type": "image_url", "image_url": {"url": "x"}}],
+                )
+            ],
+        )
+        assert request_has_non_text_content(req) is True
+
+    def test_audio_block_detected(self):
+        req = ChatRequest(
+            model="m",
+            messages=[
+                Message(role="user", content=[{"type": "input_audio", "input_audio": {}}])
+            ],
+        )
+        assert request_has_non_text_content(req) is True
+
+    def test_file_block_detected(self):
+        req = ChatRequest(
+            model="m",
+            messages=[Message(role="user", content=[{"type": "file", "file": {}}])],
+        )
+        assert request_has_non_text_content(req) is True
+
+    def test_document_block_detected(self):
+        req = ChatRequest(
+            model="m",
+            messages=[
+                Message(
+                    role="user",
+                    content=[{"type": "document", "source": {"type": "base64"}}],
+                )
+            ],
+        )
+        assert request_has_non_text_content(req) is True
+
+    def test_text_block_only_is_text(self):
+        req = ChatRequest(
+            model="m",
+            messages=[Message(role="user", content=[{"type": "text", "text": "hi"}])],
+        )
+        assert request_has_non_text_content(req) is False
+
+
+class TestStatusMapping:
+    @pytest.mark.parametrize(
+        "status,reason,expected",
+        [
+            ("completed", None, "stop"),
+            ("incomplete", "max_output_tokens", "length"),
+            ("incomplete", "content_filter", "content_filter"),
+            ("incomplete", "other", "stop"),
+            ("failed", None, None),
+            ("cancelled", None, None),
+            ("unknown_status", None, None),
+            (None, None, None),
+        ],
+    )
+    def test_map(self, status, reason, expected):
+        assert map_responses_status_to_chat(status, reason) == expected
+
+
+class TestChatToResponses:
+    def test_system_message_becomes_instructions(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(role="system", content="You are a poet."),
+                Message(role="user", content="Write a haiku."),
+            ],
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.instructions == "You are a poet."
+        assert isinstance(out.input, list)
+        assert out.input[0]["role"] == "user"
+        assert out.input[0]["content"][0]["type"] == "input_text"
+
+    def test_assistant_tool_call_round_trip(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(role="user", content="weather?"),
+                Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
+                        }
+                    ],
+                ),
+                Message(
+                    role="tool",
+                    content="sunny",
+                    tool_call_id="call_1",
+                ),
+            ],
+        )
+        out = chat_request_to_responses_request(req)
+        types = [item["type"] for item in out.input]
+        assert types == ["message", "function_call", "function_call_output"]
+        assert out.input[1] == {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "get_weather",
+            "arguments": '{"city":"SF"}',
+        }
+        assert out.input[2] == {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "sunny",
+        }
+
+    def test_tools_translated_to_responses_shape(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="hi")],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "fetch",
+                        "description": "fetch a URL",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.tools == [
+            {
+                "type": "function",
+                "name": "fetch",
+                "description": "fetch a URL",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+    def test_thinking_budget_derives_effort(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="hi")],
+            thinking_budget=8192,
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.reasoning_effort == "high"
+
+    def test_explicit_effort_wins(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="hi")],
+            thinking_budget=8192,
+            reasoning_effort="low",
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.reasoning_effort == "low"
+
+    def test_max_tokens_maps_to_max_output_tokens(self):
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=1234,
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.max_output_tokens == 1234
+
+    def test_multi_block_text_joined_with_blank_line(self):
+        """Multi-block user text must be joined with \\n\\n, not concatenated.
+
+        Regression: ``"".join`` would silently merge boundaries between blocks
+        (``"foo"`` + ``"bar"`` -> ``"foobar"``), changing prompt meaning.
+        """
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "foo"},
+                        {"type": "text", "text": "bar"},
+                    ],
+                )
+            ],
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.input[0]["content"][0]["text"] == "foo\n\nbar"
+
+    def test_assistant_history_uses_input_text(self):
+        """Replayed assistant turns must be input_text, not output_text.
+
+        OpenAI's request schema (mirrored in this project's
+        ResponsesInputTextContent) uses input_text for all input message
+        content; using output_text in request history is a contract mismatch.
+        """
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[
+                Message(role="user", content="ping"),
+                Message(role="assistant", content="pong"),
+                Message(role="user", content="again?"),
+            ],
+        )
+        out = chat_request_to_responses_request(req)
+        assert out.input[1] == {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "input_text", "text": "pong"}],
+        }
+        # Sanity: every message item content block uses input_text.
+        for item in out.input:
+            if item.get("type") == "message":
+                for block in item["content"]:
+                    assert block["type"] == "input_text"
+
+
+class TestResponsesToChat:
+    def test_text_only(self):
+        resp = ResponsesResponse(
+            content="hello",
+            model="gpt-5.4",
+            usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.content == "hello"
+        assert chat.finish_reason == "stop"
+        assert chat.usage == {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
+
+    def test_tool_calls_reshaped(self):
+        resp = ResponsesResponse(
+            content="",
+            model="gpt-5.4",
+            tool_calls=[ResponsesToolCall(call_id="c1", name="fn", arguments="{}")],
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "tool_calls"
+        assert chat.tool_calls == [
+            {"id": "c1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}
+        ]
+
+    def test_thinking_passthrough(self):
+        resp = ResponsesResponse(
+            content="answer",
+            model="gpt-5.4",
+            thinking="step 1, step 2",
+            thinking_signature="opaque-id",
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.thinking == "step 1, step 2"
+        assert chat.thinking_signature == "opaque-id"
+
+    def test_finish_reason_length_preserved(self):
+        resp = ResponsesResponse(
+            content="truncated",
+            model="gpt-5.4",
+            finish_reason="length",
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "length"
+
+    def test_finish_reason_content_filter_preserved(self):
+        resp = ResponsesResponse(
+            content="",
+            model="gpt-5.4",
+            finish_reason="content_filter",
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "content_filter"
+
+    def test_finish_reason_default_when_unset(self):
+        resp = ResponsesResponse(content="hi", model="gpt-5.4")
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "stop"
+
+    def test_tool_calls_finish_default_when_status_missing(self):
+        resp = ResponsesResponse(
+            content="",
+            model="gpt-5.4",
+            tool_calls=[ResponsesToolCall(call_id="c1", name="fn", arguments="{}")],
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "tool_calls"
+
+    def test_completed_status_with_tool_calls_upgrades_to_tool_calls(self):
+        """A 'completed' /responses payload that emitted tool calls is a tool-use turn.
+
+        Regression: previously map_responses_status_to_chat("completed") -> "stop"
+        beat the tool-call default, leaking 'end_turn' to Anthropic translators.
+        """
+        resp = ResponsesResponse(
+            content="",
+            model="gpt-5.4",
+            tool_calls=[ResponsesToolCall(call_id="c1", name="fn", arguments="{}")],
+            finish_reason="stop",
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "tool_calls"
+
+    def test_explicit_length_with_tool_calls_keeps_length(self):
+        """A non-stop upstream finish_reason should NOT be downgraded by tool calls."""
+        resp = ResponsesResponse(
+            content="",
+            model="gpt-5.4",
+            tool_calls=[ResponsesToolCall(call_id="c1", name="fn", arguments="{}")],
+            finish_reason="length",
+        )
+        chat = responses_response_to_chat_response(resp, "gpt-5.4")
+        assert chat.finish_reason == "length"
+
+
+class TestStreamChunkConversion:
+    def test_text_delta(self):
+        chunk = ResponsesStreamChunk(content="hi")
+        out = responses_chunk_to_chat_chunk(chunk)
+        assert out.content == "hi"
+        assert out.tool_calls is None
+
+    def test_thinking_delta(self):
+        chunk = ResponsesStreamChunk(content="", thinking="thought", thinking_signature="sig")
+        out = responses_chunk_to_chat_chunk(chunk)
+        assert out.thinking == "thought"
+        assert out.thinking_signature == "sig"
+
+    def test_tool_call_chunk(self):
+        chunk = ResponsesStreamChunk(
+            content="",
+            tool_call=ResponsesToolCall(call_id="c2", name="g", arguments='{"a":1}'),
+        )
+        out = responses_chunk_to_chat_chunk(chunk)
+        assert out.tool_calls == [
+            {"id": "c2", "type": "function", "function": {"name": "g", "arguments": '{"a":1}'}}
+        ]
+
+    def test_finish_with_usage(self):
+        chunk = ResponsesStreamChunk(
+            content="",
+            finish_reason="stop",
+            usage={"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+        )
+        out = responses_chunk_to_chat_chunk(chunk)
+        assert out.finish_reason == "stop"
+        assert out.usage == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+class TestCopilotResponsesFailureRaises:
+    """Terminal upstream statuses must surface as ProviderError, not stop."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["failed", "cancelled"])
+    async def test_non_streaming_failed_raises(self, status):
+        from router_maestro.providers.copilot import CopilotProvider
+
+        provider = CopilotProvider()
+
+        mock_resp = httpx.Response(
+            200,
+            json={
+                "status": status,
+                "model": "gpt-5.4",
+                "output": [],
+                "error": {"message": f"upstream {status}"},
+            },
+            request=httpx.Request("POST", "https://api.githubcopilot.com/responses"),
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_resp
+
+        with (
+            patch.object(provider, "ensure_token", AsyncMock(return_value=None)),
+            patch.object(provider, "_get_headers", return_value={}),
+            patch.object(provider, "_get_client", return_value=mock_client),
+        ):
+            with pytest.raises(ProviderError) as exc:
+                await provider.responses_completion(
+                    ResponsesRequest(model="gpt-5.4", input="hi")
+                )
+            assert status in str(exc.value)
+            assert "upstream" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_completed_does_not_raise(self):
+        from router_maestro.providers.copilot import CopilotProvider
+
+        provider = CopilotProvider()
+
+        mock_resp = httpx.Response(
+            200,
+            json={
+                "status": "completed",
+                "model": "gpt-5.4",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            },
+            request=httpx.Request("POST", "https://api.githubcopilot.com/responses"),
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_resp
+
+        with (
+            patch.object(provider, "ensure_token", AsyncMock(return_value=None)),
+            patch.object(provider, "_get_headers", return_value={}),
+            patch.object(provider, "_get_client", return_value=mock_client),
+        ):
+            out = await provider.responses_completion(
+                ResponsesRequest(model="gpt-5.4", input="hi")
+            )
+        assert out.content == "ok"
+        assert out.finish_reason == "stop"
+
+
+class TestGeminiRouteFieldPreservation:
+    """Regression: Gemini stream route must preserve reasoning + experimental fields."""
+
+    def test_stream_route_helper_preserves_all_fields(self, monkeypatch):
+        """_maybe_enable_responses_api must keep reasoning_effort, thinking_*, extra."""
+        monkeypatch.setenv(ENV_FLAG, "1")
+        from router_maestro.server.routes.gemini import _maybe_enable_responses_api
+
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="hi")],
+            temperature=0.5,
+            max_tokens=512,
+            stream=True,
+            tools=[{"type": "function", "function": {"name": "x"}}],
+            tool_choice="auto",
+            thinking_budget=4096,
+            thinking_type="enabled",
+            reasoning_effort="high",
+            extra={"custom": "value"},
+        )
+        out = _maybe_enable_responses_api(req, "gpt-5.4")
+        assert out.use_responses_api is True
+        assert out.reasoning_effort == "high"
+        assert out.thinking_budget == 4096
+        assert out.thinking_type == "enabled"
+        assert out.tool_choice == "auto"
+        assert out.tools == [{"type": "function", "function": {"name": "x"}}]
+        assert out.extra == {"custom": "value"}
+        assert out.stream is True
+        assert out.temperature == 0.5
+        assert out.max_tokens == 512
+
+    def test_stream_route_helper_noop_when_flag_off(self, monkeypatch):
+        monkeypatch.delenv(ENV_FLAG, raising=False)
+        from router_maestro.server.routes.gemini import _maybe_enable_responses_api
+
+        req = ChatRequest(
+            model="gpt-5.4",
+            messages=[Message(role="user", content="hi")],
+            reasoning_effort="medium",
+        )
+        out = _maybe_enable_responses_api(req, "gpt-5.4")
+        # Returns the original request unchanged.
+        assert out is req
+        assert out.use_responses_api is False
+        assert out.reasoning_effort == "medium"


### PR DESCRIPTION
## Summary

- New opt-in path: routes Anthropic & Gemini entry requests through Copilot's `/responses` endpoint instead of `/chat/completions` when the resolved model is GPT-5.x. Direct API probing confirmed only GPT-5.x on Copilot accepts `/responses`; Claude and Gemini reject it.
- Gated by `ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API` (default off). Kill-switch enforced inside `should_use_responses_for_chat`, not just at entry routes.
- New module `src/router_maestro/utils/responses_bridge.py` translates between `ChatRequest`/`ChatResponse` and `ResponsesRequest`/`ResponsesResponse`.

## Behaviour

- **Multimodal fallback**: image_url / image / input_image / audio / file / **document** (Anthropic) / unknown structured blocks force fallback to `/chat/completions` instead of being silently dropped.
- **Multi-block text** joined with `\n\n` (matches sibling translators) so block boundaries aren't collapsed.
- **Assistant history** items use `input_text` (matches project schema and what Copilot's `/responses` accepts as request-history).
- **finish_reason** mapped from upstream `status` / `incomplete_details.reason`: `completed → stop`, `incomplete + max_output_tokens → length`, `incomplete + content_filter → content_filter`. Tool-call upgrade ensures completed responses with tool calls surface as `tool_calls` (Anthropic translator otherwise emits `end_turn`).
- **failed / cancelled** status raise `ProviderError` instead of silently returning a blank "stop".
- **Reasoning summaries** captured via `response.reasoning_summary_text.delta/.done` events and surfaced as `thinking` + a single `thinking_signature` on done.
- Gemini streaming route now preserves `reasoning_effort`, `thinking_budget`, `thinking_type`, `use_responses_api`, `extra` when toggling `stream=True` (pre-existing field-loss bug fixed).

## Known limitations (intentional)

- `parallel_tool_calls` not bridged (no first-class `ChatRequest` field; `extra` not forwarded).
- `[DONE]` without a `response.done`/`response.completed` event falls back to `stop`/`tool_calls` synthetic finish — same posture as the existing `/chat` streaming path.

## Test plan

- [x] `uv run pytest tests/ -q` — 719 tests pass (43 new in `test_responses_bridge.py`)
- [x] `uv run ruff check src/ tests/` — clean
- [x] Codex code-review-codex skill iterated 5 rounds; HIGH/MEDIUM/LOW findings addressed where in scope.
- [x] E2E (server with flag on, Anthropic API → GPT-5.x):
  - `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`: `thinking` blocks returned at `budget=4096/16000`; text-only at `budget=1024` (matches `/responses` summary gating at low effort).
  - `claude-opus-4.6` sanity: still routed through `/chat` unchanged when flag is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)