### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.1"
+version = "0.3.2"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Bump to **0.3.2** to ship the Anthropic SSE ping-keepalive fix from #61.
- The ping-frame change resets Claude Code's 15 s "time since last protocol event" timer, fixing stream cancellations seen on slow upstreams (notably `claude-opus-4.7-1m`).

## Test plan

- [x] `pyproject.toml`, `src/router_maestro/__init__.py`, and `uv.lock` updated to 0.3.2.
- [x] Tests + lint already verified on the merged #61.
- [ ] Tag `v0.3.2` after merge, rebuild image, deploy to kevin-ss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)