### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.1.37"
+version = "0.2.0"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.1.37"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.1.37"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump version 0.1.37 → 0.2.0
- Minor version reflects PR #54 — experimental Copilot `/responses` routing for Anthropic and Gemini entry routes (opt-in via `ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API`).

## Test plan
- [x] `pyproject.toml`, `__init__.py`, `uv.lock` all updated and consistent
- [ ] CI green