### PR TITLE
fix(streaming): forward gpt-5.5 tool_search_call as function_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.5 (2026-05-13)
+
+### Fixes
+
+- **gpt-5.5 via Codex no longer stops mid-task during exploration.** v0.3.4 fixed `apply_patch`-driven stalls; this release fixes the next variant — gpt-5.5 stopping after only "Explored" some files (e.g. when the user runs Codex's `/init`). Codex CLI ≥ v0.130 registers a `tool_search` tool (`type: "tool_search"`, `execution: "client"`) so the model can dynamically discover MCP tools; gpt-5.5 invokes it via `output_item.done` items of type `tool_search_call`, which the Copilot provider had no branch for. The event was silently bucketed into `unknown_event_counts`, Codex never received a tool call, the model "explored, said it would search, then ended the turn." The provider now translates `tool_search_call` into a regular `function_call` named `tool_search` (JSON-encoded arguments), which the route emits as standard `response.function_call_arguments.*` + `output_item.done` events — the shape Codex's client-side `tool_search` executor expects.
+
+- **Reasoning items echoed back across turns are explicitly preserved.** `convert_input_to_internal()` now has a dedicated `type: "reasoning"` branch that forwards `id`, `summary`, and (when present) `encrypted_content` upstream — mirroring vscode-copilot-chat's `extractThinkingData` pattern. Previously these items hit a generic fallback that worked for most shapes but didn't normalize the field set, so non-Codex clients echoing slightly different reasoning shapes could leak unknown sibling fields to Copilot. This is preparation for stateful Copilot models: today Copilot CAPI for gpt-5.5 returns empty reasoning items (no encrypted content), but the input-side handler will round-trip cleanly the moment Copilot starts honoring `include: ["reasoning.encrypted_content"]`.
+
+- **`unhandled event types` warning is no longer noisy.** Five upstream events that the route synthesizes its own equivalents from (`response.created`, `response.in_progress`, `response.content_part.added`, `response.content_part.done`, `response.output_text.done`) and one benign `output_item.done:message` are now filtered out of the diagnostic. The warning fires only when an event type genuinely needs attention, making future stream-shape regressions easier to spot.
+
+---
+
 ## v0.3.4 (2026-05-13)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.4"
+version = "0.3.5"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -35,6 +35,21 @@ COPILOT_CHAT_URL = f"{COPILOT_BASE_URL}/chat/completions"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_RESPONSES_URL = f"{COPILOT_BASE_URL}/responses"
 
+# Upstream /responses events we intentionally don't consume because the route
+# (server/routes/responses.py) synthesizes its own equivalents from the deltas
+# we DO consume. Filtering them keeps the ``unknown_event_counts`` warning
+# focused on event types that genuinely need our attention.
+_BENIGN_UPSTREAM_EVENTS = frozenset(
+    {
+        "response.created",
+        "response.in_progress",
+        "response.content_part.added",
+        "response.content_part.done",
+        "response.output_text.done",
+    }
+)
+_BENIGN_DONE_ITEM_TYPES = frozenset({"message"})
+
 
 def _claude_supports_reasoning(bare_lower: str) -> bool:
     """Whether a Claude model on Copilot exposes any reasoning control.
@@ -1095,6 +1110,23 @@ class CopilotProvider(BaseProvider):
                                 "arguments": "",
                                 "is_custom": True,
                             }
+                        elif item.get("type") == "tool_search_call":
+                            # Codex CLI registers a `tool_search` tool
+                            # (execution=client) so the model can dynamically
+                            # discover MCP tools. gpt-5.x calls it via this
+                            # item type; forward as a regular function_call
+                            # named "tool_search" so Codex executes it and
+                            # returns a function_call_output.
+                            # NOTE: arguments arrive whole on output_item.done;
+                            # if Copilot ever streams them via a dedicated
+                            # delta event we'll spot it via unknown_event_counts.
+                            output_idx = data.get("output_index", 0)
+                            pending_fcs[output_idx] = {
+                                "call_id": item.get("call_id", ""),
+                                "name": "tool_search",
+                                "arguments": "",
+                                "is_custom": False,
+                            }
 
                     # Handle function call arguments delta - accumulate silently
                     elif event_type == "response.function_call_arguments.delta":
@@ -1205,11 +1237,36 @@ class CopilotProvider(BaseProvider):
                             sig = item.get("encrypted_content") or item.get("id")
                             if sig:
                                 yield ResponsesStreamChunk(content="", thinking_signature=sig)
-                        else:
-                            unknown_event_counts[f"output_item.done:{item.get('type')}"] = (
-                                unknown_event_counts.get(f"output_item.done:{item.get('type')}", 0)
-                                + 1
+                        elif item.get("type") == "tool_search_call":
+                            # Forward as function_call so Codex's client-side
+                            # tool_search executor receives it. Arguments arrive
+                            # as a dict here; serialize because function_call
+                            # arguments are JSON strings downstream.
+                            output_idx = data.get("output_index", 0)
+                            fc = pending_fcs.pop(output_idx, None)
+                            args = item.get("arguments")
+                            if isinstance(args, str):
+                                args_str = args
+                            elif args is None:
+                                args_str = "{}"
+                            else:
+                                args_str = json.dumps(args)
+                            call_id = item.get("call_id") or (fc and fc.get("call_id")) or ""
+                            emitted_tool_call = True
+                            yield ResponsesStreamChunk(
+                                content="",
+                                tool_call=ResponsesToolCall(
+                                    call_id=call_id,
+                                    name="tool_search",
+                                    arguments=args_str,
+                                    is_custom=False,
+                                ),
                             )
+                        else:
+                            item_type = item.get("type")
+                            if item_type not in _BENIGN_DONE_ITEM_TYPES:
+                                key = f"output_item.done:{item_type}"
+                                unknown_event_counts[key] = unknown_event_counts.get(key, 0) + 1
 
                     # Handle done event to get final usage
                     elif event_type == "response.done":
@@ -1315,10 +1372,14 @@ class CopilotProvider(BaseProvider):
 
                     # Catch-all: count any other event types so we can spot
                     # things we silently drop (e.g. custom_tool_call_input.*).
+                    # ``_BENIGN_UPSTREAM_EVENTS`` are intentionally skipped —
+                    # the route synthesizes equivalents from the deltas we
+                    # already consume.
                     else:
-                        unknown_event_counts[event_type] = (
-                            unknown_event_counts.get(event_type, 0) + 1
-                        )
+                        if event_type not in _BENIGN_UPSTREAM_EVENTS:
+                            unknown_event_counts[event_type] = (
+                                unknown_event_counts.get(event_type, 0) + 1
+                            )
 
                 # If stream ended without explicit completion event, emit final chunk
                 if not stream_finished:

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -117,6 +117,19 @@ def convert_input_to_internal(
                         "output": output,
                     }
                 )
+
+            elif item_type == "reasoning":
+                # Echoed back from a prior turn — preserve the full shape so
+                # Copilot can correlate chain-of-thought across turns. Mirrors
+                # vscode-copilot-chat responsesApi.ts:216-230 (extractThinkingData).
+                reasoning_item: dict[str, Any] = {
+                    "type": "reasoning",
+                    "id": item.get("id"),
+                    "summary": item.get("summary", []) or [],
+                }
+                if item.get("encrypted_content"):
+                    reasoning_item["encrypted_content"] = item["encrypted_content"]
+                items.append(reasoning_item)
             else:
                 items.append(convert_content_to_serializable(item))
 

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -1,0 +1,208 @@
+"""Tests for Copilot /responses streaming event handlers.
+
+These tests exercise the `responses_completion_stream` parser against
+synthetic SSE payloads produced via `httpx.MockTransport`. The goal is to
+pin down handling of event types that have caused regressions in the field
+(custom_tool_call from v0.3.4, tool_search_call from v0.3.5).
+"""
+
+import json
+import logging
+
+import httpx
+import pytest
+
+from router_maestro.providers import CopilotProvider
+from router_maestro.providers.base import ResponsesRequest, ResponsesStreamChunk
+
+
+def _sse_lines(events: list[dict]) -> bytes:
+    """Encode a list of events as SSE `data: …\\n\\n` lines."""
+    parts = []
+    for evt in events:
+        parts.append(f"data: {json.dumps(evt)}\n\n")
+    return "".join(parts).encode("utf-8")
+
+
+def _make_provider_with_stream(body: bytes) -> CopilotProvider:
+    """Build a CopilotProvider whose HTTP client returns ``body`` on POST.
+
+    Bypasses ``ensure_token`` and the GitHub OAuth flow by stubbing
+    ``_get_headers`` and the token-refresh hook.
+    """
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    provider = CopilotProvider()
+    provider._client = httpx.AsyncClient(transport=transport)
+    # Skip token refresh entirely — tests run offline.
+    provider.ensure_token = _noop  # type: ignore[method-assign]
+    provider._get_headers = lambda: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+    return provider
+
+
+async def _noop() -> None:
+    return None
+
+
+async def _collect(provider: CopilotProvider, model: str = "gpt-5.5") -> list:
+    chunks: list[ResponsesStreamChunk] = []
+    async for chunk in provider.responses_completion_stream(
+        ResponsesRequest(model=model, input="hi", stream=True)
+    ):
+        chunks.append(chunk)
+    return chunks
+
+
+class TestToolSearchCallForwarding:
+    """gpt-5.x's `tool_search_call` must surface as a regular function_call."""
+
+    @pytest.mark.asyncio
+    async def test_tool_search_call_emitted_as_function_call(self):
+        events = [
+            {"type": "response.created", "response": {}},
+            {"type": "response.in_progress", "response": {}},
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "type": "tool_search_call",
+                    "execution": "client",
+                    "call_id": "call_abc123",
+                    "status": "in_progress",
+                    "arguments": {},
+                },
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "tool_search_call",
+                    "execution": "client",
+                    "call_id": "call_abc123",
+                    "status": "completed",
+                    "arguments": {"query": "writing files", "limit": 8},
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {"status": "completed", "usage": None},
+            },
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        chunks = await _collect(provider)
+        tool_chunks = [c for c in chunks if c.tool_call is not None]
+
+        assert len(tool_chunks) == 1, f"expected one tool_call chunk, got {chunks}"
+        tc = tool_chunks[0].tool_call
+        assert tc is not None
+        assert tc.name == "tool_search"
+        assert tc.is_custom is False
+        assert tc.call_id == "call_abc123"
+        # Arguments must be a JSON string (function_call shape downstream).
+        assert json.loads(tc.arguments) == {"query": "writing files", "limit": 8}
+
+    @pytest.mark.asyncio
+    async def test_tool_search_call_with_string_arguments_passes_through(self):
+        # Hypothetical: if Copilot ever serializes arguments as a string,
+        # we must not double-encode.
+        events = [
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "tool_search_call",
+                    "execution": "client",
+                    "call_id": "call_xyz",
+                    "arguments": '{"query": "x"}',
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        chunks = await _collect(provider)
+        tool_chunks = [c for c in chunks if c.tool_call is not None]
+
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].tool_call
+        assert tc is not None
+        assert tc.arguments == '{"query": "x"}'
+
+
+class TestUnknownEventNoise:
+    """Benign upstream events should not trigger the unhandled-event warning."""
+
+    @pytest.mark.asyncio
+    async def test_benign_events_skipped_from_warning(self, caplog):
+        events = [
+            {"type": "response.created", "response": {}},
+            {"type": "response.in_progress", "response": {}},
+            {
+                "type": "response.content_part.added",
+                "item_id": "msg-1",
+                "part": {"type": "output_text", "text": ""},
+            },
+            {
+                "type": "response.output_text.delta",
+                "item_id": "msg-1",
+                "delta": "hello",
+            },
+            {
+                "type": "response.output_text.done",
+                "item_id": "msg-1",
+                "text": "hello",
+            },
+            {
+                "type": "response.content_part.done",
+                "item_id": "msg-1",
+                "part": {"type": "output_text", "text": "hello"},
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "id": "msg-1",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "hello"}],
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        with caplog.at_level(logging.WARNING, logger="providers.copilot"):
+            await _collect(provider)
+
+        warnings = [r for r in caplog.records if "unhandled event types" in r.getMessage()]
+        assert warnings == [], (
+            "benign upstream events leaked into the unknown-event warning: "
+            f"{[w.getMessage() for w in warnings]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_genuinely_unknown_event_still_warned(self, caplog):
+        events = [
+            {"type": "response.created", "response": {}},
+            {
+                "type": "response.brand_new_event_type_we_dont_know",
+                "data": "stuff",
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        with caplog.at_level(logging.WARNING, logger="providers.copilot"):
+            await _collect(provider)
+
+        warnings = [r for r in caplog.records if "unhandled event types" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "brand_new_event_type_we_dont_know" in warnings[0].getMessage()

--- a/tests/test_responses_helpers.py
+++ b/tests/test_responses_helpers.py
@@ -153,6 +153,48 @@ class TestConvertInputToInternal:
         result = convert_input_to_internal(input_data)
         assert result[0]["output"] == '{"temp": 72}'
 
+    def test_reasoning_item_preserved_with_encrypted_content(self):
+        """Reasoning items echoed back from prior turns must keep id, summary,
+        and encrypted_content so Copilot can correlate chain-of-thought."""
+        input_data = [
+            {
+                "type": "reasoning",
+                "id": "rs-abc",
+                "summary": [{"type": "summary_text", "text": "thinking..."}],
+                "encrypted_content": "blob",
+            }
+        ]
+        result = convert_input_to_internal(input_data)
+        assert result == [
+            {
+                "type": "reasoning",
+                "id": "rs-abc",
+                "summary": [{"type": "summary_text", "text": "thinking..."}],
+                "encrypted_content": "blob",
+            }
+        ]
+
+    def test_reasoning_item_without_encrypted_content_omits_key(self):
+        """No encrypted_content key on the way in → none on the way out."""
+        input_data = [
+            {
+                "type": "reasoning",
+                "id": "rs-abc",
+                "summary": [{"type": "summary_text", "text": "..."}],
+            }
+        ]
+        result = convert_input_to_internal(input_data)
+        assert "encrypted_content" not in result[0]
+        assert result[0]["type"] == "reasoning"
+        assert result[0]["id"] == "rs-abc"
+
+    def test_reasoning_item_missing_summary_normalizes_to_empty_list(self):
+        """Some Codex versions echo reasoning items without a summary field;
+        we must still produce a valid reasoning item."""
+        input_data = [{"type": "reasoning", "id": "rs-xyz"}]
+        result = convert_input_to_internal(input_data)
+        assert result[0]["summary"] == []
+
 
 class TestConvertToolsToInternal:
     """Tests for tools conversion."""

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Fixes gpt-5.5 stopping mid-task in Codex (e.g. when running `/init`) — model would explore some files, then end the turn without writing anything.
- Root cause: Codex CLI ≥ v0.130 registers a `tool_search` tool (`execution: client`) for dynamic MCP discovery. gpt-5.5 invokes it via `output_item.done` items of `type: tool_search_call`, which our Copilot stream parser had no branch for. Events were silently bucketed into `unknown_event_counts`; Codex never received a tool call.
- Translates `tool_search_call` into a regular `function_call` named `tool_search` with JSON-encoded arguments — the shape Codex's client-side executor expects.
- Adds explicit `type: reasoning` branch in `convert_input_to_internal()` so reasoning items echoed back across turns are forwarded with `id`/`summary`/`encrypted_content` intact (mirrors vscode-copilot-chat's `extractThinkingData`).
- Filters five benign upstream events the route synthesizes its own equivalents from out of the `unhandled event types` warning, so future stream-shape regressions stand out.

## Production evidence

OpenClaw logs from the user's failing `/init` run:

```
WARNING  Copilot /responses unhandled event types: model=gpt-5.5 counts={
    'response.created': 1, 'response.in_progress': 1,
    'response.content_part.added': 1, 'response.output_text.done': 1,
    'response.content_part.done': 1, 'output_item.done:message': 1,
    'output_item.done:tool_search_call': 1   ← THE SMOKING GUN
}
```

After this fix the `tool_search_call` line is gone and Codex receives the tool call → executes search → returns output → model continues with the actual write.

## Test plan

- [x] `uv run pytest tests/ -v` — 758 passed (7 new)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — clean
- [ ] After deploy: `ssh OpenClaw "docker logs router-maestro --since 10m | grep -E 'unhandled event types|function_calls=[1-9]'"` — expect no `output_item.done:tool_search_call`
- [ ] Manual: codex `/init` in a scratch repo via OpenClaw — model should write AGENTS.md without stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)