### PR TITLE
fix: codex config + gpt-5.5 streaming (apply_patch, CAPI reasoning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.4 (2026-05-13)
+
+### Fixes
+
+- **`router-maestro config codex` no longer writes invalid project-level keys.** Selecting project-level scope used to dump `model_provider` and `[model_providers.router-maestro]` into `./.codex/config.toml`, which Codex CLI 0.130+ rejects with `Ignored unsupported project-local config keys`. Project-level configs now contain only the `model = "..."` override (and inherit the provider definition from `~/.codex/config.toml`); re-running the command also self-heals existing project files written by older releases, while leaving any user-added providers untouched.
+
+- **gpt-5.5 via Codex no longer stops mid-task before writing files.** Three gaps were causing the Responses-API stream to silently drop most of the model's output when used through Codex's `apply_patch` flow:
+  1. **Custom tools were unhandled.** Codex registers `apply_patch` as a `type: "custom"` tool. gpt-5.5 streamed the patch body via `response.custom_tool_call_input.delta` (hundreds of events per call), and the Copilot provider had no branch for them — every byte of the patch was discarded, so Codex saw zero tool calls and aborted. The provider now recognizes `custom_tool_call` items, accumulates the input deltas, and the route forwards them as `custom_tool_call` events with raw `input` (not JSON `arguments`) so Codex parses them correctly.
+  2. **Reasoning summaries from CAPI models were dropped.** Copilot CAPI delivers `gpt-5.x` chain-of-thought inside `output_item.done.item.summary[]` rather than as `reasoning_summary_text.delta` events. The provider now reads the summary array on `output_item.done` and forwards it as thinking chunks, with a `received_delta_summary` guard so BYOK models that stream both don't get duplicated.
+  3. **`reasoning.encrypted_content` was not requested.** The Responses payload now sets `include: ["reasoning.encrypted_content"]`, matching the upstream vscode-copilot-chat reference client, so reasoning state can round-trip across turns.
+
+  The provider also logs a one-line `unhandled event types` warning when the upstream stream contains events the bridge doesn't recognize, so future stream-shape changes are easier to spot.
+
+---
+
 ## v0.3.3 (2026-05-08)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.3"
+version = "0.3.4"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -85,6 +85,28 @@ def get_gemini_cli_paths() -> dict[str, Path]:
     }
 
 
+def _build_router_maestro_provider_table(openai_url: str) -> tomlkit.items.Table:
+    """Build the `[model_providers.router-maestro]` TOML table for Codex user config."""
+    table = tomlkit.table()
+    table["name"] = "Router Maestro"
+    table["base_url"] = openai_url
+    table["env_key"] = "ROUTER_MAESTRO_API_KEY"
+    table["wire_api"] = "responses"
+    return table
+
+
+def _user_codex_has_router_maestro_provider(user_config_path: Path) -> bool:
+    """Return True iff the user-level Codex config sets `model_provider = "router-maestro"`."""
+    if not user_config_path.exists():
+        return False
+    try:
+        with open(user_config_path, "rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError):
+        return False
+    return data.get("model_provider") == "router-maestro"
+
+
 def _backup_if_exists(path: Path) -> None:
     """Prompt to backup an existing config file before overwriting."""
     if not path.exists():
@@ -336,33 +358,56 @@ def codex_config() -> None:
 
     # Update configuration
     existing_config["model"] = selected_model
-    existing_config["model_provider"] = "router-maestro"
 
-    # Create or update model_providers section
-    if "model_providers" not in existing_config:
-        existing_config["model_providers"] = tomlkit.table()
-
-    provider_config = tomlkit.table()
-    provider_config["name"] = "Router Maestro"
-    provider_config["base_url"] = openai_url
-    provider_config["env_key"] = "ROUTER_MAESTRO_API_KEY"
-    provider_config["wire_api"] = "responses"
-    existing_config["model_providers"]["router-maestro"] = provider_config
+    if level == "user":
+        existing_config["model_provider"] = "router-maestro"
+        if "model_providers" not in existing_config:
+            existing_config["model_providers"] = tomlkit.table()
+        existing_config["model_providers"]["router-maestro"] = _build_router_maestro_provider_table(
+            openai_url
+        )
+    else:
+        # Codex CLI 0.130+ rejects model_provider/model_providers at project scope.
+        # Strip the keys this command wrote in older releases so the file stops
+        # tripping the "Ignored unsupported project-local config keys" warning.
+        existing_config.pop("model_provider", None)
+        providers = existing_config.get("model_providers")
+        if providers is not None:
+            providers.pop("router-maestro", None)
+            if len(providers) == 0:
+                existing_config.pop("model_providers", None)
 
     # Write config
     config_path.parent.mkdir(parents=True, exist_ok=True)
     with open(config_path, "w", encoding="utf-8") as f:
         f.write(tomlkit.dumps(existing_config))
 
-    console.print(
-        Panel(
+    if level == "user":
+        body = (
             f"[green]Created {config_path}[/green]\n\n"
             f"Model: {selected_model}\n\n"
             f"Endpoint: {openai_url}\n\n"
             "[dim]Start router-maestro server before using Codex:[/dim]\n"
             "  router-maestro server start\n\n"
             "[dim]Set API key environment variable (optional):[/dim]\n"
-            "  export ROUTER_MAESTRO_API_KEY=your-key",
+            "  export ROUTER_MAESTRO_API_KEY=your-key"
+        )
+    else:
+        if _user_codex_has_router_maestro_provider(paths["user"]):
+            inheritance_line = f"[dim]Inheriting provider from {paths['user']}.[/dim]"
+        else:
+            inheritance_line = (
+                "[yellow]User-level Router-Maestro config not found.[/yellow]\n"
+                "Run [bold]router-maestro config codex[/bold] and pick option 1 first,\n"
+                "otherwise Codex won't know how to reach the server."
+            )
+        body = (
+            f"[green]Created {config_path}[/green]\n\nModel: {selected_model}\n\n{inheritance_line}"
+        )
+
+    console.print(
+        Panel(
+            body,
             title="Success",
             border_style="green",
         )

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -148,6 +148,10 @@ class ResponsesToolCall:
     call_id: str
     name: str
     arguments: str
+    # ``True`` for custom (free-form text) tools like Codex's ``apply_patch``.
+    # The route forwards these as ``custom_tool_call`` items with raw ``input``
+    # rather than function_call items with JSON ``arguments``.
+    is_custom: bool = False
 
 
 @dataclass

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -849,6 +849,11 @@ class CopilotProvider(BaseProvider):
             # ``summary: auto`` opts in to reasoning_summary_text events so we
             # can forward chain-of-thought as Anthropic thinking blocks.
             payload["reasoning"] = {"effort": upstream_effort, "summary": "auto"}
+            # Copilot CAPI doesn't stream reasoning_summary_text deltas for some
+            # models; the summary instead arrives in output_item.done.item.summary[].
+            # Asking for encrypted_content also lets us round-trip reasoning state
+            # across turns (matches vscode-copilot-chat reference client).
+            payload["include"] = ["reasoning.encrypted_content"]
         return payload
 
     def _extract_response_content(self, data: dict) -> str:
@@ -1011,9 +1016,17 @@ class CopilotProvider(BaseProvider):
                 stream_finished = False
                 final_usage = None
                 emitted_tool_call = False
+                # Set when reasoning_summary_text.delta arrives (BYOK behaviour);
+                # used to skip the duplicate summary that output_item.done would
+                # otherwise re-emit.
+                received_reasoning_summary = False
                 # Track pending function calls being streamed, keyed by output_index
                 # (Copilot obfuscates item IDs differently across events, so we can't match by ID)
                 pending_fcs: dict[int, dict] = {}
+                # Diagnostic: count any event types we don't explicitly handle
+                # so we can spot custom_tool_call_input.* or other channels we
+                # might be dropping.
+                unknown_event_counts: dict[str, int] = {}
 
                 async for line in response.aiter_lines():
                     if stream_finished:
@@ -1051,6 +1064,7 @@ class CopilotProvider(BaseProvider):
                     elif event_type == "response.reasoning_summary_text.delta":
                         delta = data.get("delta", "")
                         if delta:
+                            received_reasoning_summary = True
                             yield ResponsesStreamChunk(content="", thinking=delta)
 
                     elif event_type == "response.reasoning_summary_text.done":
@@ -1067,10 +1081,30 @@ class CopilotProvider(BaseProvider):
                                 "call_id": item.get("call_id", ""),
                                 "name": item.get("name", ""),
                                 "arguments": "",
+                                "is_custom": False,
+                            }
+                        elif item.get("type") == "custom_tool_call":
+                            # Custom tools (e.g. Codex's apply_patch) stream
+                            # raw text via custom_tool_call_input.delta. Same
+                            # bookkeeping as function_call but flagged so the
+                            # route emits the right event shape downstream.
+                            output_idx = data.get("output_index", 0)
+                            pending_fcs[output_idx] = {
+                                "call_id": item.get("call_id", ""),
+                                "name": item.get("name", ""),
+                                "arguments": "",
+                                "is_custom": True,
                             }
 
                     # Handle function call arguments delta - accumulate silently
                     elif event_type == "response.function_call_arguments.delta":
+                        delta = data.get("delta", "")
+                        output_idx = data.get("output_index", 0)
+                        fc = pending_fcs.get(output_idx)
+                        if fc and delta:
+                            fc["arguments"] += delta
+
+                    elif event_type == "response.custom_tool_call_input.delta":
                         delta = data.get("delta", "")
                         output_idx = data.get("output_index", 0)
                         fc = pending_fcs.get(output_idx)
@@ -1091,6 +1125,24 @@ class CopilotProvider(BaseProvider):
                                     call_id=fc["call_id"],
                                     name=fc["name"],
                                     arguments=fc["arguments"],
+                                    is_custom=fc.get("is_custom", False),
+                                ),
+                            )
+
+                    elif event_type == "response.custom_tool_call_input.done":
+                        output_idx = data.get("output_index", 0)
+                        fc = pending_fcs.pop(output_idx, None)
+                        if fc:
+                            # Custom tool deltas use ``input`` not ``arguments``.
+                            fc["arguments"] = data.get("input", fc["arguments"])
+                            emitted_tool_call = True
+                            yield ResponsesStreamChunk(
+                                content="",
+                                tool_call=ResponsesToolCall(
+                                    call_id=fc["call_id"],
+                                    name=fc["name"],
+                                    arguments=fc["arguments"],
+                                    is_custom=True,
                                 ),
                             )
 
@@ -1111,6 +1163,53 @@ class CopilotProvider(BaseProvider):
                                         arguments=item.get("arguments", "{}"),
                                     ),
                                 )
+                        elif item.get("type") == "custom_tool_call":
+                            # Fallback: if custom_tool_call_input.done didn't
+                            # fire (or pending_fcs was already drained), emit
+                            # from the final item payload.
+                            output_idx = data.get("output_index", 0)
+                            fc = pending_fcs.pop(output_idx, None)
+                            if fc is not None:
+                                emitted_tool_call = True
+                                yield ResponsesStreamChunk(
+                                    content="",
+                                    tool_call=ResponsesToolCall(
+                                        call_id=item.get("call_id", ""),
+                                        name=item.get("name", ""),
+                                        arguments=item.get("input", ""),
+                                        is_custom=True,
+                                    ),
+                                )
+                        elif item.get("type") == "reasoning":
+                            # Copilot CAPI delivers the reasoning summary here
+                            # rather than via reasoning_summary_text.delta.
+                            # Forward each summary segment as a thinking chunk
+                            # only if we didn't already get them as deltas
+                            # (BYOK models stream both — don't duplicate).
+                            summary_list = item.get("summary", []) or []
+                            logger.info(
+                                "Copilot /responses reasoning item: "
+                                "received_delta_summary=%s summary_segments=%d "
+                                "encrypted=%s id=%s",
+                                received_reasoning_summary,
+                                len(summary_list),
+                                bool(item.get("encrypted_content")),
+                                item.get("id"),
+                            )
+                            if not received_reasoning_summary:
+                                for summary in summary_list:
+                                    if isinstance(summary, dict):
+                                        text = summary.get("text") or ""
+                                        if text:
+                                            yield ResponsesStreamChunk(content="", thinking=text)
+                            sig = item.get("encrypted_content") or item.get("id")
+                            if sig:
+                                yield ResponsesStreamChunk(content="", thinking_signature=sig)
+                        else:
+                            unknown_event_counts[f"output_item.done:{item.get('type')}"] = (
+                                unknown_event_counts.get(f"output_item.done:{item.get('type')}", 0)
+                                + 1
+                            )
 
                     # Handle done event to get final usage
                     elif event_type == "response.done":
@@ -1129,11 +1228,32 @@ class CopilotProvider(BaseProvider):
                                 status_code=502,
                             )
                         incomplete = resp.get("incomplete_details") or {}
-                        finish = (
-                            map_responses_status_to_chat(status, incomplete.get("reason")) or "stop"
-                        )
+                        incomplete_reason = incomplete.get("reason")
+                        finish = map_responses_status_to_chat(status, incomplete_reason) or "stop"
                         if emitted_tool_call and finish == "stop":
                             finish = "tool_calls"
+                        if status == "incomplete":
+                            logger.warning(
+                                "Copilot /responses stream incomplete: model=%s status=%s "
+                                "incomplete_reason=%s mapped_finish=%s emitted_tool_call=%s "
+                                "usage=%s",
+                                request.model,
+                                status,
+                                incomplete_reason,
+                                finish,
+                                emitted_tool_call,
+                                final_usage,
+                            )
+                        else:
+                            logger.info(
+                                "Copilot /responses stream done: model=%s status=%s "
+                                "mapped_finish=%s emitted_tool_call=%s usage=%s",
+                                request.model,
+                                status,
+                                finish,
+                                emitted_tool_call,
+                                final_usage,
+                            )
                         yield ResponsesStreamChunk(
                             content="",
                             finish_reason=finish,
@@ -1160,17 +1280,45 @@ class CopilotProvider(BaseProvider):
                                 status_code=502,
                             )
                         incomplete = resp.get("incomplete_details") or {}
-                        finish = (
-                            map_responses_status_to_chat(status, incomplete.get("reason")) or "stop"
-                        )
+                        incomplete_reason = incomplete.get("reason")
+                        finish = map_responses_status_to_chat(status, incomplete_reason) or "stop"
                         if emitted_tool_call and finish == "stop":
                             finish = "tool_calls"
+                        if status == "incomplete":
+                            logger.warning(
+                                "Copilot /responses stream incomplete (via .completed): "
+                                "model=%s status=%s incomplete_reason=%s mapped_finish=%s "
+                                "emitted_tool_call=%s usage=%s",
+                                request.model,
+                                status,
+                                incomplete_reason,
+                                finish,
+                                emitted_tool_call,
+                                final_usage,
+                            )
+                        else:
+                            logger.info(
+                                "Copilot /responses stream completed: model=%s status=%s "
+                                "mapped_finish=%s emitted_tool_call=%s usage=%s",
+                                request.model,
+                                status,
+                                finish,
+                                emitted_tool_call,
+                                final_usage,
+                            )
                         yield ResponsesStreamChunk(
                             content="",
                             finish_reason=finish,
                             usage=final_usage,
                         )
                         stream_finished = True
+
+                    # Catch-all: count any other event types so we can spot
+                    # things we silently drop (e.g. custom_tool_call_input.*).
+                    else:
+                        unknown_event_counts[event_type] = (
+                            unknown_event_counts.get(event_type, 0) + 1
+                        )
 
                 # If stream ended without explicit completion event, emit final chunk
                 if not stream_finished:
@@ -1179,6 +1327,13 @@ class CopilotProvider(BaseProvider):
                         content="",
                         finish_reason="tool_calls" if emitted_tool_call else "stop",
                         usage=final_usage,
+                    )
+
+                if unknown_event_counts:
+                    logger.warning(
+                        "Copilot /responses unhandled event types: model=%s counts=%s",
+                        request.model,
+                        unknown_event_counts,
                     )
 
         except httpx.TimeoutException as e:

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -174,12 +174,18 @@ def make_usage(raw_usage: dict[str, Any] | None) -> dict[str, Any] | None:
 
     input_tokens = raw_usage.get("input_tokens", 0)
     output_tokens = raw_usage.get("output_tokens", 0)
+    upstream_input_details = raw_usage.get("input_tokens_details") or {}
+    upstream_output_details = raw_usage.get("output_tokens_details") or {}
 
     return {
         "input_tokens": input_tokens,
-        "input_tokens_details": {"cached_tokens": 0},
+        "input_tokens_details": {
+            "cached_tokens": upstream_input_details.get("cached_tokens", 0),
+        },
         "output_tokens": output_tokens,
-        "output_tokens_details": {"reasoning_tokens": 0},
+        "output_tokens_details": {
+            "reasoning_tokens": upstream_output_details.get("reasoning_tokens", 0),
+        },
         "total_tokens": input_tokens + output_tokens,
     }
 
@@ -302,6 +308,16 @@ class _StreamMessageState:
     current_message_id: str | None = None
     accumulated_content: str = ""
     message_started: bool = False
+    # Reasoning summary state. ``current_reasoning_id`` is the local
+    # ``rs-…`` id we assign; ``upstream_reasoning_id`` is whatever Copilot
+    # sent on ``response.reasoning_summary_text.done`` (we forward it as the
+    # ``encrypted_content`` field so Codex can correlate).
+    current_reasoning_id: str | None = None
+    upstream_reasoning_id: str | None = None
+    accumulated_reasoning: str = ""
+    reasoning_started: bool = False
+    summary_index: int = 0
+    reasoning_item_count: int = 0
 
     def close_open_message(self, advance_index: bool = True) -> list[str]:
         """Close the currently open message.
@@ -323,6 +339,64 @@ class _StreamMessageState:
             self.output_index += 1
         self.message_started = False
         self.current_message_id = None
+        return events
+
+    def close_open_reasoning(self, advance_index: bool = True) -> list[str]:
+        """Close any open reasoning summary block + reasoning item.
+
+        Emits the OpenAI Responses-API event sequence:
+          response.reasoning_summary_text.done
+          response.reasoning_summary_part.done
+          response.output_item.done (item.type == "reasoning")
+        """
+        if not self.reasoning_started or not self.current_reasoning_id:
+            return []
+        rs_id = self.current_reasoning_id
+        text = self.accumulated_reasoning
+        summary_part = {"type": "summary_text", "text": text}
+        reasoning_item = {
+            "type": "reasoning",
+            "id": rs_id,
+            "summary": [summary_part],
+        }
+        if self.upstream_reasoning_id:
+            reasoning_item["encrypted_content"] = self.upstream_reasoning_id
+        events = [
+            sse_event(
+                {
+                    "type": "response.reasoning_summary_text.done",
+                    "item_id": rs_id,
+                    "output_index": self.output_index,
+                    "summary_index": self.summary_index,
+                    "text": text,
+                }
+            ),
+            sse_event(
+                {
+                    "type": "response.reasoning_summary_part.done",
+                    "item_id": rs_id,
+                    "output_index": self.output_index,
+                    "summary_index": self.summary_index,
+                    "part": summary_part,
+                }
+            ),
+            sse_event(
+                {
+                    "type": "response.output_item.done",
+                    "output_index": self.output_index,
+                    "item": reasoning_item,
+                }
+            ),
+        ]
+        self.output_items.append(reasoning_item)
+        self.reasoning_item_count += 1
+        if advance_index:
+            self.output_index += 1
+        self.reasoning_started = False
+        self.current_reasoning_id = None
+        self.upstream_reasoning_id = None
+        self.accumulated_reasoning = ""
+        self.summary_index = 0
         return events
 
 
@@ -384,8 +458,64 @@ async def stream_response(
         )
 
         async for chunk in stream:
+            # Handle reasoning summary text deltas. gpt-5.x and other thinking
+            # models stream chain-of-thought via these events; if we don't
+            # forward them, Codex sees only the final user-visible message and
+            # the model appears to "stop without doing anything" because all
+            # of its planning tokens vanished. We open a separate
+            # ``reasoning`` output item so messages and tool_calls keep their
+            # own item indices.
+            if chunk.thinking:
+                if state.message_started:
+                    for evt in state.close_open_message():
+                        yield evt
+                if not state.reasoning_started:
+                    state.current_reasoning_id = generate_id("rs")
+                    state.reasoning_started = True
+                    state.summary_index = 0
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": state.output_index,
+                            "item": {
+                                "type": "reasoning",
+                                "id": state.current_reasoning_id,
+                                "summary": [],
+                            },
+                        }
+                    )
+                    yield sse_event(
+                        {
+                            "type": "response.reasoning_summary_part.added",
+                            "item_id": state.current_reasoning_id,
+                            "output_index": state.output_index,
+                            "summary_index": state.summary_index,
+                            "part": {"type": "summary_text", "text": ""},
+                        }
+                    )
+                state.accumulated_reasoning += chunk.thinking
+                yield sse_event(
+                    {
+                        "type": "response.reasoning_summary_text.delta",
+                        "item_id": state.current_reasoning_id,
+                        "output_index": state.output_index,
+                        "summary_index": state.summary_index,
+                        "delta": chunk.thinking,
+                    }
+                )
+
+            if chunk.thinking_signature:
+                state.upstream_reasoning_id = chunk.thinking_signature
+                for evt in state.close_open_reasoning():
+                    yield evt
+
             # Handle text content
             if chunk.content:
+                # Close any open reasoning before switching to a message item
+                # so the output indices stay monotonic and Codex can replay
+                # the items in order.
+                for evt in state.close_open_reasoning():
+                    yield evt
                 if not state.message_started:
                     state.current_message_id = generate_id("msg")
                     state.message_started = True
@@ -430,50 +560,102 @@ async def stream_response(
             # Handle complete tool call
             if chunk.tool_call:
                 tc = chunk.tool_call
+                for evt in state.close_open_reasoning():
+                    yield evt
                 for evt in state.close_open_message():
                     yield evt
 
-                fc_id = generate_id("fc")
-                fc_item = make_function_call_item(fc_id, tc.call_id, tc.name, tc.arguments)
-
-                yield sse_event(
-                    {
-                        "type": "response.output_item.added",
-                        "output_index": state.output_index,
-                        "item": make_function_call_item(
-                            fc_id, tc.call_id, tc.name, "", "in_progress"
-                        ),
+                if tc.is_custom:
+                    # Custom tool call (e.g. apply_patch) — free-form text input,
+                    # not JSON arguments. Round-trip as custom_tool_call so codex
+                    # parses ``input`` as raw text.
+                    ctc_id = generate_id("ctc")
+                    ctc_item = {
+                        "type": "custom_tool_call",
+                        "id": ctc_id,
+                        "call_id": tc.call_id,
+                        "name": tc.name,
+                        "input": tc.arguments,
+                        "status": "completed",
                     }
-                )
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": state.output_index,
+                            "item": {
+                                **ctc_item,
+                                "input": "",
+                                "status": "in_progress",
+                            },
+                        }
+                    )
+                    yield sse_event(
+                        {
+                            "type": "response.custom_tool_call_input.delta",
+                            "item_id": ctc_id,
+                            "output_index": state.output_index,
+                            "delta": tc.arguments,
+                        }
+                    )
+                    yield sse_event(
+                        {
+                            "type": "response.custom_tool_call_input.done",
+                            "item_id": ctc_id,
+                            "output_index": state.output_index,
+                            "input": tc.arguments,
+                        }
+                    )
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": state.output_index,
+                            "item": ctc_item,
+                        }
+                    )
+                    state.output_items.append(ctc_item)
+                    state.output_index += 1
+                else:
+                    fc_id = generate_id("fc")
+                    fc_item = make_function_call_item(fc_id, tc.call_id, tc.name, tc.arguments)
 
-                yield sse_event(
-                    {
-                        "type": "response.function_call_arguments.delta",
-                        "item_id": fc_id,
-                        "output_index": state.output_index,
-                        "delta": tc.arguments,
-                    }
-                )
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": state.output_index,
+                            "item": make_function_call_item(
+                                fc_id, tc.call_id, tc.name, "", "in_progress"
+                            ),
+                        }
+                    )
 
-                yield sse_event(
-                    {
-                        "type": "response.function_call_arguments.done",
-                        "item_id": fc_id,
-                        "output_index": state.output_index,
-                        "arguments": tc.arguments,
-                    }
-                )
+                    yield sse_event(
+                        {
+                            "type": "response.function_call_arguments.delta",
+                            "item_id": fc_id,
+                            "output_index": state.output_index,
+                            "delta": tc.arguments,
+                        }
+                    )
 
-                yield sse_event(
-                    {
-                        "type": "response.output_item.done",
-                        "output_index": state.output_index,
-                        "item": fc_item,
-                    }
-                )
+                    yield sse_event(
+                        {
+                            "type": "response.function_call_arguments.done",
+                            "item_id": fc_id,
+                            "output_index": state.output_index,
+                            "arguments": tc.arguments,
+                        }
+                    )
 
-                state.output_items.append(fc_item)
-                state.output_index += 1
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": state.output_index,
+                            "item": fc_item,
+                        }
+                    )
+
+                    state.output_items.append(fc_item)
+                    state.output_index += 1
 
             if chunk.usage:
                 final_usage = chunk.usage
@@ -481,6 +663,8 @@ async def stream_response(
             if chunk.finish_reason:
                 stream_completed = True
 
+                for evt in state.close_open_reasoning():
+                    yield evt
                 for evt in state.close_open_message(advance_index=False):
                     yield evt
 
@@ -497,8 +681,18 @@ async def stream_response(
                 )
 
         if not stream_completed:
-            logger.warning("Stream ended without finish_reason, sending completion events")
+            logger.warning(
+                "Stream ended without finish_reason: req_id=%s model=%s output_items=%d "
+                "accumulated_text_len=%d message_started=%s — emitting fallback completion",
+                request_id,
+                request.model,
+                len(state.output_items),
+                len(state.accumulated_content),
+                state.message_started,
+            )
 
+            for evt in state.close_open_reasoning():
+                yield evt
             for evt in state.close_open_message(advance_index=False):
                 yield evt
 
@@ -515,11 +709,31 @@ async def stream_response(
             )
 
         elapsed_ms = (time.time() - start_time) * 1000
+        function_call_count = sum(
+            1 for item in state.output_items if item.get("type") == "function_call"
+        )
+        message_count = sum(1 for item in state.output_items if item.get("type") == "message")
+        reasoning_count = sum(1 for item in state.output_items if item.get("type") == "reasoning")
         logger.info(
-            "Stream completed: req_id=%s, elapsed=%.1fms, output_items=%d",
+            "Stream completed: req_id=%s model=%s elapsed=%.1fms output_items=%d "
+            "(messages=%d, function_calls=%d, reasoning=%d) text_len=%d "
+            "reasoning_text_len=%d stream_completed=%s usage=%s",
             request_id,
+            request.model,
             elapsed_ms,
             len(state.output_items),
+            message_count,
+            function_call_count,
+            reasoning_count,
+            len(state.accumulated_content),
+            sum(
+                len(part.get("text", ""))
+                for item in state.output_items
+                if item.get("type") == "reasoning"
+                for part in item.get("summary", [])
+            ),
+            stream_completed,
+            final_usage,
         )
 
         # NOTE: Do NOT send "data: [DONE]\n\n" - agent-maestro doesn't send it

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,12 @@
 """Tests for configuration module."""
 
 import tempfile
+import tomllib
 from pathlib import Path
 
+import tomlkit
+
+from router_maestro.cli import config as cli_config
 from router_maestro.cli.config import (
     _OPUS_1M_NATIVE_KEY,
     _OPUS_1M_SOURCE_MODEL,
@@ -196,3 +200,141 @@ class TestMaybeInjectOpus1M:
         """Guard against accidental changes to the source model constant."""
         assert _OPUS_1M_SOURCE_MODEL == "github-copilot/claude-opus-4.6-1m"
         assert _OPUS_1M_NATIVE_KEY == "claude-opus-4-6[1m]"
+
+
+class _StubAdminClient:
+    endpoint = "http://localhost:8080"
+
+
+def _setup_codex_env(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    level_choice: str,
+    model_choice: str = "1",
+    backup_yes: bool = False,
+):
+    """Patch the world for an in-process call to ``cli_config.codex_config()``.
+
+    ``level_choice`` is "1" (user) or "2" (project). ``model_choice`` is the
+    1-indexed table choice (or "0" for auto-routing). ``backup_yes`` controls
+    the response to the backup prompt that fires when the target file exists.
+    """
+    home = tmp_path / "home"
+    cwd = tmp_path / "project"
+    home.mkdir()
+    cwd.mkdir()
+    monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: cwd))
+
+    fake_models = [
+        {"provider": "github-copilot", "id": "gpt-5.5", "name": "GPT-5.5"},
+        {"provider": "github-copilot", "id": "claude-opus-4.6", "name": "Claude Opus 4.6"},
+    ]
+    monkeypatch.setattr(cli_config, "_fetch_and_display_models", lambda: list(fake_models))
+    monkeypatch.setattr(cli_config, "get_admin_client", lambda: _StubAdminClient())
+
+    answers = iter([level_choice, model_choice])
+    monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
+    monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: backup_yes)
+
+    return home, cwd
+
+
+class TestCodexConfig:
+    """Tests for ``router-maestro config codex`` (the ``codex_config`` CLI command)."""
+
+    def test_user_level_writes_full_config(self, tmp_path, monkeypatch):
+        """User-level scope writes ``model``, ``model_provider``, and the provider table."""
+        home, _ = _setup_codex_env(monkeypatch, tmp_path, level_choice="1")
+
+        cli_config.codex_config()
+
+        user_path = home / ".codex" / "config.toml"
+        assert user_path.exists()
+        with open(user_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["model"] == "github-copilot/gpt-5.5"
+        assert data["model_provider"] == "router-maestro"
+        provider = data["model_providers"]["router-maestro"]
+        assert provider == {
+            "name": "Router Maestro",
+            "base_url": "http://localhost:8080/api/openai/v1",
+            "env_key": "ROUTER_MAESTRO_API_KEY",
+            "wire_api": "responses",
+        }
+
+    def test_project_level_writes_only_model(self, tmp_path, monkeypatch):
+        """Project-level scope must NOT write ``model_provider``/``model_providers``."""
+        _, cwd = _setup_codex_env(monkeypatch, tmp_path, level_choice="2")
+
+        cli_config.codex_config()
+
+        project_path = cwd / ".codex" / "config.toml"
+        assert project_path.exists()
+        with open(project_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data == {"model": "github-copilot/gpt-5.5"}
+
+    def test_project_level_self_heals_stale_keys(self, tmp_path, monkeypatch):
+        """Re-running at project level strips the unsupported keys older versions wrote."""
+        _, cwd = _setup_codex_env(
+            monkeypatch, tmp_path, level_choice="2", model_choice="2", backup_yes=False
+        )
+
+        project_path = cwd / ".codex" / "config.toml"
+        project_path.parent.mkdir(parents=True, exist_ok=True)
+        stale = tomlkit.document()
+        stale["model"] = "github-copilot/old-model"
+        stale["model_provider"] = "router-maestro"
+        providers = tomlkit.table()
+        rm_table = tomlkit.table()
+        rm_table["name"] = "Router Maestro"
+        rm_table["base_url"] = "http://stale/v1"
+        rm_table["env_key"] = "ROUTER_MAESTRO_API_KEY"
+        rm_table["wire_api"] = "responses"
+        providers["router-maestro"] = rm_table
+        stale["model_providers"] = providers
+        # Unrelated key the user might have hand-added — must survive untouched.
+        stale["model_context_window"] = 400000
+        with open(project_path, "w", encoding="utf-8") as f:
+            f.write(tomlkit.dumps(stale))
+
+        cli_config.codex_config()
+
+        with open(project_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["model"] == "github-copilot/claude-opus-4.6"
+        assert "model_provider" not in data
+        assert "model_providers" not in data
+        assert data["model_context_window"] == 400000
+
+    def test_project_level_preserves_other_model_providers(self, tmp_path, monkeypatch):
+        """Project-level cleanup removes only ``router-maestro``, not user-added providers."""
+        _, cwd = _setup_codex_env(monkeypatch, tmp_path, level_choice="2", backup_yes=False)
+
+        project_path = cwd / ".codex" / "config.toml"
+        project_path.parent.mkdir(parents=True, exist_ok=True)
+        seed = tomlkit.document()
+        seed["model_provider"] = "router-maestro"  # stale top-level key
+        providers = tomlkit.table()
+        rm_table = tomlkit.table()
+        rm_table["name"] = "Router Maestro"
+        rm_table["base_url"] = "http://stale/v1"
+        providers["router-maestro"] = rm_table
+        other_table = tomlkit.table()
+        other_table["name"] = "User Custom"
+        other_table["base_url"] = "https://other.example.com/v1"
+        providers["other"] = other_table
+        seed["model_providers"] = providers
+        with open(project_path, "w", encoding="utf-8") as f:
+            f.write(tomlkit.dumps(seed))
+
+        cli_config.codex_config()
+
+        with open(project_path, "rb") as f:
+            data = tomllib.load(f)
+        assert data["model"] == "github-copilot/gpt-5.5"
+        assert "model_provider" not in data
+        assert "router-maestro" not in data["model_providers"]
+        assert data["model_providers"]["other"]["name"] == "User Custom"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Two unrelated Codex-side fixes bundled into v0.3.4 since both surfaced from the same debugging session.

### `router-maestro config codex` no longer writes invalid project-level keys
Codex CLI 0.130+ rejects `model_provider`/`model_providers` at project scope. The command now writes only `model = "..."` at project level (provider definition is inherited from `~/.codex/config.toml`), and re-running self-heals project files left over from older releases. Four new `TestCodexConfig` tests cover user/project levels and the self-heal path.

### gpt-5.5 via Codex no longer stops mid-task before writing files
Three gaps in the Responses-API stream handler made the model silently halt right before `apply_patch`:

1. **Custom tools were unhandled.** Codex registers `apply_patch` as `type: "custom"`. gpt-5.5 streams the patch body via `response.custom_tool_call_input.delta` (~700 events per call) — every byte was discarded so Codex saw zero tool calls. The provider now recognizes `custom_tool_call` items, accumulates input deltas, and the route forwards them as `custom_tool_call` events with raw `input`.
2. **CAPI reasoning summaries were dropped.** Copilot CAPI delivers gpt-5.x chain-of-thought in `output_item.done.item.summary[]`, not as `reasoning_summary_text.delta`. Now read from there, with a guard so BYOK models that stream both don't get duplicated.
3. **`reasoning.encrypted_content` was not requested.** Added to the payload `include` field so reasoning state can round-trip across turns (matches vscode-copilot-chat reference).

Also added an `unhandled event types` warning so future stream-shape changes are easier to spot.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — applied
- [x] `uv run pytest tests/ -v` — 744 passed
- [x] Hot-patched the production container and ran `/init` in Codex against gpt-5.5 — `apply_patch` now writes files end-to-end (root cause confirmed via `unhandled event types` log surfacing 694 `custom_tool_call_input.delta` events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)