### PR TITLE
fix(copilot): pass through namespace tool registries with inner tools[] (v0.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.9 (2026-05-13)
+
+### Fixes
+
+- **MCP tool registries (Kusto, ado-mcp, context7, …) actually reach the model now.** v0.3.8 preserved the `namespace` field on `function_call` round-trips, but the underlying MCP tool calls still 400'd with `Missing namespace for function_call 'execute_query'. It does not exist in the default namespace.` because we were silently dropping the namespace tool registry itself from the request. The Codex `/responses` request carries tools shaped as `{"type": "namespace", "name": "mcp__kusto_mcp__", "tools": [{"type": "function", "name": "execute_query", ...}, ...]}` — a wrapper around the actual function definitions. We were filtering ALL `type: "namespace"` items out (added in an earlier release to suppress a `Missing required parameter: 'tools[N].tools'` 400 from Copilot), so the model received `tool_search_call` results referencing tools Copilot's request validator had no record of. The filter now keeps namespace items that carry a non-empty inner `tools` array (the legitimate registry shape) and only drops the empty/missing variants that were the original 400's actual cause.
+
+---
+
 ## v0.3.8 (2026-05-13)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.8"
+version = "0.3.9"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -792,14 +792,16 @@ class CopilotProvider(BaseProvider):
             raise ProviderError(f"Failed to list models: {e}", retryable=True)
 
     # Tools that are not supported by Copilot Responses API.
-    # ``namespace`` is emitted by Codex CLI to group MCP servers behind a
-    # tool-search facade; Copilot rejects it with
+    # ``namespace`` items are conditionally allowed: if they carry an inner
+    # ``tools`` array (Codex's MCP registry shape) they MUST pass through
+    # so Copilot can resolve namespaced function_calls like
+    # ``kusto/execute_query``. Bare namespace items without an inner
+    # ``tools`` array are dropped because Copilot rejects them with
     # ``Missing required parameter: 'tools[N].tools'``.
     UNSUPPORTED_TOOL_TYPES = {
         "web_search",
         "web_search_preview",
         "code_interpreter",
-        "namespace",
     }
 
     def _filter_unsupported_tools(self, tools: list[dict] | None) -> list[dict] | None:
@@ -817,9 +819,22 @@ class CopilotProvider(BaseProvider):
         filtered = []
         for tool in tools:
             tool_type = tool.get("type", "function")
-            # Only include function tools, filter out unsupported built-in tools
             if tool_type == "function":
                 filtered.append(tool)
+            elif tool_type == "namespace":
+                # Codex's MCP discovery returns namespace items wrapping
+                # the actual function tools. Pass through ONLY when the
+                # inner ``tools`` array is present and non-empty —
+                # otherwise Copilot 400s with
+                # ``Missing required parameter: 'tools[N].tools'``.
+                inner = tool.get("tools")
+                if isinstance(inner, list) and inner:
+                    filtered.append(tool)
+                else:
+                    logger.debug(
+                        "Filtering out empty namespace tool: %s",
+                        tool.get("name"),
+                    )
             elif tool_type not in self.UNSUPPORTED_TOOL_TYPES:
                 filtered.append(tool)
             else:

--- a/tests/test_copilot_tool_filter.py
+++ b/tests/test_copilot_tool_filter.py
@@ -18,9 +18,9 @@ class TestFilterUnsupportedTools:
         ]
         assert self.provider._filter_unsupported_tools(tools) == tools
 
-    def test_drops_namespace_tools(self):
-        # Codex CLI emits these to group MCP servers; Copilot rejects with
-        # "Missing required parameter: 'tools[N].tools'".
+    def test_drops_empty_namespace_tools(self):
+        # Bare namespace items without an inner tools[] still trigger
+        # "Missing required parameter: 'tools[N].tools'" — drop those only.
         tools = [
             {"type": "function", "name": "foo"},
             {
@@ -34,6 +34,49 @@ class TestFilterUnsupportedTools:
         assert result is not None
         assert all(t["type"] == "function" for t in result)
         assert [t["name"] for t in result] == ["foo", "bar"]
+
+    def test_keeps_namespace_with_inner_tools(self):
+        # Codex's MCP registry shape — namespace wraps the actual function
+        # tools. Dropping the wrapper means Copilot can't resolve
+        # ``execute_query`` and 400s with ``Missing namespace for
+        # function_call 'execute_query'`` (v0.3.8 → v0.3.9 bug).
+        kusto_namespace = {
+            "type": "namespace",
+            "name": "mcp__kusto_mcp__",
+            "description": "Tools in the mcp__kusto_mcp__ namespace.",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "execute_query",
+                    "description": "Execute a KQL query",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            ],
+        }
+        tools = [
+            {"type": "function", "name": "shell"},
+            kusto_namespace,
+        ]
+        result = self.provider._filter_unsupported_tools(tools)
+        assert result is not None
+        assert len(result) == 2
+        assert result[1] == kusto_namespace
+
+    def test_drops_namespace_with_empty_tools_list(self):
+        # ``tools: []`` is just as bad as omitting the field — Copilot
+        # 400s the same way. Drop both shapes.
+        tools = [
+            {"type": "function", "name": "foo"},
+            {
+                "type": "namespace",
+                "name": "mcp__empty__",
+                "description": "...",
+                "tools": [],
+            },
+        ]
+        result = self.provider._filter_unsupported_tools(tools)
+        assert result is not None
+        assert [t["name"] for t in result] == ["foo"]
 
     def test_drops_web_search_and_code_interpreter(self):
         tools = [

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Stop dropping Copilot CAPI's MCP namespace tool registries — items shaped `{type: "namespace", name: "mcp__X__", tools: [{type: "function", ...}]}` were silently filtered out, so Copilot's tool registry never learned which functions belonged to which namespace.
- Result downstream: model called `execute_query` from the `kusto` namespace, Copilot 400'd with `Missing namespace for function_call 'execute_query'. It does not exist in the default namespace.` (the same error v0.3.8 was supposed to fix from the round-trip side).
- Keep the original `Missing required parameter: 'tools[N].tools'` guard intact: still drop bare/empty namespace items (no inner `tools[]`, or `tools: []`).

## Why v0.3.8 didn't fix it

v0.3.8 added namespace round-trip on the `function_call` item itself — necessary, but not sufficient. Production logs revealed the actual upstream shape was a tool **registry** wrapper, not a per-call field. We were dropping the registry entirely in `_filter_unsupported_tools`, so Copilot never knew `execute_query` lived under `kusto` in the first place.

## Test plan

- [x] `uv run pytest tests/ -v` — 768 passing (was 766, +2 new namespace passthrough tests)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — clean
- [ ] Deploy to OpenClaw and verify Kusto MCP `execute_query` round-trips without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)