### PR TITLE
fix(streaming): preserve upstream error body for 4xx responses (v0.3.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.2"
+version = "0.3.3"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -285,6 +285,13 @@ class BaseProvider(ABC):
         if include_body:
             try:
                 error_body = error.response.text
+            except httpx.ResponseNotRead:
+                # Streamed responses must be read before .text is available.
+                # Callers should `await response.aread()` first; if they
+                # didn't, surface that explicitly so the log isn't blank.
+                error_body = (
+                    "<response body not read; pre-read with aread() in the streaming handler>"
+                )
             except Exception:
                 error_body = ""
             logger.error(

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -1,5 +1,6 @@
 """GitHub Copilot provider implementation."""
 
+import contextlib
 import json
 import time
 from collections.abc import AsyncIterator
@@ -612,6 +613,15 @@ class CopilotProvider(BaseProvider):
                 json=payload,
                 headers=self._get_headers(vision_request=has_images),
             ) as response:
+                # Streamed responses defer body reads; if the upstream returns
+                # an error status, pull the body *inside* the stream context
+                # so the connection is still open. Reading after the
+                # `async with` exits raises StreamClosed and the helper would
+                # log "Copilot stream API error: 4xx -" with no upstream
+                # detail (the original symptom this fix addresses).
+                if response.status_code >= 400:
+                    with contextlib.suppress(Exception):
+                        await response.aread()
                 response.raise_for_status()
 
                 stream_finished = False

--- a/src/router_maestro/providers/openai_base.py
+++ b/src/router_maestro/providers/openai_base.py
@@ -1,5 +1,6 @@
 """Shared OpenAI-compatible chat provider logic."""
 
+import contextlib
 import json
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
@@ -128,6 +129,15 @@ class OpenAIChatProvider(BaseProvider, ABC):
                     headers=self._get_headers(),
                     timeout=TIMEOUT_STREAMING,
                 ) as response:
+                    # Streamed responses defer body reads; if the upstream
+                    # returns an error status, pull the body *inside* the
+                    # stream context so the connection is still open. After
+                    # the `async with` exits the response is closed and
+                    # `aread()` would raise StreamClosed, leaving the log as
+                    # "API error: 4xx -" with no upstream detail.
+                    if response.status_code >= 400:
+                        with contextlib.suppress(Exception):
+                            await response.aread()
                     response.raise_for_status()
 
                     async for line in response.aiter_lines():
@@ -155,7 +165,9 @@ class OpenAIChatProvider(BaseProvider, ABC):
                                     tool_calls=tool_calls,
                                 )
             except httpx.HTTPStatusError as e:
-                self._raise_http_status_error(label, e, self._logger, stream=True)
+                self._raise_http_status_error(
+                    label, e, self._logger, stream=True, include_body=True
+                )
             except httpx.TimeoutException as e:
                 self._raise_timeout_error(label, e, self._logger, stream=True)
             except httpx.HTTPError as e:

--- a/tests/test_streaming_error_body.py
+++ b/tests/test_streaming_error_body.py
@@ -1,0 +1,96 @@
+"""Regression tests for streaming-error body logging.
+
+Background
+----------
+When `client.stream()` raises an `HTTPStatusError` via `raise_for_status()`,
+the response body has *not* been read yet — `response.text` raises
+`httpx.ResponseNotRead`. Earlier versions of `_raise_http_status_error`
+caught that as a generic `Exception` and silently set the body to "",
+producing useless logs like `Copilot stream API error: 400 -`.
+
+This module pins down two guarantees:
+
+1. The shared helper now emits an explicit "<response body not read; ...>"
+   sentinel (instead of an empty string) when a streamed response is passed
+   in without first calling `aread()`.
+2. After the caller pre-reads the body via `await response.aread()`, the
+   helper includes the actual upstream payload in both the log and the
+   `ProviderError` message.
+"""
+
+import httpx
+import pytest
+
+from router_maestro.providers.base import BaseProvider, ProviderError
+from router_maestro.utils import get_logger
+
+
+def _streamed_status_error(body: bytes, status: int = 400) -> httpx.HTTPStatusError:
+    """Build a real `HTTPStatusError` whose response body is not yet read."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=status, content=body)
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        with client.stream("POST", "https://example.invalid/chat") as response:
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                # Important: do NOT read the body here — that's the whole
+                # point of the regression. We want the exception to carry a
+                # response that hasn't been consumed yet.
+                return exc
+    raise AssertionError("raise_for_status should have raised")
+
+
+def test_helper_uses_sentinel_when_streamed_body_not_read(monkeypatch):
+    """Without a pre-read, the helper must surface the unread-body sentinel
+    rather than silently emit an empty body string."""
+    err = _streamed_status_error(b'{"error":{"message":"missing image media_type"}}')
+
+    # MockTransport buffers the body, so we have to simulate the
+    # "streamed but not read yet" state by forcing `.text` to raise
+    # `ResponseNotRead` the way real httpx does on an unread stream.
+    def _raise_not_read(self):
+        raise httpx.ResponseNotRead()
+
+    monkeypatch.setattr(httpx.Response, "text", property(_raise_not_read))
+
+    with pytest.raises(ProviderError) as excinfo:
+        BaseProvider._raise_http_status_error(
+            "Copilot",
+            err,
+            get_logger("test"),
+            stream=True,
+            include_body=True,
+        )
+
+    msg = str(excinfo.value)
+    assert "400" in msg
+    assert "response body not read" in msg
+
+
+def test_helper_includes_body_after_caller_reads_it():
+    """After the caller pre-reads the streamed response body, the upstream
+    payload must show up verbatim in the raised `ProviderError`."""
+    payload = b'{"error":{"message":"image media_type unsupported"}}'
+    err = _streamed_status_error(payload)
+
+    # Simulate what the streaming handler now does before invoking the
+    # helper: pull the body in synchronously via .read() (the async path
+    # uses `await response.aread()`).
+    err.response.read()
+
+    with pytest.raises(ProviderError) as excinfo:
+        BaseProvider._raise_http_status_error(
+            "Copilot",
+            err,
+            get_logger("test"),
+            stream=True,
+            include_body=True,
+        )
+
+    msg = str(excinfo.value)
+    assert "image media_type unsupported" in msg
+    assert excinfo.value.status_code == 400

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Fix a long-standing logging bug where Copilot / OpenAI-compatible **streaming** 4xx errors were surfaced as `Copilot stream API error: 400 -` with no upstream detail.
- Pull the response body **inside** the `async with client.stream(...)` block so it's still readable; reading after the context exits raises `StreamClosed`.
- Now both the server log and the SSE `error` event include the actual upstream payload (e.g. `{"error":{"message":"Could not process image"}}`).
- Defense-in-depth in `_raise_http_status_error`: distinguish `httpx.ResponseNotRead` from other failures and emit an explicit sentinel so future call sites that forget to pre-read aren't masked.
- Bump version `0.3.2 → 0.3.3`.

## Why

Reproduced while sweeping `github-copilot/claude-haiku-4.5` over streaming Anthropic + OpenAI APIs:

- Empty user content → upstream rejects, but client sees only `400 -`.
- Malformed image bytes → same blank error.

After the fix:
```
Copilot API error: 400 - {"error":{"message":"messages: at least one message is required","code":"invalid_request_body"}}
Copilot API error: 400 - {"error":{"message":"Could not process image","code":"invalid_request_body"}}
```

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pytest tests/ -q` — **740 passed** (incl. 2 new regression tests in `tests/test_streaming_error_body.py`)
- [x] Live verification against local server with `claude-haiku-4.5`:
  - empty content → SSE error includes `messages: at least one message is required`
  - bad image bytes → SSE error includes `Could not process image`
  - normal request → unchanged, `message_start … message_stop` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)