### PR TITLE
fix(responses): preserve reasoning round-trip and xhigh on /responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.11"
+version = "0.3.12"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.11"
+__version__ = "0.3.12"

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -195,6 +195,14 @@ class ResponsesResponse:
     tool_calls: list[ResponsesToolCall] | None = None
     # Reasoning summary text aggregated from /responses' "reasoning" output items.
     thinking: str | None = None
+    # Upstream reasoning item id (e.g. ``rs_…``). Must round-trip back to
+    # Copilot as the reasoning item's ``id`` because the encrypted blob below
+    # was signed against this id; pairing the blob with a different id 400s
+    # with ``Encrypted content could not be decrypted``.
+    thinking_id: str | None = None
+    # Upstream encrypted reasoning blob (``encrypted_content``). Round-trips
+    # alongside ``thinking_id`` so Copilot can verify and continue chain-of-
+    # thought across turns.
     thinking_signature: str | None = None
     # Upstream completion status mapped to chat-style finish reason
     # ("stop" | "length" | "content_filter" | "tool_calls"). None means
@@ -214,6 +222,9 @@ class ResponsesStreamChunk:
     # Incremental reasoning summary text delta (from
     # ``response.reasoning_summary_text.delta`` events).
     thinking: str | None = None
+    # Upstream reasoning item id (carried separately from the encrypted blob —
+    # see ResponsesResponse.thinking_id).
+    thinking_id: str | None = None
     thinking_signature: str | None = None
 
 

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -46,6 +46,12 @@ _BENIGN_UPSTREAM_EVENTS = frozenset(
         "response.content_part.added",
         "response.content_part.done",
         "response.output_text.done",
+        # Reasoning ``part`` events are pure structure envelopes (no text
+        # payload — that arrives via ``reasoning_summary_text.delta``). The
+        # route synthesizes its own added/done events from the deltas we DO
+        # consume, mirroring how ``content_part.*`` is handled for messages.
+        "response.reasoning_summary_part.added",
+        "response.reasoning_summary_part.done",
     }
 )
 _BENIGN_DONE_ITEM_TYPES = frozenset({"message"})

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -876,12 +876,31 @@ class CopilotProvider(BaseProvider):
             payload["tool_choice"] = request.tool_choice
         if request.parallel_tool_calls is not None:
             payload["parallel_tool_calls"] = request.parallel_tool_calls
-        upstream_effort = downgrade_for_upstream(request.reasoning_effort)
-        if upstream_effort is not None:
-            if request.reasoning_effort == "xhigh":
+        # Catalog-driven path: trust whatever Copilot's
+        # ``capabilities.supports.reasoning_effort`` advertises for this model.
+        # Mirrors the chat path at copilot.py:147-164 — both paths must agree,
+        # otherwise codex+gpt-5.x silently runs at ``high`` while chat runs at
+        # ``xhigh``. Falls back to ``downgrade_for_upstream`` when the catalog
+        # is cold (first request after restart) so we never block on a fetch.
+        catalog = self._catalog_effort_values(request.model)
+        if catalog is not None:
+            if not catalog:
+                upstream_effort: str | None = None
+            else:
+                desired = request.reasoning_effort
+                if desired is None:
+                    upstream_effort = None
+                else:
+                    upstream_effort = _pick_closest_effort(desired, catalog)
+        else:
+            upstream_effort = downgrade_for_upstream(request.reasoning_effort)
+            if request.reasoning_effort == "xhigh" and upstream_effort == "high":
                 logger.warning(
-                    "Copilot Responses does not accept reasoning_effort=xhigh; downgrading to high"
+                    "Copilot Responses catalog cold for %s; "
+                    "downgrading reasoning_effort=xhigh to high as a precaution",
+                    request.model,
                 )
+        if upstream_effort is not None:
             # ``summary: auto`` opts in to reasoning_summary_text events so we
             # can forward chain-of-thought as Anthropic thinking blocks.
             payload["reasoning"] = {"effort": upstream_effort, "summary": "auto"}
@@ -909,25 +928,31 @@ class CopilotProvider(BaseProvider):
                         content += content_item.get("text", "")
         return content
 
-    def _extract_reasoning(self, data: dict) -> tuple[str | None, str | None]:
-        """Extract aggregated reasoning summary text and signature.
+    def _extract_reasoning(self, data: dict) -> tuple[str | None, str | None, str | None]:
+        """Extract aggregated reasoning summary text, upstream id, and blob.
 
-        Returns ``(thinking_text, thinking_signature)``. Both are ``None``
-        when the response has no reasoning output.
+        Returns ``(thinking_text, thinking_id, thinking_signature)``. All
+        three are ``None`` when the response has no reasoning output. The
+        ``id`` and the ``encrypted_content`` blob must be round-tripped
+        together — the blob is signed against its id, so pairing it with a
+        locally-generated id 400s the next turn.
         """
         text_parts: list[str] = []
-        signature: str | None = None
+        upstream_id: str | None = None
+        encrypted: str | None = None
         for output in data.get("output", []):
             if output.get("type") != "reasoning":
                 continue
-            if signature is None:
-                signature = output.get("id")
+            if upstream_id is None:
+                upstream_id = output.get("id")
+            if encrypted is None:
+                encrypted = output.get("encrypted_content")
             for summary in output.get("summary", []) or []:
                 if isinstance(summary, dict):
                     chunk = summary.get("text") or ""
                     if chunk:
                         text_parts.append(chunk)
-        return ("".join(text_parts) or None, signature)
+        return ("".join(text_parts) or None, upstream_id, encrypted)
 
     def _extract_tool_calls(self, data: dict) -> list[ResponsesToolCall]:
         """Extract tool calls from Responses API response.
@@ -971,7 +996,7 @@ class CopilotProvider(BaseProvider):
 
             content = self._extract_response_content(data)
             tool_calls = self._extract_tool_calls(data)
-            thinking, thinking_sig = self._extract_reasoning(data)
+            thinking, thinking_id, thinking_sig = self._extract_reasoning(data)
 
             usage = None
             if "usage" in data:
@@ -1004,6 +1029,7 @@ class CopilotProvider(BaseProvider):
                 usage=usage,
                 tool_calls=tool_calls if tool_calls else None,
                 thinking=thinking,
+                thinking_id=thinking_id,
                 thinking_signature=thinking_sig,
                 finish_reason=finish_reason,
             )
@@ -1102,7 +1128,17 @@ class CopilotProvider(BaseProvider):
                         delta = data.get("delta", "")
                         if delta:
                             received_reasoning_summary = True
-                            yield ResponsesStreamChunk(content="", thinking=delta)
+                            # Surface upstream item_id (e.g. ``rs_…``) on
+                            # every delta so the route can use it as the
+                            # reasoning item's id. Pairing the upstream-signed
+                            # ``encrypted_content`` blob with a different id
+                            # 400s the next turn with ``Encrypted content
+                            # could not be decrypted``.
+                            yield ResponsesStreamChunk(
+                                content="",
+                                thinking=delta,
+                                thinking_id=data.get("item_id"),
+                            )
 
                     elif event_type == "response.reasoning_summary_text.done":
                         # Don't yield ``thinking_signature=item_id`` here. The
@@ -1263,15 +1299,35 @@ class CopilotProvider(BaseProvider):
                                 bool(item.get("encrypted_content")),
                                 item.get("id"),
                             )
+                            upstream_id = item.get("id")
+                            encrypted_blob = item.get("encrypted_content")
                             if not received_reasoning_summary:
                                 for summary in summary_list:
                                     if isinstance(summary, dict):
                                         text = summary.get("text") or ""
                                         if text:
-                                            yield ResponsesStreamChunk(content="", thinking=text)
-                            sig = item.get("encrypted_content") or item.get("id")
-                            if sig:
-                                yield ResponsesStreamChunk(content="", thinking_signature=sig)
+                                            # Carry upstream id on each
+                                            # synthesized chunk so the route
+                                            # uses it as the reasoning item's
+                                            # id from the very first delta.
+                                            yield ResponsesStreamChunk(
+                                                content="",
+                                                thinking=text,
+                                                thinking_id=upstream_id,
+                                            )
+                            # Emit the upstream id and the encrypted blob
+                            # separately so the route can pair them on the
+                            # reasoning output item it forwards to Codex. The
+                            # blob is only valid against its own id; using a
+                            # locally-generated id (or worse, treating the id
+                            # as the signature) 400s the next turn with
+                            # ``Encrypted content could not be decrypted``.
+                            if upstream_id or encrypted_blob:
+                                yield ResponsesStreamChunk(
+                                    content="",
+                                    thinking_id=upstream_id,
+                                    thinking_signature=encrypted_blob,
+                                )
                         elif item.get("type") == "tool_search_call":
                             # Forward as kind="tool_search" so the route emits
                             # an actual tool_search_call wire item — codex's

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -1105,9 +1105,16 @@ class CopilotProvider(BaseProvider):
                             yield ResponsesStreamChunk(content="", thinking=delta)
 
                     elif event_type == "response.reasoning_summary_text.done":
-                        item_id = data.get("item_id")
-                        if item_id:
-                            yield ResponsesStreamChunk(content="", thinking_signature=item_id)
+                        # Don't yield ``thinking_signature=item_id`` here. The
+                        # Codex path treats every signature as ``encrypted_content``
+                        # and round-trips it to Copilot, which then 400s with
+                        # ``Encrypted content could not be decrypted`` because
+                        # ``item_id`` is just a local identifier, not the real
+                        # encrypted blob. The real blob arrives later on
+                        # ``output_item.done.item.encrypted_content``; emit the
+                        # signature there so both Codex and Anthropic round-trips
+                        # use the verifiable value.
+                        pass
 
                     # Handle function call output_item.added - start of a new function call
                     elif event_type == "response.output_item.added":

--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -631,6 +631,7 @@ class Router:
             tools=original_request.tools,
             tool_choice=original_request.tool_choice,
             parallel_tool_calls=original_request.parallel_tool_calls,
+            reasoning_effort=original_request.reasoning_effort,
         )
 
     async def _execute_responses_with_fallback(

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -126,12 +126,22 @@ def convert_input_to_internal(
                 # Echoed back from a prior turn — preserve the full shape so
                 # Copilot can correlate chain-of-thought across turns. Mirrors
                 # vscode-copilot-chat responsesApi.ts:216-230 (extractThinkingData).
+                #
+                # Codex CLI's ``ResponseItem::Reasoning`` marks ``id`` as
+                # ``#[serde(default, skip_serializing)]`` (see openai/codex
+                # codex-rs/protocol/src/models.rs), so it NEVER sends the id
+                # back on round-trip. Copilot CAPI signs ``encrypted_content``
+                # against the upstream id and rejects (id, blob) pairs that
+                # don't match. Without an id, the blob is unverifiable, so we
+                # MUST strip it — otherwise Copilot 400s with ``Encrypted
+                # content could not be decrypted``. (See openai/codex#17541
+                # and the parallel litellm bug BerriAI/litellm#22189.)
                 reasoning_item: dict[str, Any] = {
                     "type": "reasoning",
                     "id": item.get("id"),
                     "summary": item.get("summary", []) or [],
                 }
-                if item.get("encrypted_content"):
+                if item.get("encrypted_content") and item.get("id"):
                     reasoning_item["encrypted_content"] = item["encrypted_content"]
                 items.append(reasoning_item)
             else:
@@ -307,6 +317,24 @@ async def create_response(request: ResponsesRequest):
         response_id = generate_id("resp")
         output: list[dict[str, Any]] = []
 
+        # Emit the reasoning item BEFORE the message so the (id, blob) pair
+        # round-trips back to Copilot intact. ``thinking_id`` must be the
+        # upstream id (Copilot signs ``thinking_signature`` against it) — see
+        # base.py ResponsesResponse for the rationale.
+        if response.thinking_id or response.thinking:
+            reasoning_item: dict[str, Any] = {
+                "type": "reasoning",
+                "id": response.thinking_id or generate_id("rs"),
+                "summary": (
+                    [{"type": "summary_text", "text": response.thinking}]
+                    if response.thinking
+                    else []
+                ),
+            }
+            if response.thinking_signature:
+                reasoning_item["encrypted_content"] = response.thinking_signature
+            output.append(reasoning_item)
+
         if response.content:
             message_id = generate_id("msg")
             output.append(make_message_item(message_id, response.content))
@@ -352,12 +380,17 @@ class _StreamMessageState:
     current_message_id: str | None = None
     accumulated_content: str = ""
     message_started: bool = False
-    # Reasoning summary state. ``current_reasoning_id`` is the local
-    # ``rs-…`` id we assign; ``upstream_reasoning_id`` is whatever Copilot
-    # sent on ``response.reasoning_summary_text.done`` (we forward it as the
-    # ``encrypted_content`` field so Codex can correlate).
+    # Reasoning summary state. ``current_reasoning_id`` is the upstream
+    # reasoning item id (e.g. ``rs_…``) when Copilot supplies it on the
+    # first ``reasoning_summary_text.delta``, falling back to a locally-
+    # generated ``rs-…`` only if the upstream never sent one.
+    # ``upstream_encrypted_content`` is the verifiable blob from
+    # ``output_item.done.item.encrypted_content``; it is signed against the
+    # upstream id, so the (id, blob) pair MUST round-trip together — pairing
+    # the blob with a local id 400s the next turn with ``Encrypted content
+    # could not be decrypted``.
     current_reasoning_id: str | None = None
-    upstream_reasoning_id: str | None = None
+    upstream_encrypted_content: str | None = None
     accumulated_reasoning: str = ""
     reasoning_started: bool = False
     summary_index: int = 0
@@ -403,8 +436,8 @@ class _StreamMessageState:
             "id": rs_id,
             "summary": [summary_part],
         }
-        if self.upstream_reasoning_id:
-            reasoning_item["encrypted_content"] = self.upstream_reasoning_id
+        if self.upstream_encrypted_content:
+            reasoning_item["encrypted_content"] = self.upstream_encrypted_content
         events = [
             sse_event(
                 {
@@ -438,7 +471,7 @@ class _StreamMessageState:
             self.output_index += 1
         self.reasoning_started = False
         self.current_reasoning_id = None
-        self.upstream_reasoning_id = None
+        self.upstream_encrypted_content = None
         self.accumulated_reasoning = ""
         self.summary_index = 0
         return events
@@ -514,7 +547,12 @@ async def stream_response(
                     for evt in state.close_open_message():
                         yield evt
                 if not state.reasoning_started:
-                    state.current_reasoning_id = generate_id("rs")
+                    # Prefer the upstream reasoning item id (e.g. ``rs_…``)
+                    # supplied on the delta event. Copilot signs the
+                    # encrypted_content blob against this id, so emitting a
+                    # locally-generated id would mismatch the blob and 400
+                    # the next turn.
+                    state.current_reasoning_id = chunk.thinking_id or generate_id("rs")
                     state.reasoning_started = True
                     state.summary_index = 0
                     yield sse_event(
@@ -548,8 +586,15 @@ async def stream_response(
                     }
                 )
 
+            # The upstream id may also arrive separately (e.g. on
+            # output_item.done before any text deltas arrive). Capture it
+            # so close_open_reasoning emits the correct (id, blob) pair.
+            if chunk.thinking_id and state.reasoning_started:
+                if state.current_reasoning_id != chunk.thinking_id:
+                    state.current_reasoning_id = chunk.thinking_id
+
             if chunk.thinking_signature:
-                state.upstream_reasoning_id = chunk.thinking_signature
+                state.upstream_encrypted_content = chunk.thinking_signature
                 for evt in state.close_open_reasoning():
                     yield evt
 

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -247,11 +247,12 @@ async def create_response(request: ResponsesRequest):
     start_time = time.time()
 
     logger.info(
-        "Received responses request: req_id=%s, model=%s, stream=%s, has_tools=%s",
+        "Received responses request: req_id=%s, model=%s, stream=%s, has_tools=%s, reasoning=%s",
         request_id,
         request.model,
         request.stream,
         request.tools is not None,
+        request.reasoning,
     )
 
     model_router = get_router()
@@ -275,7 +276,17 @@ async def create_response(request: ResponsesRequest):
         if effort and effort in VALID_EFFORTS:
             internal_request.reasoning_effort = effort
 
+    pre_rewrite_model = internal_request.model
+    pre_rewrite_effort = internal_request.reasoning_effort
     internal_request = await model_router.rewrite_to_reasoning_variant(internal_request)
+    logger.info(
+        "Reasoning resolved: req_id=%s pre_model=%s pre_effort=%s post_model=%s post_effort=%s",
+        request_id,
+        pre_rewrite_model,
+        pre_rewrite_effort,
+        internal_request.model,
+        internal_request.reasoning_effort,
+    )
 
     if request.stream:
         return sse_streaming_response(

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -485,3 +485,78 @@ class TestThinkingSignatureSource:
         assert sigs == [encrypted_blob], (
             f"expected exactly one signature == encrypted blob, got {sigs!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_upstream_reasoning_id_threaded_through_chunks(self):
+        # The upstream reasoning item id (e.g. ``rs_…``) must surface as
+        # ``thinking_id`` so the route can use it as the reasoning item's
+        # id. Copilot signs ``encrypted_content`` against this id; pairing
+        # the blob with a locally-generated id 400s the next turn with
+        # ``Encrypted content could not be decrypted``.
+        encrypted_blob = "ENC_BLOB_" + "Y" * 200
+        events = [
+            {"type": "response.created", "response": {}},
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs_upstream_xyz",
+                "delta": "planning...",
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs_upstream_xyz",
+                    "encrypted_content": encrypted_blob,
+                    "summary": [{"type": "summary_text", "text": "planning..."}],
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        chunks = await _collect(provider)
+
+        thinking_ids = [c.thinking_id for c in chunks if c.thinking_id]
+        # The upstream id surfaces on the first delta and again on the
+        # output_item.done chunk — both must equal the upstream id (never
+        # a locally-generated ``rs-…``).
+        assert thinking_ids, "expected at least one chunk with thinking_id set"
+        assert all(tid == "rs_upstream_xyz" for tid in thinking_ids), (
+            f"expected all thinking_ids to be the upstream id, got {thinking_ids!r}"
+        )
+
+        # The signature chunk must carry the upstream id AND the blob
+        # together so the route can pair them on the reasoning output item.
+        sig_chunks = [c for c in chunks if c.thinking_signature]
+        assert len(sig_chunks) == 1
+        assert sig_chunks[0].thinking_signature == encrypted_blob
+        assert sig_chunks[0].thinking_id == "rs_upstream_xyz"
+
+    @pytest.mark.asyncio
+    async def test_no_signature_when_upstream_omits_encrypted_content(self):
+        # Defensive: if Copilot ever ships a reasoning item without
+        # ``encrypted_content``, we MUST NOT fall back to ``item.id`` (a
+        # short opaque string) — the codex path would treat it as a blob,
+        # round-trip it, and earn a 400.
+        events = [
+            {"type": "response.created", "response": {}},
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs_no_blob",
+                    "summary": [{"type": "summary_text", "text": "thinking..."}],
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        chunks = await _collect(provider)
+
+        sigs = [c.thinking_signature for c in chunks if c.thinking_signature]
+        assert sigs == [], (
+            f"expected no signatures when upstream omits encrypted_content, got {sigs!r}"
+        )

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -435,3 +435,53 @@ class TestUnknownEventNoise:
             "reasoning_summary_part envelopes leaked into the unknown-event warning: "
             f"{[w.getMessage() for w in warnings]}"
         )
+
+
+class TestThinkingSignatureSource:
+    """The reasoning ``thinking_signature`` must be the upstream encrypted blob.
+
+    Codex round-trips it back to Copilot as ``encrypted_content``; if we emit
+    the local ``item_id`` (a short identifier, not a verifiable blob), Copilot
+    400s the next turn with ``Encrypted content could not be decrypted``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_signature_is_encrypted_blob_not_item_id(self):
+        encrypted_blob = "ENC_BLOB_" + "X" * 200  # stand-in for the real ~2KB blob
+        events = [
+            {"type": "response.created", "response": {}},
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs-upstream-1",
+                "delta": "thinking...",
+            },
+            {
+                "type": "response.reasoning_summary_text.done",
+                "item_id": "rs-upstream-1",
+                "text": "thinking...",
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs-upstream-1",
+                    "encrypted_content": encrypted_blob,
+                    "summary": [{"type": "summary_text", "text": "thinking..."}],
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        chunks = await _collect(provider)
+
+        sigs = [c.thinking_signature for c in chunks if c.thinking_signature]
+        # Exactly one signature must be emitted, and it must be the encrypted
+        # blob — not the local ``item_id``. The previous behavior emitted
+        # ``rs-upstream-1`` first (from summary_text.done), which the route
+        # latched as the final encrypted_content and the encrypted blob
+        # arriving later was silently dropped.
+        assert sigs == [encrypted_blob], (
+            f"expected exactly one signature == encrypted blob, got {sigs!r}"
+        )

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -388,3 +388,50 @@ class TestUnknownEventNoise:
         warnings = [r for r in caplog.records if "unhandled event types" in r.getMessage()]
         assert len(warnings) == 1
         assert "brand_new_event_type_we_dont_know" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_summary_part_events_skipped_from_warning(self, caplog):
+        """``reasoning_summary_part.added/done`` are pure structure envelopes.
+
+        The route synthesizes its own equivalents from the
+        ``reasoning_summary_text.delta`` we already consume — same pattern as
+        ``content_part.*`` for messages. Without the skip, every xhigh request
+        produced a noisy ``unhandled event types`` warning that drowned out
+        genuinely-unknown events.
+        """
+        events = [
+            {"type": "response.created", "response": {}},
+            {
+                "type": "response.reasoning_summary_part.added",
+                "item_id": "rs-1",
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": ""},
+            },
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs-1",
+                "delta": "thinking...",
+            },
+            {
+                "type": "response.reasoning_summary_text.done",
+                "item_id": "rs-1",
+                "text": "thinking...",
+            },
+            {
+                "type": "response.reasoning_summary_part.done",
+                "item_id": "rs-1",
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": "thinking..."},
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+        provider = _make_provider_with_stream(_sse_lines(events))
+
+        with caplog.at_level(logging.WARNING, logger="providers.copilot"):
+            await _collect(provider)
+
+        warnings = [r for r in caplog.records if "unhandled event types" in r.getMessage()]
+        assert warnings == [], (
+            "reasoning_summary_part envelopes leaked into the unknown-event warning: "
+            f"{[w.getMessage() for w in warnings]}"
+        )

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -100,20 +100,78 @@ class TestOpenAIPayloadEffort:
 
 
 class TestCopilotResponsesPayloadEffort:
+    @staticmethod
+    def _seed_catalog(provider: CopilotProvider, model_id: str, allowed: list[str]) -> None:
+        """Prime the model cache so ``_catalog_effort_values`` returns ``allowed``."""
+        from router_maestro.providers.base import ModelInfo
+
+        provider._models_ttl_cache.set(
+            [
+                ModelInfo(
+                    id=model_id,
+                    name=model_id,
+                    provider="github-copilot",
+                    reasoning_effort_values=allowed,
+                )
+            ]
+        )
+
     def test_responses_payload_writes_reasoning(self):
         provider = CopilotProvider()
+        self._seed_catalog(provider, "gpt-5", ["low", "medium", "high"])
         req = ResponsesRequest(model="gpt-5", input="hi", reasoning_effort="high")
         payload = provider._build_responses_payload(req)
         assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
 
-    def test_responses_payload_downgrades_xhigh(self):
+    def test_responses_payload_preserves_xhigh_when_catalog_advertises_it(self):
+        # Regression: chat path is catalog-driven and preserves ``xhigh`` for
+        # gpt-5.5 (catalog: ['none','low','medium','high','xhigh']). Responses
+        # path used to unconditionally downgrade — codex+gpt-5.5 silently ran
+        # at ``high`` while chat ran at ``xhigh``. Both paths must agree.
         provider = CopilotProvider()
-        req = ResponsesRequest(model="gpt-5", input="hi", reasoning_effort="xhigh")
+        self._seed_catalog(provider, "gpt-5.5", ["none", "low", "medium", "high", "xhigh"])
+        req = ResponsesRequest(model="gpt-5.5", input="hi", reasoning_effort="xhigh")
+        payload = provider._build_responses_payload(req)
+        assert payload["reasoning"] == {"effort": "xhigh", "summary": "auto"}
+
+    def test_responses_payload_picks_closest_when_xhigh_unsupported(self):
+        # gpt-5-mini's catalog tops out at ``high``. Asking for ``xhigh`` must
+        # land on ``high`` (not silently fall back to nothing).
+        provider = CopilotProvider()
+        self._seed_catalog(provider, "gpt-5-mini", ["low", "medium", "high"])
+        req = ResponsesRequest(model="gpt-5-mini", input="hi", reasoning_effort="xhigh")
+        payload = provider._build_responses_payload(req)
+        assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
+
+    def test_responses_payload_clamps_to_catalog_for_clamped_models(self):
+        # claude-opus-4.7's catalog only advertises ``medium``. Asking for
+        # ``xhigh`` must clamp down to ``medium`` — same as the chat path.
+        provider = CopilotProvider()
+        self._seed_catalog(provider, "claude-opus-4.7", ["medium"])
+        req = ResponsesRequest(model="claude-opus-4.7", input="hi", reasoning_effort="xhigh")
+        payload = provider._build_responses_payload(req)
+        assert payload["reasoning"] == {"effort": "medium", "summary": "auto"}
+
+    def test_responses_payload_omits_when_catalog_says_no_reasoning(self):
+        # An empty catalog list means "no reasoning supported" — emit nothing.
+        provider = CopilotProvider()
+        self._seed_catalog(provider, "gpt-4o", [])
+        req = ResponsesRequest(model="gpt-4o", input="hi", reasoning_effort="high")
+        payload = provider._build_responses_payload(req)
+        assert "reasoning" not in payload
+
+    def test_responses_payload_falls_back_to_downgrade_when_catalog_cold(self):
+        # Cold cache (no list_models call yet) — fall back to the
+        # downgrade_for_upstream heuristic so we never block on a fetch.
+        provider = CopilotProvider()
+        # No _seed_catalog call → cache is cold.
+        req = ResponsesRequest(model="gpt-5.5", input="hi", reasoning_effort="xhigh")
         payload = provider._build_responses_payload(req)
         assert payload["reasoning"] == {"effort": "high", "summary": "auto"}
 
     def test_responses_payload_omits_when_unset(self):
         provider = CopilotProvider()
+        self._seed_catalog(provider, "gpt-5", ["low", "medium", "high", "xhigh"])
         payload = provider._build_responses_payload(ResponsesRequest(model="gpt-5", input="hi"))
         assert "reasoning" not in payload
 

--- a/tests/test_responses_route_wire_shape.py
+++ b/tests/test_responses_route_wire_shape.py
@@ -199,6 +199,86 @@ class TestFunctionCallWireShape:
         assert done[0]["item"]["arguments"] == '{"location": "NYC"}'
 
 
+class TestReasoningRoundTrip:
+    """The reasoning output_item must preserve the upstream (id, blob) pair.
+
+    Copilot signs ``encrypted_content`` against the upstream reasoning item
+    id (e.g. ``rs_…``). When Codex round-trips the reasoning item back on
+    the next turn, the (id, blob) pair has to match what Copilot emitted —
+    otherwise the next request 400s with ``Encrypted content could not be
+    decrypted``. The route MUST use ``chunk.thinking_id`` as the item id,
+    NOT a locally-generated ``rs-…`` slug.
+    """
+
+    @pytest.mark.asyncio
+    async def test_upstream_reasoning_id_used_on_output_item(self):
+        upstream_id = "rs_upstream_xyz_12345"
+        encrypted_blob = "ENC_BLOB_" + "Z" * 200
+        events = await _drive(
+            [
+                # First reasoning delta — carries upstream id.
+                ResponsesStreamChunk(content="", thinking="planning...", thinking_id=upstream_id),
+                # Final reasoning chunk — id + encrypted blob from
+                # output_item.done in the upstream stream.
+                ResponsesStreamChunk(
+                    content="",
+                    thinking_id=upstream_id,
+                    thinking_signature=encrypted_blob,
+                ),
+                ResponsesStreamChunk(content="hello", finish_reason="stop"),
+            ]
+        )
+
+        # output_item.added for reasoning must carry the upstream id, not a
+        # locally-generated ``rs-…`` slug.
+        added_reasoning = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.added"
+            and e.get("item", {}).get("type") == "reasoning"
+        ]
+        assert len(added_reasoning) == 1
+        assert added_reasoning[0]["item"]["id"] == upstream_id
+
+        # output_item.done must pair the upstream id with the encrypted blob.
+        done_reasoning = [
+            e
+            for e in events
+            if e.get("type") == "response.output_item.done"
+            and e.get("item", {}).get("type") == "reasoning"
+        ]
+        assert len(done_reasoning) == 1
+        item = done_reasoning[0]["item"]
+        assert item["id"] == upstream_id, (
+            f"reasoning item id must be the upstream id, got {item['id']!r} "
+            f"(this would 400 the next turn with 'Encrypted content could not be decrypted')"
+        )
+        assert item["encrypted_content"] == encrypted_blob
+
+    @pytest.mark.asyncio
+    async def test_reasoning_summary_text_events_use_upstream_id(self):
+        # The summary_text.delta / .done events must reference the same
+        # upstream id (codex correlates them by item_id).
+        upstream_id = "rs_upstream_abc"
+        events = await _drive(
+            [
+                ResponsesStreamChunk(content="", thinking="thinking...", thinking_id=upstream_id),
+                ResponsesStreamChunk(
+                    content="",
+                    thinking_id=upstream_id,
+                    thinking_signature="BLOB",
+                ),
+                ResponsesStreamChunk(content="ok", finish_reason="stop"),
+            ]
+        )
+
+        for evt in events:
+            if evt.get("type", "").startswith("response.reasoning_summary"):
+                assert evt.get("item_id") == upstream_id, (
+                    f"{evt['type']} should reference upstream id, got {evt.get('item_id')!r}"
+                )
+
+
 class TestFunctionCallNamespaceWireShape:
     """Namespaced function_calls must emit `namespace` field downstream
     so Codex can echo it back next turn — Copilot 400s otherwise."""

--- a/tests/test_router_advanced.py
+++ b/tests/test_router_advanced.py
@@ -517,6 +517,24 @@ class TestRouterCreateRequestWithModel:
         assert new_request.max_output_tokens == 1000
         assert new_request.instructions == "Be helpful"
 
+    def test_create_responses_request_preserves_reasoning_effort(self, router):
+        """reasoning_effort must survive provider/fallback rebuild.
+
+        Regression: codex sent ``reasoning: {effort: xhigh}`` on /responses,
+        the route set it on the internal request, but the rebuild dropped it
+        before the Copilot provider saw it — so ``_build_responses_payload``
+        omitted the ``reasoning`` block entirely and Copilot ran at default
+        (medium) instead of xhigh.
+        """
+        original = ResponsesRequest(
+            model="github-copilot/gpt-5.5",
+            input="Hello",
+            reasoning_effort="xhigh",
+        )
+        new_request = router._create_responses_request_with_model(original, "gpt-5.5")
+
+        assert new_request.reasoning_effort == "xhigh"
+
     def test_create_chat_request_with_tools(self, router):
         """Test creating a ChatRequest preserving tools."""
         original = ChatRequest(

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.11"
+version = "0.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Three bugs that broke `codex+gpt-5.x` with `xhigh`:

1. **Encrypted reasoning blob round-trip 400'd** with `Encrypted content could not be decrypted`. Codex CLI's `ResponseItem::Reasoning` marks `id` as `#[serde(default, skip_serializing)]`, so it never sends the id back. Copilot signs `encrypted_content` against the upstream id; pairing the blob with no id (or a locally-generated `rs-...` id) fails signature verification. **Fix:** thread upstream `thinking_id` separately through `ResponsesStreamChunk`/`ResponsesResponse`, use it as the reasoning item id, and strip `encrypted_content` from input items missing an id (the pair is unverifiable).

2. **`xhigh` was unconditionally downgraded to `high`** on the `/responses` path even though Copilot's gateway advertises `xhigh` as a `supported_value` for `gpt-5.x`. The chat path already preserved `xhigh` — both paths must agree, otherwise `codex+gpt-5.x` silently ran at `high` while chat ran at `xhigh`. **Fix:** make `/responses` path catalog-driven (matches chat path at `copilot.py:147-164`), with `downgrade_for_upstream` as cold-cache fallback.

3. **Stream path emitted reasoning items with locally-generated `rs-...` ids** instead of the upstream `rs_...` id. **Fix:** prefer `chunk.thinking_id` from `reasoning_summary_text.delta` and update late-arriving ids before `close_open_reasoning` emits the `(id, blob)` pair.

## Test plan

- [x] All 783 existing tests pass
- [x] New: `test_upstream_reasoning_id_threaded_through_chunks` (Copilot provider)
- [x] New: `test_no_signature_when_upstream_omits_encrypted_content` (defensive)
- [x] New: `TestReasoningRoundTrip` (route wire shape — upstream id flows through `output_item.added`/`done`)
- [x] New: `test_responses_payload_preserves_xhigh_when_catalog_advertises_it`
- [x] New: `test_responses_payload_picks_closest_when_xhigh_unsupported` (gpt-5-mini)
- [x] New: `test_responses_payload_clamps_to_catalog_for_clamped_models` (claude-opus-4.7)
- [x] New: `test_responses_payload_omits_when_catalog_says_no_reasoning`
- [x] New: `test_responses_payload_falls_back_to_downgrade_when_catalog_cold`
- [x] Verified live on production: 11/11 `/responses` 200 OK after deploy, 0 `Encrypted content` errors, upstream payload `'reasoning': {'effort': 'xhigh', 'summary': 'auto'}`, `reasoning_tokens` 251–516

Bumps version to `0.3.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)