### PR TITLE
fix(streaming): emit Anthropic ping events as keepalive (15s client timeout)

### DIFF
--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -50,6 +50,13 @@ router = APIRouter()
 
 TEST_RESPONSE_TEXT = "This is a test response from Router-Maestro."
 
+# Real Anthropic protocol ping event used as the SSE keepalive frame for
+# this route. SSE comments (the shared default) don't reset Claude Code's
+# "time since last protocol event" timer, which fires at ~15s and cancels
+# the stream while a slow upstream (e.g. claude-opus-4.7-1m) is still
+# producing its first content token.
+ANTHROPIC_PING_FRAME = f"event: ping\ndata: {json.dumps({'type': 'ping'})}\n\n"
+
 
 async def _resolve_provider_name(model: str) -> str | None:
     """Resolve which provider will handle a model.
@@ -197,7 +204,10 @@ async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIReques
     # Handle test model
     if request.model == "test":
         if request.stream:
-            return sse_streaming_response(_stream_test_response())
+            return sse_streaming_response(
+                _stream_test_response(),
+                keepalive_frame=ANTHROPIC_PING_FRAME,
+            )
         return _create_test_response()
 
     model_router = get_router()
@@ -267,6 +277,7 @@ async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIReques
         estimated_tokens = _estimate_input_tokens(request, provider_name)
         return sse_streaming_response(
             stream_response(model_router, chat_request, request.model, estimated_tokens),
+            keepalive_frame=ANTHROPIC_PING_FRAME,
         )
 
     try:

--- a/src/router_maestro/server/streaming.py
+++ b/src/router_maestro/server/streaming.py
@@ -11,6 +11,8 @@ logger = get_logger("server.streaming")
 
 SSE_KEEPALIVE_INTERVAL = 5.0  # seconds
 
+SSE_KEEPALIVE_COMMENT = ": keepalive\n\n"
+
 SSE_HEADERS = {
     "Cache-Control": "no-cache",
     "Connection": "keep-alive",
@@ -20,14 +22,20 @@ SSE_HEADERS = {
 
 async def resilient_sse_generator(
     inner: AsyncGenerator[str, None],
+    keepalive_frame: str = SSE_KEEPALIVE_COMMENT,
 ) -> AsyncGenerator[str, None]:
-    """Wrap an SSE generator with keepalive comments and error handling.
+    """Wrap an SSE generator with keepalive frames and error handling.
 
-    Emits ``: keepalive\\n\\n`` every ``SSE_KEEPALIVE_INTERVAL`` seconds when
-    no data is produced by the inner generator.  SSE comments are ignored by
-    compliant clients but keep bytes flowing on the wire, preventing
-    intermediary proxies and client-side socket timeouts from killing the
-    connection.
+    Emits ``keepalive_frame`` every ``SSE_KEEPALIVE_INTERVAL`` seconds when
+    no data is produced by the inner generator.  Defaults to a SSE comment
+    (``: keepalive\\n\\n``), which is ignored by compliant clients but keeps
+    bytes flowing on the wire to prevent intermediary proxies and client
+    socket timeouts from killing the connection.
+
+    Routes whose clients track a "time since last *protocol* event" timer
+    (notably Claude Code, which times out at ~15s of comment-only traffic
+    on the Anthropic Messages stream) should pass a real protocol event
+    frame here instead — e.g. ``event: ping\\ndata: {"type":"ping"}\\n\\n``.
 
     Exception handling:
     - ``asyncio.CancelledError`` — logged as client disconnect, re-raised
@@ -57,7 +65,7 @@ async def resilient_sse_generator(
                 yield value
             else:
                 # Timeout — no data within the keepalive interval
-                yield ": keepalive\n\n"
+                yield keepalive_frame
 
     except asyncio.CancelledError:
         logger.info("Client disconnected (stream cancelled)")
@@ -78,14 +86,19 @@ async def resilient_sse_generator(
 
 def sse_streaming_response(
     generator: AsyncGenerator[str, None],
+    keepalive_frame: str = SSE_KEEPALIVE_COMMENT,
 ) -> StreamingResponse:
     """Create a ``StreamingResponse`` with SSE headers and keepalive wrapper.
 
     This is the single entry-point that all streaming endpoints should use
     instead of constructing ``StreamingResponse`` directly.
+
+    ``keepalive_frame`` overrides the default SSE comment with a route-
+    specific protocol event when the client requires one (see
+    ``resilient_sse_generator`` for context).
     """
     return StreamingResponse(
-        resilient_sse_generator(generator),
+        resilient_sse_generator(generator, keepalive_frame=keepalive_frame),
         media_type="text/event-stream",
         headers=SSE_HEADERS,
     )

--- a/tests/test_anthropic_stream_keepalive.py
+++ b/tests/test_anthropic_stream_keepalive.py
@@ -1,0 +1,114 @@
+"""Tests for the Anthropic-route SSE keepalive frame.
+
+Claude Code's stream consumer cancels at ~15s when only SSE comments
+(``: keepalive\\n\\n``) flow between the eager ``message_start`` event and
+the first upstream chunk.  The Anthropic route compensates by passing
+real ``event: ping`` frames as the keepalive shape — this module verifies
+that wiring stays in place and that the OpenAI route is not affected.
+"""
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from unittest.mock import patch
+
+import pytest
+
+from router_maestro.server.routes.anthropic import ANTHROPIC_PING_FRAME
+from router_maestro.server.streaming import (
+    SSE_KEEPALIVE_COMMENT,
+    resilient_sse_generator,
+)
+
+
+async def _slow_then_done(delay: float, item: str) -> AsyncGenerator[str, None]:
+    """Sleep ``delay`` seconds, then emit ``item`` and finish."""
+    await asyncio.sleep(delay)
+    yield item
+
+
+async def _collect(gen: AsyncGenerator[str, None]) -> list[str]:
+    return [item async for item in gen]
+
+
+def test_anthropic_ping_frame_is_valid_protocol_event():
+    """The constant must be a real Anthropic ``ping`` SSE event, not a comment."""
+    assert ANTHROPIC_PING_FRAME.startswith("event: ping\n")
+    assert "data: " in ANTHROPIC_PING_FRAME
+    assert ANTHROPIC_PING_FRAME.endswith("\n\n")
+    # data line must be parseable JSON with type=ping
+    data_line = next(line for line in ANTHROPIC_PING_FRAME.split("\n") if line.startswith("data: "))
+    payload = json.loads(data_line[len("data: ") :])
+    assert payload == {"type": "ping"}
+
+
+@pytest.mark.asyncio
+async def test_keepalive_frame_overrides_default_comment():
+    """When ``keepalive_frame`` is supplied, it replaces the SSE comment."""
+    with patch("router_maestro.server.streaming.SSE_KEEPALIVE_INTERVAL", 0.05):
+        result = await _collect(
+            resilient_sse_generator(
+                _slow_then_done(0.2, "data: final\n\n"),
+                keepalive_frame=ANTHROPIC_PING_FRAME,
+            )
+        )
+
+    pings = [r for r in result if r == ANTHROPIC_PING_FRAME]
+    comments = [r for r in result if r == SSE_KEEPALIVE_COMMENT]
+    assert len(pings) >= 1, f"Expected ping frames, got: {result}"
+    assert comments == [], "Anthropic keepalive must not emit SSE comments"
+    assert "data: final\n\n" in result
+
+
+@pytest.mark.asyncio
+async def test_default_keepalive_is_still_sse_comment():
+    """Routes that don't override keep the SSE comment (OpenAI/Codex regression)."""
+    with patch("router_maestro.server.streaming.SSE_KEEPALIVE_INTERVAL", 0.05):
+        result = await _collect(resilient_sse_generator(_slow_then_done(0.2, "data: final\n\n")))
+
+    comments = [r for r in result if r == SSE_KEEPALIVE_COMMENT]
+    assert len(comments) >= 1
+    pings = [r for r in result if r.startswith("event: ping")]
+    assert pings == []
+
+
+@pytest.mark.asyncio
+async def test_anthropic_route_passes_ping_frame_to_streaming_response():
+    """``stream`` requests must wire ``ANTHROPIC_PING_FRAME`` into the response.
+
+    Guards against accidentally regressing to the default SSE comment when
+    refactoring ``routes/anthropic.py``.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from router_maestro.server.routes.anthropic import router as anthropic_router
+
+    captured: dict = {}
+
+    real_sse = pytest.importorskip("router_maestro.server.routes.anthropic")
+    original = real_sse.sse_streaming_response
+
+    def _spy(generator, keepalive_frame=SSE_KEEPALIVE_COMMENT):
+        captured["keepalive_frame"] = keepalive_frame
+        return original(generator, keepalive_frame=keepalive_frame)
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+
+    with patch.object(real_sse, "sse_streaming_response", side_effect=_spy):
+        client = TestClient(app)
+        # The ``test`` model short-circuits before hitting any provider, so
+        # we don't need to mock the router.
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "stream": True,
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert captured.get("keepalive_frame") == ANTHROPIC_PING_FRAME


### PR DESCRIPTION
## Summary

- Fix SSE streams cancelled by Claude Code at exactly 15 s when targeting slow upstreams (e.g. `claude-opus-4.7-1m`, whose first content token can take 15-25 s).
- Root cause: Claude Code's stream consumer tracks a *time since last protocol event* timer (~15 s) and treats SSE comments (`: keepalive\n\n`) as no-ops. After v0.3.1's eager `message_start` + single `ping` at t=0, only comments flowed until upstream first chunk; client cancelled at the 15 s mark.
- Fix: parameterize `resilient_sse_generator` / `sse_streaming_response` with an optional `keepalive_frame`. The Anthropic route now passes a real `event: ping\ndata: {\"type\":\"ping\"}\n\n` frame instead of a comment. OpenAI / Codex / Gemini routes keep the SSE comment default — their clients have no `ping` event in spec and comments are sufficient.

## Test plan

- [x] `uv run pytest -q` — 738 passed (4 new in `tests/test_anthropic_stream_keepalive.py` + 734 existing).
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] Regression guard verifies OpenAI route keepalive still emits SSE comments.
- [ ] Manual verification post-deploy: `claude -p "<long prompt>" --model claude-opus-4.7-1m` against kevin-ss; expect stream to stay open through first content token (15-25 s window) instead of dropping at 15 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)