### PR TITLE
fix(copilot): defer function_call emission to output_item.done for MCP namespace (v0.3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
-## v0.3.9 (2026-05-13)
+## v0.3.10 (2026-05-13)
+
+### Fixes
+
+- **MCP `function_call` round-trips no longer drop the `namespace` field mid-stream.** v0.3.8 added namespace preservation on the dataclass and v0.3.9 stopped dropping the namespace tool registry, but Kusto MCP still 400'd with `Missing namespace for function_call 'execute_query'. It does not exist in the default namespace. Round-trip the model's function_call item with its namespace field included.` The remaining bug was in the SSE event ordering inside `copilot.py`: Copilot CAPI sends function_call events in the order `output_item.added` → `function_call_arguments.delta` × N → `function_call_arguments.done` → `output_item.done`, and the **`namespace` field is only present on the final `output_item.done` event** (matching codex's `ev_function_call_with_namespace` test fixture in `codex-rs/core/tests/common/responses.rs:829-844`). The streaming parser was emitting the `ResponsesToolCall` on `function_call_arguments.done` and popping the bookkeeping entry, so when `output_item.done` arrived with the namespace, the fallback `if fc is not None` branch never ran. Emission is now deferred to `output_item.done` for all function_call items, with the in-progress dict kept alive (`pending_fcs.get` instead of `pop`) on `function_call_arguments.done`. The namespace, arguments, and item identity all come from the canonical `output_item.done` payload, with the bookkeeping dict only used as a fallback for sparse items. A new regression test (`test_emission_deferred_until_output_item_done`) reproduces the exact production wire shape that v0.3.8 and v0.3.9 missed.
+
+---
 
 ### Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.9"
+version = "0.3.10"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.9"
+__version__ = "0.3.10"

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -1164,24 +1164,18 @@ class CopilotProvider(BaseProvider):
                         if fc and delta:
                             fc["arguments"] += delta
 
-                    # Handle function call arguments done
+                    # Handle function call arguments done — finalize arguments
+                    # but DON'T emit yet. Copilot CAPI sends the ``namespace``
+                    # field (required for MCP-namespaced tools like
+                    # ``kusto/execute_query``) on the *later* ``output_item.done``
+                    # event, not on this one. Emitting here loses namespace and
+                    # the next turn 400s with ``Missing namespace for
+                    # function_call 'X'``. Defer to output_item.done.
                     elif event_type == "response.function_call_arguments.done":
                         output_idx = data.get("output_index", 0)
-                        fc = pending_fcs.pop(output_idx, None)
+                        fc = pending_fcs.get(output_idx)
                         if fc:
                             fc["arguments"] = data.get("arguments", fc["arguments"])
-                            # Emit complete tool call
-                            emitted_tool_call = True
-                            yield ResponsesStreamChunk(
-                                content="",
-                                tool_call=ResponsesToolCall(
-                                    call_id=fc["call_id"],
-                                    name=fc["name"],
-                                    arguments=fc["arguments"],
-                                    kind=fc.get("kind", "function"),
-                                    namespace=fc.get("namespace"),
-                                ),
-                            )
 
                     elif event_type == "response.custom_tool_call_input.done":
                         output_idx = data.get("output_index", 0)
@@ -1200,24 +1194,29 @@ class CopilotProvider(BaseProvider):
                                 ),
                             )
 
-                    # Handle output_item.done for function calls
+                    # Handle output_item.done for function calls. Copilot
+                    # delivers ``namespace`` (for MCP tools) on this event only.
                     elif event_type == "response.output_item.done":
                         item = data.get("item", {})
                         if item.get("type") == "function_call":
                             output_idx = data.get("output_index", 0)
-                            # Only emit if not already done via function_call_arguments.done
-                            fc = pending_fcs.pop(output_idx, None)
-                            if fc is not None:
-                                emitted_tool_call = True
-                                yield ResponsesStreamChunk(
-                                    content="",
-                                    tool_call=ResponsesToolCall(
-                                        call_id=item.get("call_id", ""),
-                                        name=item.get("name", ""),
-                                        arguments=item.get("arguments", "{}"),
-                                        namespace=item.get("namespace") or fc.get("namespace"),
-                                    ),
-                                )
+                            fc = pending_fcs.pop(output_idx, None) or {}
+                            # Prefer the final item payload (carries namespace
+                            # and the canonical arguments). Fall back to the
+                            # bookkeeping dict if the item is sparse.
+                            emitted_tool_call = True
+                            yield ResponsesStreamChunk(
+                                content="",
+                                tool_call=ResponsesToolCall(
+                                    call_id=item.get("call_id") or fc.get("call_id", ""),
+                                    name=item.get("name") or fc.get("name", ""),
+                                    arguments=item.get("arguments")
+                                    or fc.get("arguments", "")
+                                    or "{}",
+                                    kind=fc.get("kind", "function"),
+                                    namespace=item.get("namespace") or fc.get("namespace"),
+                                ),
+                            )
                         elif item.get("type") == "custom_tool_call":
                             # Fallback: if custom_tool_call_input.done didn't
                             # fire (or pending_fcs was already drained), emit

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -167,6 +167,18 @@ class TestNamespacePreservation:
                 "output_index": 0,
                 "arguments": '{"query":"Heartbeat | take 5"}',
             },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc-1",
+                    "call_id": "call_kusto_1",
+                    "name": "execute_query",
+                    "namespace": "kusto",
+                    "arguments": '{"query":"Heartbeat | take 5"}',
+                },
+            },
             {"type": "response.completed", "response": {"status": "completed"}},
         ]
         provider = _make_provider_with_stream(_sse_lines(events))
@@ -181,13 +193,20 @@ class TestNamespacePreservation:
 
     @pytest.mark.asyncio
     async def test_namespace_only_on_done_event(self):
-        # Hypothetical: Copilot attaches namespace only on output_item.done,
-        # not on added. The fallback path must catch this.
+        # This is the actual production wire shape: Copilot CAPI attaches
+        # namespace ONLY on output_item.done, NOT on output_item.added (which
+        # arrives before the model has decided which namespaced tool to invoke).
+        # We must defer emission until output_item.done so the field is present.
         events = [
             {
                 "type": "response.output_item.added",
                 "output_index": 0,
                 "item": {"type": "function_call", "call_id": "c1", "name": "x"},
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "output_index": 0,
+                "arguments": "{}",
             },
             {
                 "type": "response.output_item.done",
@@ -224,13 +243,80 @@ class TestNamespacePreservation:
                 "output_index": 0,
                 "arguments": '{"city":"NYC"}',
             },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "weather",
+                    "arguments": '{"city":"NYC"}',
+                },
+            },
             {"type": "response.completed", "response": {"status": "completed"}},
         ]
         provider = _make_provider_with_stream(_sse_lines(events))
         chunks = await _collect(provider)
         tool_chunks = [c for c in chunks if c.tool_call is not None]
+        assert len(tool_chunks) == 1
         assert tool_chunks[0].tool_call is not None
         assert tool_chunks[0].tool_call.namespace is None
+
+    @pytest.mark.asyncio
+    async def test_emission_deferred_until_output_item_done(self):
+        # Reproduction of the v0.3.9 production bug: arguments.done fires
+        # BEFORE output_item.done, and Copilot only puts namespace on
+        # output_item.done. Emitting on arguments.done loses namespace and
+        # the next turn 400s with ``Missing namespace for function_call 'X'``.
+        events = [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "call_id": "call_late_ns",
+                    "name": "execute_query",
+                },  # no namespace yet
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "output_index": 0,
+                "delta": '{"query":',
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "output_index": 0,
+                "delta": '"x"}',
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "output_index": 0,
+                "arguments": '{"query":"x"}',
+            },  # still no namespace; we MUST NOT emit here
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "call_id": "call_late_ns",
+                    "name": "execute_query",
+                    "namespace": "mcp__kusto_mcp__",
+                    "arguments": '{"query":"x"}',
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+        chunks = await _collect(provider)
+        tool_chunks = [c for c in chunks if c.tool_call is not None]
+        assert len(tool_chunks) == 1, (
+            f"expected exactly one emission deferred to output_item.done, got {len(tool_chunks)}"
+        )
+        tc = tool_chunks[0].tool_call
+        assert tc is not None
+        assert tc.name == "execute_query"
+        assert tc.namespace == "mcp__kusto_mcp__"
+        assert tc.arguments == '{"query":"x"}'
 
 
 class TestUnknownEventNoise:

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Root cause (the v0.3.8/v0.3.9 misses)

Copilot CAPI streams function_call SSE events in this order:

1. `response.output_item.added` (no namespace yet)
2. `response.function_call_arguments.delta` × N
3. `response.function_call_arguments.done`
4. `response.output_item.done` ← **`namespace` field is ONLY here**

Verified against codex's test fixture `ev_function_call_with_namespace` in [`codex-rs/core/tests/common/responses.rs:829-844`](https://github.com/openai/codex/blob/main/codex-rs/core/tests/common/responses.rs#L829-L844).

The streaming parser was emitting `ResponsesToolCall` on event #3 and `pop()`'ing the entry from `pending_fcs`. When event #4 arrived with the namespace, the fallback `if fc is not None` branch in `output_item.done` never fired (entry already popped). v0.3.8 added a fallback path that read namespace from the bookkeeping dict instead of the wire — but the bookkeeping dict never had it because `output_item.added` (where we'd captured it) doesn't carry the field either.

## Fix

- `function_call_arguments.done` no longer pops the bookkeeping entry and no longer emits — it just buffers the final arguments string.
- `output_item.done` is now the single emission point for all function_calls. It reads namespace + canonical arguments + identity from the wire item, falling back to the bookkeeping dict only for sparse fields.
- New regression test reproduces the exact production SSE order that v0.3.8 and v0.3.9 both missed (would fail on master).

## Test plan

- [x] `uv run pytest tests/ -v` — 769 passing (was 768; +1 ordering regression test)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — clean
- [ ] Deploy v0.3.10 to OpenClaw and verify Kusto MCP `execute_query` round-trips without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)