### PR TITLE
fix(responses): preserve MCP namespace on function_call round-trip (v0.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.8 (2026-05-13)
+
+### Fixes
+
+- **MCP tool calls (Kusto, ado-mcp, context7, …) no longer 400 mid-stream.** v0.3.7 unblocked Codex's MCP discovery via `tool_search`, so the model could finally see and call namespaced MCP tools — but the very next turn died with `Copilot API error: 400 - Missing namespace for function_call 'execute_query'. It does not exist in the default namespace. Round-trip the model's function_call item with its namespace field included.` Copilot CAPI attaches a `namespace` field (e.g. `"kusto"`) to MCP-routed `function_call` items; Codex echoes that field back on the next turn so Copilot can resolve which MCP server owns the tool. Router-Maestro stripped the field at three points — `copilot.py`'s `output_item.added`/`output_item.done` parsers, the `_extract_tool_calls` non-streaming path, and `responses.py`'s `convert_input_to_internal()` — because each layer used an explicit field whitelist. The whitelists now include `namespace`, the `ResponsesToolCall` dataclass carries it through, and `make_function_call_item` emits it on the wire when present (and omits the key entirely when absent, so non-MCP tool calls keep their old shape and Copilot doesn't see a literal `null`).
+  - Reference: agent-maestro uses zod `looseObject()` (`agent-maestro/src/server/schemas/openai.ts:541-548`) which preserves unknown fields automatically — the same dynamic that protected it from this bug.
+
+---
+
 ## v0.3.7 (2026-05-13)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.7"
+version = "0.3.8"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -157,6 +157,11 @@ class ResponsesToolCall:
     #                     it as a function_call(name="tool_search") makes the
     #                     dispatcher silently abort the call (v0.3.5/0.3.6 bug).
     kind: Literal["function", "custom", "tool_search"] = "function"
+    # MCP namespace, when the upstream emits one (e.g. Copilot CAPI's
+    # ``kusto/execute_query`` → namespace="kusto"). Must round-trip back to
+    # the upstream verbatim or the next turn 400s with
+    # ``Missing namespace for function_call 'X'`` (v0.3.7 → v0.3.8 bug).
+    namespace: str | None = None
 
     @property
     def is_custom(self) -> bool:

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -925,6 +925,7 @@ class CopilotProvider(BaseProvider):
                         call_id=output.get("call_id", ""),
                         name=output.get("name", ""),
                         arguments=output.get("arguments", "{}"),
+                        namespace=output.get("namespace"),
                     )
                 )
         return tool_calls
@@ -1097,6 +1098,9 @@ class CopilotProvider(BaseProvider):
                                 "name": item.get("name", ""),
                                 "arguments": "",
                                 "kind": "function",
+                                # MCP namespace (e.g. "kusto"). Required on
+                                # round-trip or Copilot 400s the next turn.
+                                "namespace": item.get("namespace"),
                             }
                         elif item.get("type") == "custom_tool_call":
                             # Custom tools (e.g. Codex's apply_patch) stream
@@ -1160,6 +1164,7 @@ class CopilotProvider(BaseProvider):
                                     name=fc["name"],
                                     arguments=fc["arguments"],
                                     kind=fc.get("kind", "function"),
+                                    namespace=fc.get("namespace"),
                                 ),
                             )
 
@@ -1195,6 +1200,7 @@ class CopilotProvider(BaseProvider):
                                         call_id=item.get("call_id", ""),
                                         name=item.get("name", ""),
                                         arguments=item.get("arguments", "{}"),
+                                        namespace=item.get("namespace") or fc.get("namespace"),
                                     ),
                                 )
                         elif item.get("type") == "custom_tool_call":

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -95,16 +95,20 @@ def convert_input_to_internal(
                 items.append({"type": "message", "role": role, "content": content})
 
             elif item_type == "function_call":
-                items.append(
-                    {
-                        "type": "function_call",
-                        "id": item.get("id"),
-                        "call_id": item.get("call_id"),
-                        "name": item.get("name"),
-                        "arguments": item.get("arguments", "{}"),
-                        "status": item.get("status", "completed"),
-                    }
-                )
+                fc_item: dict[str, Any] = {
+                    "type": "function_call",
+                    "id": item.get("id"),
+                    "call_id": item.get("call_id"),
+                    "name": item.get("name"),
+                    "arguments": item.get("arguments", "{}"),
+                    "status": item.get("status", "completed"),
+                }
+                # Preserve MCP namespace verbatim. Copilot CAPI rejects the
+                # next turn with ``Missing namespace for function_call 'X'``
+                # if a previously-namespaced call is round-tripped without it.
+                if item.get("namespace") is not None:
+                    fc_item["namespace"] = item["namespace"]
+                items.append(fc_item)
 
             elif item_type == "function_call_output":
                 output = item.get("output", "")
@@ -215,10 +219,15 @@ def make_message_item(msg_id: str, text: str, status: str = "completed") -> dict
 
 
 def make_function_call_item(
-    fc_id: str, call_id: str, name: str, arguments: str, status: str = "completed"
+    fc_id: str,
+    call_id: str,
+    name: str,
+    arguments: str,
+    status: str = "completed",
+    namespace: str | None = None,
 ) -> dict[str, Any]:
     """Create function_call output item."""
-    return {
+    item: dict[str, Any] = {
         "type": "function_call",
         "id": fc_id,
         "call_id": call_id,
@@ -226,6 +235,9 @@ def make_function_call_item(
         "arguments": arguments,
         "status": status,
     }
+    if namespace is not None:
+        item["namespace"] = namespace
+    return item
 
 
 @router.post("/api/openai/v1/responses")
@@ -291,7 +303,15 @@ async def create_response(request: ResponsesRequest):
         if response.tool_calls:
             for tc in response.tool_calls:
                 fc_id = generate_id("fc")
-                output.append(make_function_call_item(fc_id, tc.call_id, tc.name, tc.arguments))
+                output.append(
+                    make_function_call_item(
+                        fc_id,
+                        tc.call_id,
+                        tc.name,
+                        tc.arguments,
+                        namespace=tc.namespace,
+                    )
+                )
 
         return ResponsesResponse(
             id=response_id,
@@ -670,14 +690,25 @@ async def stream_response(
                     state.output_index += 1
                 else:
                     fc_id = generate_id("fc")
-                    fc_item = make_function_call_item(fc_id, tc.call_id, tc.name, tc.arguments)
+                    fc_item = make_function_call_item(
+                        fc_id,
+                        tc.call_id,
+                        tc.name,
+                        tc.arguments,
+                        namespace=tc.namespace,
+                    )
 
                     yield sse_event(
                         {
                             "type": "response.output_item.added",
                             "output_index": state.output_index,
                             "item": make_function_call_item(
-                                fc_id, tc.call_id, tc.name, "", "in_progress"
+                                fc_id,
+                                tc.call_id,
+                                tc.name,
+                                "",
+                                "in_progress",
+                                namespace=tc.namespace,
                             ),
                         }
                     )

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -139,6 +139,100 @@ class TestToolSearchCallForwarding:
         assert tc.arguments == '{"query": "x"}'
 
 
+class TestNamespacePreservation:
+    """MCP-namespaced function_calls must preserve `namespace` end-to-end.
+
+    Copilot CAPI rejects the next turn with
+    ``Missing namespace for function_call 'X'`` if a previously-namespaced
+    call is round-tripped without it (v0.3.7 → v0.3.8 bug).
+    """
+
+    @pytest.mark.asyncio
+    async def test_namespace_captured_from_output_item_added(self):
+        events = [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc-1",
+                    "call_id": "call_kusto_1",
+                    "name": "execute_query",
+                    "namespace": "kusto",
+                    "arguments": "",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "output_index": 0,
+                "arguments": '{"query":"Heartbeat | take 5"}',
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+        chunks = await _collect(provider)
+        tool_chunks = [c for c in chunks if c.tool_call is not None]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].tool_call
+        assert tc is not None
+        assert tc.name == "execute_query"
+        assert tc.namespace == "kusto"
+        assert tc.kind == "function"
+
+    @pytest.mark.asyncio
+    async def test_namespace_only_on_done_event(self):
+        # Hypothetical: Copilot attaches namespace only on output_item.done,
+        # not on added. The fallback path must catch this.
+        events = [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"type": "function_call", "call_id": "c1", "name": "x"},
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "x",
+                    "namespace": "ns1",
+                    "arguments": "{}",
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+        chunks = await _collect(provider)
+        tool_chunks = [c for c in chunks if c.tool_call is not None]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].tool_call
+        assert tc is not None
+        assert tc.namespace == "ns1"
+
+    @pytest.mark.asyncio
+    async def test_no_namespace_stays_none(self):
+        # Regression: standard (non-MCP) function_calls don't carry namespace.
+        events = [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"type": "function_call", "call_id": "c1", "name": "weather"},
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "output_index": 0,
+                "arguments": '{"city":"NYC"}',
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+        chunks = await _collect(provider)
+        tool_chunks = [c for c in chunks if c.tool_call is not None]
+        assert tool_chunks[0].tool_call is not None
+        assert tool_chunks[0].tool_call.namespace is None
+
+
 class TestUnknownEventNoise:
     """Benign upstream events should not trigger the unhandled-event warning."""
 

--- a/tests/test_responses_input_conversion.py
+++ b/tests/test_responses_input_conversion.py
@@ -1,0 +1,72 @@
+"""Tests for ``convert_input_to_internal``'s field preservation.
+
+Codex CLI round-trips MCP-namespaced ``function_call`` items back to the
+upstream on the next turn. If we strip the ``namespace`` field while
+converting the input, Copilot CAPI rejects the request with::
+
+    Missing namespace for function_call 'execute_query'.
+    It does not exist in the default namespace.
+    Round-trip the model's function_call item with its namespace field
+    included.
+
+These tests pin the input-side behavior down.
+"""
+
+from router_maestro.server.routes.responses import convert_input_to_internal
+
+
+def test_function_call_namespace_preserved():
+    items = convert_input_to_internal(
+        [
+            {
+                "type": "function_call",
+                "id": "fc-1",
+                "call_id": "call_1",
+                "name": "execute_query",
+                "namespace": "kusto",
+                "arguments": '{"query":"x"}',
+                "status": "completed",
+            },
+        ]
+    )
+    assert isinstance(items, list)
+    assert items[0]["type"] == "function_call"
+    assert items[0]["namespace"] == "kusto"
+    assert items[0]["call_id"] == "call_1"
+    assert items[0]["name"] == "execute_query"
+    assert items[0]["arguments"] == '{"query":"x"}'
+
+
+def test_function_call_without_namespace_omits_field():
+    # Non-MCP function_calls must NOT gain a ``namespace=None`` key —
+    # Copilot may treat the presence of the key as a signal.
+    items = convert_input_to_internal(
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "weather",
+                "arguments": "{}",
+            },
+        ]
+    )
+    assert isinstance(items, list)
+    assert "namespace" not in items[0]
+
+
+def test_function_call_explicit_none_namespace_omitted():
+    # Defensive: even if Codex sends ``namespace: null`` we drop the field
+    # rather than forwarding a literal null which Copilot may also reject.
+    items = convert_input_to_internal(
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "weather",
+                "arguments": "{}",
+                "namespace": None,
+            },
+        ]
+    )
+    assert isinstance(items, list)
+    assert "namespace" not in items[0]

--- a/tests/test_responses_route_wire_shape.py
+++ b/tests/test_responses_route_wire_shape.py
@@ -199,6 +199,70 @@ class TestFunctionCallWireShape:
         assert done[0]["item"]["arguments"] == '{"location": "NYC"}'
 
 
+class TestFunctionCallNamespaceWireShape:
+    """Namespaced function_calls must emit `namespace` field downstream
+    so Codex can echo it back next turn — Copilot 400s otherwise."""
+
+    @pytest.mark.asyncio
+    async def test_namespace_emitted_in_output_item(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="call_kusto_1",
+                        name="execute_query",
+                        arguments='{"query":"x"}',
+                        kind="function",
+                        namespace="kusto",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+        done = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "function_call"
+        ]
+        assert len(done) == 1
+        assert done[0]["item"]["namespace"] == "kusto"
+
+        added = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.added"
+            and e.get("item", {}).get("type") == "function_call"
+        ]
+        assert len(added) == 1
+        assert added[0]["item"]["namespace"] == "kusto"
+
+    @pytest.mark.asyncio
+    async def test_no_namespace_no_field_in_output(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(
+                    content="",
+                    tool_call=ResponsesToolCall(
+                        call_id="c1",
+                        name="weather",
+                        arguments="{}",
+                        kind="function",
+                    ),
+                ),
+                ResponsesStreamChunk(content="", finish_reason="stop"),
+            ]
+        )
+        done = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "function_call"
+        ]
+        assert "namespace" not in done[0]["item"]
+
+
 class TestCustomToolCallWireShape:
     """Custom tools (apply_patch) must still emit custom_tool_call shape."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Copilot CAPI attaches a \`namespace\` field (e.g. \`\"kusto\"\`) to MCP-routed \`function_call\` items, and rejects the next turn with \`Missing namespace for function_call 'X'\` if it isn't echoed back. Router-Maestro stripped the field at three points — \`copilot.py\` output_item.added/done parsers, \`_extract_tool_calls\`, and \`responses.py\` \`convert_input_to_internal\` — because each layer used an explicit field whitelist.
- Whitelists now include \`namespace\`, \`ResponsesToolCall\` carries it through, and \`make_function_call_item\` emits it on the wire when present (omits the key when absent, so non-MCP calls keep their old shape).
- Reference: agent-maestro uses zod \`looseObject()\` (\`agent-maestro/src/server/schemas/openai.ts:541-548\`) which preserves unknown fields automatically — same dynamic that protected it from this bug.

## Bug repro

After v0.3.7 fixed \`tool_search_call\` wire shape, Codex now successfully discovers MCP tools. User configured Kusto MCP, model called \`execute_query\`:

\`\`\`
Stream disconnected before completion: Copilot API error: 400 -
{\"error\":{\"message\":\"Missing namespace for function_call 'execute_query'.
It does not exist in the default namespace.
Round-trip the model's function_call item with its namespace field included.\",
\"code\":\"invalid_request_body\"}}
\`\`\`

## Test plan

- [x] \`uv run pytest tests/ -v\` — 766 passed (was 758, +8 new namespace tests)
- [x] \`uv run ruff check src/ tests/ && uv run ruff format src/ tests/\` — clean
- [x] New tests cover: namespace captured from added event, fallback from done-only event, no-namespace stays None, wire-shape emission with/without namespace, input round-trip preservation incl. explicit-null handling
- [ ] Production verification on OpenClaw after deploy: \`docker logs router-maestro --since 10m | grep -E 'Missing namespace|function_calls=[1-9]'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)