### PR TITLE
fix(logging): disable Rich markup parsing to prevent stream crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.6 (2026-05-13)
+
+### Fixes
+
+- **Streaming responses no longer crash with `Internal server error` when log messages contain bracket-syntax.** v0.3.5 made it more likely we'd hit a latent bug introduced earlier: the console `RichHandler` was configured with `markup=True`, so any log line containing user-supplied content with bracket sequences that look like Rich markup tags (e.g. Codex file references like `[/Users/likanwen/.codex/config.toml:55]` echoed back inside the request payload that `copilot.py` debug-logs at `responses_completion_stream`) raised `MarkupError` from inside `logger.debug()`. The exception propagated out of the `async for chunk in stream` loop in `routes/responses.py` and aborted the SSE response after ~20ms, surfacing to the client as `stream disconnected before completion: Internal server error`. The handler is now created with `markup=False`, so log messages are emitted as literal text — no behavior change for our own log calls (we never used Rich markup tags in log strings) and a regression test pins it down.
+
+---
+
 ## v0.3.5 (2026-05-13)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.5"
+version = "0.3.6"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"

--- a/src/router_maestro/utils/logging.py
+++ b/src/router_maestro/utils/logging.py
@@ -43,11 +43,15 @@ def setup_logging(
 
     # Console handler (Rich with colors)
     if console:
+        # markup=False: log messages often contain user-supplied content (file
+        # paths, code, JSON payloads) where bracket sequences like
+        # `[/Users/foo/.codex/config.toml:55]` would otherwise be parsed as
+        # Rich markup and raise MarkupError mid-stream.
         console_handler = RichHandler(
             show_time=True,
             show_path=False,
             rich_tracebacks=True,
-            markup=True,
+            markup=False,
         )
         console_handler.setLevel(getattr(logging, level.upper(), logging.INFO))
         logger.addHandler(console_handler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,55 @@
+"""Tests for unified logging configuration.
+
+Pinning down the markup behavior is critical: we discovered in v0.3.5 that
+RichHandler with markup=True crashes mid-stream when a log message contains
+bracket-syntax that looks like Rich markup (e.g. file paths from Codex tool
+calls: ``[/Users/likanwen/.codex/config.toml:55]``). The crash propagates
+out of ``logger.debug()`` into the streaming response handler and breaks
+the connection with an "Internal server error".
+"""
+
+import logging
+
+from rich.logging import RichHandler
+
+from router_maestro.utils.logging import setup_logging
+
+
+class TestSetupLoggingRichHandlerMarkup:
+    """Regression: console RichHandler must NOT parse log messages as markup."""
+
+    def test_console_handler_has_markup_disabled(self):
+        """RichHandler must be configured with markup=False so that user
+        content with brackets does not raise MarkupError mid-stream."""
+        setup_logging(level="DEBUG", console=True, file=False)
+
+        logger = logging.getLogger("router_maestro")
+        rich_handlers = [h for h in logger.handlers if isinstance(h, RichHandler)]
+
+        assert len(rich_handlers) == 1, "expected exactly one RichHandler"
+        # RichHandler stores the markup setting on itself for older versions
+        # and on its internal renderer for newer versions; check both.
+        handler = rich_handlers[0]
+        markup_attr = getattr(handler, "markup", None)
+        assert markup_attr is False, (
+            "RichHandler.markup must be False to keep log messages literal — "
+            "otherwise bracket-syntax in user content (file paths, code, JSON) "
+            "is parsed as markup and crashes the logger mid-stream."
+        )
+
+    def test_logging_message_with_brackets_does_not_raise(self):
+        """The exact failure mode from the v0.3.5 production incident: a
+        debug log line containing a Codex-style file reference must not
+        raise MarkupError when emitted through the configured handler."""
+        setup_logging(level="DEBUG", console=True, file=False)
+        logger = logging.getLogger("router_maestro.providers.copilot")
+
+        # This is the literal string shape that crashed prod. If the handler
+        # parses it as markup, Rich raises MarkupError.
+        payload_excerpt = (
+            "Copilot responses payload: "
+            "{'input': [{'type': 'message', 'content': "
+            "'see [/Users/likanwen/.codex/config.toml:55]'}]}"
+        )
+        # Should complete cleanly — any exception fails the test.
+        logger.debug(payload_excerpt)

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- v0.3.5 made it more likely we'd hit a latent bug: `RichHandler(markup=True)` was crashing on log lines containing bracket-syntax that looks like Rich markup tags (e.g. Codex file references like `[/Users/likanwen/.codex/config.toml:55]` inside the request payload that `copilot.py:1005` debug-logs).
- The `MarkupError` propagated out of `logger.debug()` → `async for chunk in stream` (`routes/responses.py:473`) → aborted the SSE response after ~20ms, surfacing to the client as `stream disconnected before completion: Internal server error`.
- Switched to `markup=False`. We never used Rich markup tags in log strings, so this is a no-op for our own log calls and a strict bugfix at the boundary.

## Production traceback

```
ERROR    Unexpected error in responses stream: req_id=req-4457150c2a8b424a, elapsed=20.5ms
  File "router_maestro/server/routes/responses.py", line 473, in stream_response
    async for chunk in stream:
  File "router_maestro/providers/copilot.py", line 1005, in responses_completion_stream
    logger.debug("Copilot responses payload: %s", payload)
  File "rich/markup.py", line 167, in render
    raise MarkupError(f"closing tag …")
MarkupError: closing tag '[/Users/likanwen/.codex/config.toml:55]' at position 76891 doesn't match any open tag
```

## Test plan

- [x] `uv run pytest tests/test_logging.py -v` — 2 new regression tests pass
- [x] `uv run pytest tests/ -q` — full suite passes (753 tests)
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Verify on OpenClaw post-deploy that DEBUG-level requests with Codex file references no longer crash the stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)