### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.2.0"
+version = "0.3.0"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release 0.3.0.

Highlights since 0.2.0:
- Auto-route Opus 4.7 `reasoning_effort: high|xhigh` requests to dedicated Copilot `-high` / `-xhigh` variants.
- Activate Opus 4.7 1M context (`claude-opus-4-7[1m]` → `claude-opus-4.7-1m-internal`).