### PR TITLE
fix(streaming): emit tool_search_call wire shape codex actually accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.7 (2026-05-13)
+
+### Fixes
+
+- **Codex's `tool_search` (MCP discovery) actually works now.** v0.3.5 unblocked gpt-5.5 by forwarding Copilot's `tool_search_call` events as `function_call(name="tool_search")` items. That was wrong: Codex's tool dispatcher (`codex-rs/core/src/tools/router.rs`) matches on `ResponseItem::ToolSearchCall` specifically — the function-call shape with `name="tool_search"` is looked up in Codex's function-tool registry, finds nothing (because `tool_search` is a top-level tool type, not a function), and the call gets silently aborted. Codex writes `function_call_output: 'aborted'` to the conversation, the model sees the abort, retries verbatim, and loops forever. The route now emits an actual `tool_search_call` item with `execution: "client"` and a dict-shaped `arguments` payload, matching the wire format codex's SSE parser asserts on (`codex-rs/codex-api/src/sse/responses.rs::parses_tool_search_call_items`). This restores `/init`, MCP discovery, and any other gpt-5.x flow that goes through `tool_search`.
+  - Internal: `ResponsesToolCall` gained a `kind: Literal["function", "custom", "tool_search"]` field that drives the route's branch selection. The legacy `is_custom: bool` is now a derived `@property` so existing call sites (and any out-of-tree consumers) keep working.
+
+---
+
 ## v0.3.6 (2026-05-13)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.6"
+version = "0.3.7"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import NoReturn
+from typing import Literal, NoReturn
 
 import httpx
 
@@ -148,10 +148,19 @@ class ResponsesToolCall:
     call_id: str
     name: str
     arguments: str
-    # ``True`` for custom (free-form text) tools like Codex's ``apply_patch``.
-    # The route forwards these as ``custom_tool_call`` items with raw ``input``
-    # rather than function_call items with JSON ``arguments``.
-    is_custom: bool = False
+    # Discriminates how the route emits this call to the downstream client:
+    #   - "function"    → standard ``function_call`` item with JSON ``arguments``
+    #   - "custom"      → ``custom_tool_call`` with raw ``input`` (e.g. apply_patch)
+    #   - "tool_search" → ``tool_search_call`` with ``execution: "client"`` and a
+    #                     dict ``arguments`` payload. Codex's MCP tool-discovery
+    #                     dispatcher only matches this exact item type — wrapping
+    #                     it as a function_call(name="tool_search") makes the
+    #                     dispatcher silently abort the call (v0.3.5/0.3.6 bug).
+    kind: Literal["function", "custom", "tool_search"] = "function"
+
+    @property
+    def is_custom(self) -> bool:
+        return self.kind == "custom"
 
 
 @dataclass

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -1096,7 +1096,7 @@ class CopilotProvider(BaseProvider):
                                 "call_id": item.get("call_id", ""),
                                 "name": item.get("name", ""),
                                 "arguments": "",
-                                "is_custom": False,
+                                "kind": "function",
                             }
                         elif item.get("type") == "custom_tool_call":
                             # Custom tools (e.g. Codex's apply_patch) stream
@@ -1108,15 +1108,17 @@ class CopilotProvider(BaseProvider):
                                 "call_id": item.get("call_id", ""),
                                 "name": item.get("name", ""),
                                 "arguments": "",
-                                "is_custom": True,
+                                "kind": "custom",
                             }
                         elif item.get("type") == "tool_search_call":
                             # Codex CLI registers a `tool_search` tool
                             # (execution=client) so the model can dynamically
-                            # discover MCP tools. gpt-5.x calls it via this
-                            # item type; forward as a regular function_call
-                            # named "tool_search" so Codex executes it and
-                            # returns a function_call_output.
+                            # discover MCP tools. Codex's dispatcher matches on
+                            # ResponseItem::ToolSearchCall — wrapping this as a
+                            # function_call(name="tool_search") makes the call
+                            # silently abort (registry has no function tool of
+                            # that name). Tag with kind="tool_search" so the
+                            # route emits a real tool_search_call item.
                             # NOTE: arguments arrive whole on output_item.done;
                             # if Copilot ever streams them via a dedicated
                             # delta event we'll spot it via unknown_event_counts.
@@ -1125,7 +1127,7 @@ class CopilotProvider(BaseProvider):
                                 "call_id": item.get("call_id", ""),
                                 "name": "tool_search",
                                 "arguments": "",
-                                "is_custom": False,
+                                "kind": "tool_search",
                             }
 
                     # Handle function call arguments delta - accumulate silently
@@ -1157,7 +1159,7 @@ class CopilotProvider(BaseProvider):
                                     call_id=fc["call_id"],
                                     name=fc["name"],
                                     arguments=fc["arguments"],
-                                    is_custom=fc.get("is_custom", False),
+                                    kind=fc.get("kind", "function"),
                                 ),
                             )
 
@@ -1174,7 +1176,7 @@ class CopilotProvider(BaseProvider):
                                     call_id=fc["call_id"],
                                     name=fc["name"],
                                     arguments=fc["arguments"],
-                                    is_custom=True,
+                                    kind="custom",
                                 ),
                             )
 
@@ -1209,7 +1211,7 @@ class CopilotProvider(BaseProvider):
                                         call_id=item.get("call_id", ""),
                                         name=item.get("name", ""),
                                         arguments=item.get("input", ""),
-                                        is_custom=True,
+                                        kind="custom",
                                     ),
                                 )
                         elif item.get("type") == "reasoning":
@@ -1238,10 +1240,13 @@ class CopilotProvider(BaseProvider):
                             if sig:
                                 yield ResponsesStreamChunk(content="", thinking_signature=sig)
                         elif item.get("type") == "tool_search_call":
-                            # Forward as function_call so Codex's client-side
-                            # tool_search executor receives it. Arguments arrive
-                            # as a dict here; serialize because function_call
-                            # arguments are JSON strings downstream.
+                            # Forward as kind="tool_search" so the route emits
+                            # an actual tool_search_call wire item — codex's
+                            # dispatcher refuses anything else (see v0.3.7
+                            # changelog). Arguments arrive as a dict here;
+                            # serialize to a JSON string for transport on the
+                            # ResponsesToolCall dataclass; the route deserializes
+                            # before re-emitting.
                             output_idx = data.get("output_index", 0)
                             fc = pending_fcs.pop(output_idx, None)
                             args = item.get("arguments")
@@ -1259,7 +1264,7 @@ class CopilotProvider(BaseProvider):
                                     call_id=call_id,
                                     name="tool_search",
                                     arguments=args_str,
-                                    is_custom=False,
+                                    kind="tool_search",
                                 ),
                             )
                         else:

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -578,7 +578,7 @@ async def stream_response(
                 for evt in state.close_open_message():
                     yield evt
 
-                if tc.is_custom:
+                if tc.kind == "custom":
                     # Custom tool call (e.g. apply_patch) — free-form text input,
                     # not JSON arguments. Round-trip as custom_tool_call so codex
                     # parses ``input`` as raw text.
@@ -626,6 +626,47 @@ async def stream_response(
                         }
                     )
                     state.output_items.append(ctc_item)
+                    state.output_index += 1
+                elif tc.kind == "tool_search":
+                    # Codex's MCP tool-discovery dispatcher matches on
+                    # ResponseItem::ToolSearchCall (codex-rs/core/src/tools/
+                    # router.rs). Wrapping this as a function_call(name=
+                    # "tool_search") makes the dispatcher silently abort the
+                    # call (the registry has no function tool of that name)
+                    # and Codex writes ``output: 'aborted'`` to the conversation
+                    # — the model retries forever (v0.3.5/v0.3.6 bug).
+                    # Codex only requires output_item.done with the full
+                    # item; arguments must be a dict, not a JSON string.
+                    try:
+                        args_obj = json.loads(tc.arguments) if tc.arguments else {}
+                    except (TypeError, ValueError):
+                        args_obj = {}
+                    tsc_item = {
+                        "type": "tool_search_call",
+                        "call_id": tc.call_id,
+                        "execution": "client",
+                        "status": "completed",
+                        "arguments": args_obj,
+                    }
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": state.output_index,
+                            "item": {
+                                **tsc_item,
+                                "status": "in_progress",
+                                "arguments": {},
+                            },
+                        }
+                    )
+                    yield sse_event(
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": state.output_index,
+                            "item": tsc_item,
+                        }
+                    )
+                    state.output_items.append(tsc_item)
                     state.output_index += 1
                 else:
                     fc_id = generate_id("fc")

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -104,6 +104,7 @@ class TestToolSearchCallForwarding:
         tc = tool_chunks[0].tool_call
         assert tc is not None
         assert tc.name == "tool_search"
+        assert tc.kind == "tool_search"
         assert tc.is_custom is False
         assert tc.call_id == "call_abc123"
         # Arguments must be a JSON string (function_call shape downstream).
@@ -134,6 +135,7 @@ class TestToolSearchCallForwarding:
         assert len(tool_chunks) == 1
         tc = tool_chunks[0].tool_call
         assert tc is not None
+        assert tc.kind == "tool_search"
         assert tc.arguments == '{"query": "x"}'
 
 

--- a/tests/test_responses_route_wire_shape.py
+++ b/tests/test_responses_route_wire_shape.py
@@ -1,0 +1,229 @@
+"""Tests for the /responses route's wire-shape emission for tool calls.
+
+The route translates internal ``ResponsesToolCall`` objects into the SSE
+event sequence that downstream OpenAI-API-compatible clients (Codex CLI in
+particular) consume. Each ``kind`` of tool call has its own wire shape; if
+the wire shape is wrong, codex's tool dispatcher silently aborts the call
+(this is exactly how v0.3.5/v0.3.6 broke ``tool_search``).
+
+These tests pin each shape down end-to-end through ``stream_response``.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from router_maestro.providers import ResponsesRequest as InternalResponsesRequest
+from router_maestro.providers.base import ResponsesStreamChunk, ResponsesToolCall
+from router_maestro.server.routes.responses import stream_response
+
+
+class _StubRouter:
+    """Minimal Router stub that returns a pre-built chunk stream."""
+
+    def __init__(self, chunks: list[ResponsesStreamChunk]):
+        self._chunks = chunks
+
+    async def responses_completion_stream(
+        self, request: InternalResponsesRequest, fallback: bool = True
+    ) -> tuple[AsyncIterator[ResponsesStreamChunk], str]:
+        async def _gen() -> AsyncIterator[ResponsesStreamChunk]:
+            for c in self._chunks:
+                yield c
+
+        return _gen(), "github-copilot"
+
+
+def _parse_sse(events: list[str]) -> list[dict[str, Any]]:
+    """Parse an SSE-encoded event list into JSON dicts."""
+    parsed: list[dict[str, Any]] = []
+    for evt in events:
+        for line in evt.splitlines():
+            if line.startswith("data: "):
+                payload = line[len("data: ") :]
+                parsed.append(json.loads(payload))
+    return parsed
+
+
+async def _drive(chunks: list[ResponsesStreamChunk]) -> list[dict[str, Any]]:
+    router = _StubRouter(chunks)
+    req = InternalResponsesRequest(model="gpt-5.5", input="hi", stream=True)
+    raw_events: list[str] = []
+    async for evt in stream_response(router, req, request_id="req-test", start_time=0.0):  # type: ignore[arg-type]
+        raw_events.append(evt)
+    return _parse_sse(raw_events)
+
+
+class TestToolSearchCallWireShape:
+    """``kind="tool_search"`` must surface as a real ``tool_search_call`` item.
+
+    Codex's MCP tool-discovery dispatcher (codex-rs/core/src/tools/router.rs)
+    matches on ``ResponseItem::ToolSearchCall`` and rejects anything else —
+    wrapping the call as ``function_call(name="tool_search")`` causes a
+    silent abort and the model retries forever (the v0.3.5/v0.3.6 bug).
+    """
+
+    @pytest.mark.asyncio
+    async def test_emits_tool_search_call_item(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="call_abc123",
+                        name="tool_search",
+                        arguments='{"query": "writing files", "limit": 8}',
+                        kind="tool_search",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+
+        done = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "tool_search_call"
+        ]
+        assert len(done) == 1, f"expected one tool_search_call done event, got {events}"
+
+        item = done[0]["item"]
+        assert item["type"] == "tool_search_call"
+        assert item["call_id"] == "call_abc123"
+        assert item["execution"] == "client", "codex requires execution=client"
+        # Arguments must be a dict, NOT a JSON string — codex's parser does
+        # ``serde_json::from_value::<SearchToolCallParams>(arguments)``.
+        assert item["arguments"] == {"query": "writing files", "limit": 8}
+
+    @pytest.mark.asyncio
+    async def test_does_not_emit_function_call_arguments_events(self):
+        """Regression: v0.3.5/v0.3.6 emitted function_call_arguments.delta/.done
+        which polluted codex's stream parser even when it ignored the items."""
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="call_xyz",
+                        name="tool_search",
+                        arguments='{"query": "x"}',
+                        kind="tool_search",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+
+        offending = [
+            e
+            for e in events
+            if e.get("type")
+            in {
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+            }
+        ]
+        assert offending == [], (
+            "tool_search must not emit function_call_arguments events; "
+            f"got: {[e['type'] for e in offending]}"
+        )
+
+        # And there must be no function_call output_item either.
+        bad_items = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "function_call"
+        ]
+        assert bad_items == [], (
+            "tool_search must NOT be wrapped as a function_call item — "
+            "codex's dispatcher would silently abort it."
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_arguments_falls_back_to_empty_dict(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="call_bad",
+                        name="tool_search",
+                        arguments="not json",
+                        kind="tool_search",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+        done = next(
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "tool_search_call"
+        )
+        assert done["item"]["arguments"] == {}
+
+
+class TestFunctionCallWireShape:
+    """Regular function calls must still emit the legacy function_call shape."""
+
+    @pytest.mark.asyncio
+    async def test_function_call_emits_function_call_item(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="call_fn",
+                        name="get_weather",
+                        arguments='{"location": "NYC"}',
+                        kind="function",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+
+        done = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "function_call"
+        ]
+        assert len(done) == 1
+        assert done[0]["item"]["name"] == "get_weather"
+        assert done[0]["item"]["arguments"] == '{"location": "NYC"}'
+
+
+class TestCustomToolCallWireShape:
+    """Custom tools (apply_patch) must still emit custom_tool_call shape."""
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_emits_custom_tool_call_item(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="call_patch",
+                        name="apply_patch",
+                        arguments="*** Begin Patch\n*** End Patch",
+                        kind="custom",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+        done = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "custom_tool_call"
+        ]
+        assert len(done) == 1
+        assert done[0]["item"]["name"] == "apply_patch"
+        assert done[0]["item"]["input"] == "*** Begin Patch\n*** End Patch"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- v0.3.5 forwarded Copilot's `tool_search_call` events as `function_call(name="tool_search")` items. Wrong: codex's tool dispatcher (`codex-rs/core/src/tools/router.rs`) matches on `ResponseItem::ToolSearchCall` specifically. The function-call shape with `name="tool_search"` looks up "tool_search" in codex's function-tool registry, finds nothing (it's a top-level tool type, not a function), and silently aborts — codex writes `function_call_output: 'aborted'` to the conversation, the model sees the abort, retries the same call, and loops forever.
- The route now emits an actual `tool_search_call` output_item with `execution: "client"` and dict-shaped `arguments`, matching codex's SSE parser asserts (`codex-rs/codex-api/src/sse/responses.rs::parses_tool_search_call_items`).
- Internal: `ResponsesToolCall.kind: Literal["function", "custom", "tool_search"]` drives the route's branch selection. Legacy `is_custom` kept as a `@property`.

## Production evidence

```
{type: function_call, name: tool_search, ...} → {type: function_call_output, output: 'aborted'}
{type: function_call, name: tool_search, ...} → {type: function_call_output, output: 'aborted'}
... 10+ times ...
```

User report: gpt-5.5 in codex `/init` keeps "Exploring" and never makes progress.

## Test plan

- [x] `uv run pytest tests/test_responses_route_wire_shape.py -v` — 5 new tests pin the wire shape per kind
- [x] `uv run pytest tests/ -q` — full suite passes (758 tests)
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Verify on OpenClaw post-deploy: gpt-5.5 in codex `/init` calls tool_search → MCP discovery returns results → progresses past "Explored" → no more aborted-loop in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)