### PR TITLE
fix(streaming): emit message_start eagerly to prevent first-byte timeout

### DIFF
--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -25,6 +25,7 @@ from router_maestro.server.schemas.anthropic import (
 )
 from router_maestro.server.streaming import sse_streaming_response
 from router_maestro.server.translation import (
+    build_message_start_event,
     translate_anthropic_to_openai,
     translate_openai_chunk_to_anthropic_events,
 )
@@ -426,11 +427,22 @@ async def stream_response(
     estimated_input_tokens: int = 0,
 ) -> AsyncGenerator[str, None]:
     """Stream Anthropic Messages API response."""
+    response_id = f"msg_{uuid.uuid4().hex[:24]}"
+    state = AnthropicStreamState(estimated_input_tokens=estimated_input_tokens)
+
+    # Emit message_start (and a ping) BEFORE awaiting the upstream stream so
+    # the client receives bytes within milliseconds. Large-context requests
+    # (e.g. claude-opus-4.7-1m) can take 8+ seconds to produce their first
+    # token, which exceeds Claude Code's first-byte timeout and causes the
+    # client to cancel before any data arrives. Sending message_start eagerly
+    # resets that timer with a valid Anthropic protocol event.
+    start_event = build_message_start_event(state, original_model, response_id=response_id)
+    if start_event is not None:
+        yield f"event: {start_event['type']}\ndata: {json.dumps(start_event)}\n\n"
+    yield f"event: ping\ndata: {json.dumps({'type': 'ping'})}\n\n"
+
     try:
         stream, provider_name = await model_router.chat_completion_stream(request)
-        response_id = f"msg_{uuid.uuid4().hex[:24]}"
-
-        state = AnthropicStreamState(estimated_input_tokens=estimated_input_tokens)
 
         async for chunk in stream:
             # Build OpenAI-style chunk for translation. Forward reasoning

--- a/src/router_maestro/server/streaming.py
+++ b/src/router_maestro/server/streaming.py
@@ -9,7 +9,7 @@ from router_maestro.utils import get_logger
 
 logger = get_logger("server.streaming")
 
-SSE_KEEPALIVE_INTERVAL = 15.0  # seconds
+SSE_KEEPALIVE_INTERVAL = 5.0  # seconds
 
 SSE_HEADERS = {
     "Cache-Control": "no-cache",

--- a/src/router_maestro/server/translation.py
+++ b/src/router_maestro/server/translation.py
@@ -489,6 +489,47 @@ def translate_openai_to_anthropic(
     )
 
 
+def build_message_start_event(
+    state: AnthropicStreamState, model: str, response_id: str = ""
+) -> dict | None:
+    """Build an Anthropic ``message_start`` event and mark state as sent.
+
+    Returns ``None`` when ``message_start`` has already been emitted, allowing
+    callers to safely call this in multiple places (e.g. eagerly at stream
+    open AND from the chunk translator) without double-sending.
+    """
+    if state.message_start_sent:
+        return None
+
+    input_tokens = 0
+    if state.last_usage:
+        input_tokens = state.last_usage.get("prompt_tokens", 0)
+    elif state.estimated_input_tokens:
+        input_tokens = state.estimated_input_tokens
+
+    state.message_start_sent = True
+    return {
+        "type": "message_start",
+        "message": {
+            "id": response_id,
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": model,
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": 1,
+                "cache_creation_input_tokens": None,
+                "cache_read_input_tokens": None,
+                "server_tool_use": None,
+                "service_tier": "standard",
+            },
+        },
+    }
+
+
 def translate_openai_chunk_to_anthropic_events(
     chunk: dict, state: AnthropicStreamState, model: str
 ) -> list[dict]:
@@ -521,37 +562,9 @@ def translate_openai_chunk_to_anthropic_events(
     delta = choice.get("delta", {})
 
     # Send message_start if not sent yet
-    if not state.message_start_sent:
-        # Determine input tokens: prefer actual usage, fall back to estimate
-        input_tokens = 0
-        if state.last_usage:
-            input_tokens = state.last_usage.get("prompt_tokens", 0)
-        elif state.estimated_input_tokens:
-            input_tokens = state.estimated_input_tokens
-
-        events.append(
-            {
-                "type": "message_start",
-                "message": {
-                    "id": chunk.get("id", ""),
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [],
-                    "model": model,
-                    "stop_reason": None,
-                    "stop_sequence": None,
-                    "usage": {
-                        "input_tokens": input_tokens,
-                        "output_tokens": 1,
-                        "cache_creation_input_tokens": None,
-                        "cache_read_input_tokens": None,
-                        "server_tool_use": None,
-                        "service_tier": "standard",
-                    },
-                },
-            }
-        )
-        state.message_start_sent = True
+    start_event = build_message_start_event(state, model, response_id=chunk.get("id", ""))
+    if start_event is not None:
+        events.append(start_event)
 
     # Handle reasoning / thinking deltas. Copilot streams reasoning under
     # several legacy field names (reasoning_text / cot_summary / thinking).


### PR DESCRIPTION
## Summary

- Large-context requests (e.g. `claude-opus-4.7-1m`) can take 8+ seconds to produce the first upstream token, exceeding Claude Code's client-side first-byte timeout. The client cancels with `Client disconnected (stream cancelled)` before any data is sent.
- Now emit `message_start` + `ping` events **immediately** on stream open — before awaiting the upstream — so the client receives valid Anthropic protocol bytes within milliseconds and resets its first-byte timer.
- Defense-in-depth: lower `SSE_KEEPALIVE_INTERVAL` from 15s to 5s.
- Refactor: extract `build_message_start_event()` so the eager emit and the in-translator emit share one builder; the existing `state.message_start_sent` flag prevents double-sending.

## Test plan

- [x] `uv run pytest tests/ -v` — 734/734 pass
- [x] `uv run ruff check src/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [ ] Deploy to kevin-ss and verify `claude-opus-4.7-1m` streams no longer cancel at 8-9s