### PR TITLE
fix(schemas): allow extra fields on Responses input models so MCP namespace survives (v0.3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.11 (2026-05-13)
+
+### Fixes
+
+- **MCP `function_call` round-trips finally work end-to-end (Kusto, ado-mcp, context7, …).** v0.3.8/9/10 each tried to preserve the `namespace` field along the assistant→model→assistant path, and each failed because the field was already gone by the time their fix-points executed. The actual root cause was upstream of every previous fix: `ResponsesFunctionCallInput` in `schemas/responses.py` is a Pydantic v2 `BaseModel`, which **silently drops unknown fields by default**. When Codex CLI POSTed a `function_call` item with `{type, call_id, name, arguments, status, namespace}`, FastAPI parsed it through that schema and the `namespace` field was discarded *before* `convert_input_to_internal` ever saw it. Every "namespace preservation" added in v0.3.8/9/10 was reading from a dict that had already been stripped at the request boundary. Fix: add `model_config = ConfigDict(extra="allow")` to `ResponsesFunctionCallInput` (and `ResponsesFunctionCallOutput` for symmetry), plus declare `namespace: str | None = None` explicitly so it shows up in `model_dump()`. Three new schema-level regression tests (`test_pydantic_input_model_preserves_namespace`, `test_pydantic_input_model_preserves_unknown_extras`, `test_responses_request_preserves_namespace_through_full_parse`) drive the schema directly — these would have caught the bug in v0.3.8 if they'd existed.
+  - Lesson worth keeping: when a Pydantic schema sits on a request boundary, ALL field-preservation tests must drive the schema, not bypass it. Calling `convert_input_to_internal` with a hand-built dict (as the v0.3.8 tests did) skipped the very layer that was dropping the field.
+
+---
+
 ## v0.3.10 (2026-05-13)
 
 ### Fixes
@@ -11,6 +20,8 @@ All notable changes to Router-Maestro are documented here.
 - **MCP `function_call` round-trips no longer drop the `namespace` field mid-stream.** v0.3.8 added namespace preservation on the dataclass and v0.3.9 stopped dropping the namespace tool registry, but Kusto MCP still 400'd with `Missing namespace for function_call 'execute_query'. It does not exist in the default namespace. Round-trip the model's function_call item with its namespace field included.` The remaining bug was in the SSE event ordering inside `copilot.py`: Copilot CAPI sends function_call events in the order `output_item.added` → `function_call_arguments.delta` × N → `function_call_arguments.done` → `output_item.done`, and the **`namespace` field is only present on the final `output_item.done` event** (matching codex's `ev_function_call_with_namespace` test fixture in `codex-rs/core/tests/common/responses.rs:829-844`). The streaming parser was emitting the `ResponsesToolCall` on `function_call_arguments.done` and popping the bookkeeping entry, so when `output_item.done` arrived with the namespace, the fallback `if fc is not None` branch never ran. Emission is now deferred to `output_item.done` for all function_call items, with the in-progress dict kept alive (`pending_fcs.get` instead of `pop`) on `function_call_arguments.done`. The namespace, arguments, and item identity all come from the canonical `output_item.done` payload, with the bookkeeping dict only used as a fallback for sparse items. A new regression test (`test_emission_deferred_until_output_item_done`) reproduces the exact production wire shape that v0.3.8 and v0.3.9 missed.
 
 ---
+
+## v0.3.9 (2026-05-13)
 
 ### Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.10"
+version = "0.3.11"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"

--- a/src/router_maestro/server/schemas/responses.py
+++ b/src/router_maestro/server/schemas/responses.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # ============================================================================
 # Input Types
@@ -28,7 +28,16 @@ class ResponsesInputMessage(BaseModel):
 
 
 class ResponsesFunctionCallInput(BaseModel):
-    """A function call from a previous assistant response."""
+    """A function call from a previous assistant response.
+
+    ``extra="allow"`` is critical: Codex echoes back upstream-emitted fields
+    (notably ``namespace`` for MCP-routed tools like ``kusto/execute_query``)
+    that this schema doesn't enumerate. Without ``allow``, Pydantic silently
+    drops them at the FastAPI request boundary and Copilot CAPI 400s the next
+    turn with ``Missing namespace for function_call 'X'`` (v0.3.8/9/10 bug).
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     type: str = "function_call"
     id: str | None = None
@@ -36,10 +45,16 @@ class ResponsesFunctionCallInput(BaseModel):
     name: str
     arguments: str
     status: str = "completed"
+    # MCP namespace echoed back from a prior turn — required by Copilot CAPI
+    # when the original ``function_call`` was emitted with a namespace, e.g.
+    # ``mcp__kusto_mcp__``. Declared explicitly so it survives ``model_dump``.
+    namespace: str | None = None
 
 
 class ResponsesFunctionCallOutput(BaseModel):
     """Output/result from a function call execution."""
+
+    model_config = ConfigDict(extra="allow")
 
     type: str = "function_call_output"
     call_id: str

--- a/tests/test_responses_input_conversion.py
+++ b/tests/test_responses_input_conversion.py
@@ -13,6 +13,10 @@ These tests pin the input-side behavior down.
 """
 
 from router_maestro.server.routes.responses import convert_input_to_internal
+from router_maestro.server.schemas.responses import (
+    ResponsesFunctionCallInput,
+    ResponsesRequest,
+)
 
 
 def test_function_call_namespace_preserved():
@@ -70,3 +74,67 @@ def test_function_call_explicit_none_namespace_omitted():
     )
     assert isinstance(items, list)
     assert "namespace" not in items[0]
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema-level regression tests (v0.3.10 root cause)
+# ---------------------------------------------------------------------------
+#
+# The convert_input_to_internal tests above bypass Pydantic. The actual
+# v0.3.8/9/10 bug was that ``ResponsesFunctionCallInput`` silently dropped
+# ``namespace`` *before* convert_input_to_internal ever saw it because
+# Pydantic v2 ignores extra fields by default. These tests pin the schema
+# down so a future refactor can't strip the field again.
+
+
+def test_pydantic_input_model_preserves_namespace():
+    m = ResponsesFunctionCallInput(
+        type="function_call",
+        call_id="c1",
+        name="execute_query",
+        arguments="{}",
+        namespace="mcp__kusto_mcp__",
+    )
+    dumped = m.model_dump(exclude_none=True)
+    assert dumped["namespace"] == "mcp__kusto_mcp__"
+
+
+def test_pydantic_input_model_preserves_unknown_extras():
+    # extra="allow" lets future Copilot fields (tool_metadata, etc.) survive
+    # without us having to ship a release for each one.
+    m = ResponsesFunctionCallInput(
+        type="function_call",
+        call_id="c1",
+        name="x",
+        arguments="{}",
+        tool_metadata={"key": "v"},
+    )
+    dumped = m.model_dump(exclude_none=True)
+    assert dumped["tool_metadata"] == {"key": "v"}
+
+
+def test_responses_request_preserves_namespace_through_full_parse():
+    # End-to-end mirror of how FastAPI parses the Codex request body.
+    req = ResponsesRequest(
+        model="gpt-5.5",
+        input=[
+            {
+                "type": "function_call",
+                "call_id": "call_kusto_1",
+                "name": "execute_query",
+                "namespace": "mcp__kusto_mcp__",
+                "arguments": '{"query":"x"}',
+                "status": "completed",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_kusto_1",
+                "output": "ok",
+            },
+        ],
+    )
+    items = convert_input_to_internal(req.input)
+    fc = items[0]
+    assert fc["type"] == "function_call"
+    assert fc["namespace"] == "mcp__kusto_mcp__"
+    assert fc["call_id"] == "call_kusto_1"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.10"
+version = "0.3.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Root cause (the v0.3.8/9/10 misses, finally)

\`ResponsesFunctionCallInput\` in \`src/router_maestro/server/schemas/responses.py\` was a Pydantic v2 \`BaseModel\` with no \`extra="allow"\` config. Pydantic v2 silently drops unknown fields by default.

When Codex CLI POSTed a function_call item with \`{type, call_id, name, arguments, status, namespace}\`, FastAPI parsed it through that schema and \`namespace\` was discarded **before \`convert_input_to_internal\` ever saw it**. Every "namespace preservation" added in v0.3.8/9/10 was reading from a dict that had already been stripped at the request boundary.

Verified by repro:
\`\`\`python
>>> ResponsesFunctionCallInput(call_id='c1', name='execute_query', arguments='{}', namespace='kusto').model_dump(exclude_none=True)
{'type': 'function_call', 'call_id': 'c1', 'name': 'execute_query', 'arguments': '{}', 'status': 'completed'}  # namespace gone
\`\`\`

## Fix

- \`model_config = ConfigDict(extra="allow")\` on \`ResponsesFunctionCallInput\` (and \`ResponsesFunctionCallOutput\` for symmetry)
- Explicit \`namespace: str | None = None\` field declaration so it shows up in \`model_dump()\`

## Tests

Three new schema-level regression tests that drive the Pydantic layer directly — these would have caught the bug in v0.3.8 if they'd existed:

- \`test_pydantic_input_model_preserves_namespace\`
- \`test_pydantic_input_model_preserves_unknown_extras\`
- \`test_responses_request_preserves_namespace_through_full_parse\`

The previous \`convert_input_to_internal\`-based tests bypassed the very layer that was dropping the field. Lesson worth keeping: when a Pydantic schema sits on a request boundary, ALL field-preservation tests must drive the schema, not bypass it.

## Test plan

- [x] \`uv run pytest tests/ -v\` — 772 passing (was 769; +3 schema-level regression tests)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run ruff format src/ tests/\` — clean
- [x] Hot-patched on OpenClaw and confirmed Kusto MCP \`execute_query\` round-trips without 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)