### PR TITLE
fix: propagate upstream usage metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ venv.bak/
 # IDE
 .idea/
 .vscode/
+.codex/
 .claude/
 .serena/
 *.swp

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -602,6 +602,7 @@ class CopilotProvider(BaseProvider):
             "messages": messages,
             "temperature": request.temperature,
             "stream": True,
+            "stream_options": {"include_usage": True},
         }
         if request.max_tokens:
             payload["max_tokens"] = request.max_tokens

--- a/src/router_maestro/server/routes/chat.py
+++ b/src/router_maestro/server/routes/chat.py
@@ -30,6 +30,20 @@ logger = get_logger("server.routes.chat")
 router = APIRouter()
 
 
+def make_chat_usage(raw_usage: dict | None) -> ChatCompletionUsage | None:
+    """Create OpenAI chat usage while preserving upstream detail fields."""
+    if not raw_usage:
+        return None
+
+    return ChatCompletionUsage(
+        prompt_tokens=raw_usage.get("prompt_tokens", 0),
+        completion_tokens=raw_usage.get("completion_tokens", 0),
+        total_tokens=raw_usage.get("total_tokens", 0),
+        prompt_tokens_details=raw_usage.get("prompt_tokens_details"),
+        completion_tokens_details=raw_usage.get("completion_tokens_details"),
+    )
+
+
 @router.post("/api/openai/v1/chat/completions")
 async def chat_completions(request: ChatCompletionRequest):
     """Handle chat completion requests."""
@@ -89,13 +103,7 @@ async def chat_completions(request: ChatCompletionRequest):
     try:
         response, provider_name = await model_router.chat_completion(chat_request)
 
-        usage = None
-        if response.usage:
-            usage = ChatCompletionUsage(
-                prompt_tokens=response.usage.get("prompt_tokens", 0),
-                completion_tokens=response.usage.get("completion_tokens", 0),
-                total_tokens=response.usage.get("total_tokens", 0),
-            )
+        usage = make_chat_usage(response.usage)
 
         # Build response message with optional tool_calls
         response_tool_calls = None
@@ -147,6 +155,7 @@ async def stream_response(model_router: Router, request: ChatRequest) -> AsyncGe
         yield f"data: {initial_chunk.model_dump_json()}\n\n"
 
         async for chunk in stream:
+            usage = make_chat_usage(chunk.usage)
             if chunk.content or chunk.tool_calls:
                 chunk_response = ChatCompletionChunk(
                     id=response_id,
@@ -162,8 +171,18 @@ async def stream_response(model_router: Router, request: ChatRequest) -> AsyncGe
                             finish_reason=None,
                         )
                     ],
+                    usage=usage,
                 )
                 yield f"data: {chunk_response.model_dump_json()}\n\n"
+            elif usage:
+                usage_chunk = ChatCompletionChunk(
+                    id=response_id,
+                    created=created,
+                    model=request.model,
+                    choices=[],
+                    usage=usage,
+                )
+                yield f"data: {usage_chunk.model_dump_json()}\n\n"
 
             if chunk.finish_reason:
                 final_chunk = ChatCompletionChunk(
@@ -177,6 +196,7 @@ async def stream_response(model_router: Router, request: ChatRequest) -> AsyncGe
                             finish_reason=chunk.finish_reason,
                         )
                     ],
+                    usage=usage,
                 )
                 yield f"data: {final_chunk.model_dump_json()}\n\n"
 

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -312,6 +312,8 @@ async def create_response(request: ResponsesRequest):
                 input_tokens=response.usage.get("input_tokens", 0),
                 output_tokens=response.usage.get("output_tokens", 0),
                 total_tokens=response.usage.get("total_tokens", 0),
+                input_tokens_details=response.usage.get("input_tokens_details"),
+                output_tokens_details=response.usage.get("output_tokens_details"),
             )
 
         response_id = generate_id("resp")

--- a/src/router_maestro/server/schemas/openai.py
+++ b/src/router_maestro/server/schemas/openai.py
@@ -65,6 +65,8 @@ class ChatCompletionUsage(BaseModel):
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    prompt_tokens_details: dict[str, Any] | None = None
+    completion_tokens_details: dict[str, Any] | None = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -102,6 +104,7 @@ class ChatCompletionChunk(BaseModel):
     created: int
     model: str
     choices: list[ChatCompletionChunkChoice]
+    usage: ChatCompletionUsage | None = None
 
 
 class ModelObject(BaseModel):

--- a/tests/test_chat_stream_usage.py
+++ b/tests/test_chat_stream_usage.py
@@ -1,0 +1,112 @@
+"""Tests for OpenAI chat streaming usage propagation."""
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from router_maestro.providers import ChatRequest, ChatStreamChunk, CopilotProvider, Message
+from router_maestro.server.routes.chat import stream_response
+
+
+class _StubRouter:
+    """Minimal Router stub returning a pre-built chat chunk stream."""
+
+    def __init__(self, chunks: list[ChatStreamChunk]):
+        self._chunks = chunks
+
+    async def chat_completion_stream(
+        self, request: ChatRequest, fallback: bool = True
+    ) -> tuple[AsyncIterator[ChatStreamChunk], str]:
+        async def _gen() -> AsyncIterator[ChatStreamChunk]:
+            for chunk in self._chunks:
+                yield chunk
+
+        return _gen(), "github-copilot"
+
+
+def _parse_chat_stream_events(raw_events: list[str]) -> list[dict[str, Any]]:
+    events = []
+    for raw in raw_events:
+        for line in raw.splitlines():
+            if line == "data: [DONE]":
+                continue
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: ") :]))
+    return events
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_stream_emits_usage_only_chunk():
+    """Provider usage-only chunks must reach OpenAI chat streaming clients."""
+    router = _StubRouter(
+        [
+            ChatStreamChunk(content="hello"),
+            ChatStreamChunk(
+                content="",
+                usage={
+                    "prompt_tokens": 12,
+                    "completion_tokens": 3,
+                    "total_tokens": 15,
+                    "prompt_tokens_details": {"cached_tokens": 5},
+                    "completion_tokens_details": {"reasoning_tokens": 2},
+                },
+            ),
+            ChatStreamChunk(content="", finish_reason="stop"),
+        ]
+    )
+    request = ChatRequest(
+        model="github-copilot/gpt-4o",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+    raw_events = [event async for event in stream_response(router, request)]  # type: ignore[arg-type]
+    events = _parse_chat_stream_events(raw_events)
+
+    usage_events = [event for event in events if event.get("usage")]
+    assert len(usage_events) == 1
+    assert usage_events[0]["choices"] == []
+    assert usage_events[0]["usage"] == {
+        "prompt_tokens": 12,
+        "completion_tokens": 3,
+        "total_tokens": 15,
+        "prompt_tokens_details": {"cached_tokens": 5},
+        "completion_tokens_details": {"reasoning_tokens": 2},
+    }
+
+
+async def _noop() -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_copilot_chat_stream_requests_usage_from_upstream():
+    """Copilot chat streaming should ask upstream to include usage chunks."""
+    captured_payloads: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_payloads.append(json.loads(request.content))
+        body = b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+        return httpx.Response(
+            status_code=200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = CopilotProvider()
+    provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider.ensure_token = _noop  # type: ignore[method-assign]
+    provider._get_headers = lambda vision_request=False: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+
+    request = ChatRequest(
+        model="gpt-4o",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+    chunks = [chunk async for chunk in provider.chat_completion_stream(request)]
+
+    assert chunks[-1].finish_reason == "stop"
+    assert captured_payloads[0]["stream_options"] == {"include_usage": True}

--- a/tests/test_responses_helpers.py
+++ b/tests/test_responses_helpers.py
@@ -268,6 +268,18 @@ class TestMakeUsage:
         assert result["input_tokens_details"]["cached_tokens"] == 0
         assert result["output_tokens_details"]["reasoning_tokens"] == 0
 
+    def test_make_usage_preserves_details(self):
+        """Usage detail fields from upstream should be preserved."""
+        raw = {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "input_tokens_details": {"cached_tokens": 7},
+            "output_tokens_details": {"reasoning_tokens": 13},
+        }
+        result = make_usage(raw)
+        assert result["input_tokens_details"] == {"cached_tokens": 7}
+        assert result["output_tokens_details"] == {"reasoning_tokens": 13}
+
 
 class TestMakeMessageItem:
     """Tests for message item creation."""

--- a/tests/test_responses_route_wire_shape.py
+++ b/tests/test_responses_route_wire_shape.py
@@ -168,6 +168,38 @@ class TestToolSearchCallWireShape:
         assert done["item"]["arguments"] == {}
 
 
+class TestResponsesStreamUsageWireShape:
+    """Responses streaming should preserve upstream usage detail fields."""
+
+    @pytest.mark.asyncio
+    async def test_completed_event_includes_usage_details(self):
+        events = await _drive(
+            [
+                ResponsesStreamChunk(content="hello"),
+                ResponsesStreamChunk(
+                    content="",
+                    finish_reason="stop",
+                    usage={
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "total_tokens": 120,
+                        "input_tokens_details": {"cached_tokens": 60},
+                        "output_tokens_details": {"reasoning_tokens": 9},
+                    },
+                ),
+            ]
+        )
+
+        completed = next(e for e in events if e.get("type") == "response.completed")
+        assert completed["response"]["usage"] == {
+            "input_tokens": 100,
+            "input_tokens_details": {"cached_tokens": 60},
+            "output_tokens": 20,
+            "output_tokens_details": {"reasoning_tokens": 9},
+            "total_tokens": 120,
+        }
+
+
 class TestFunctionCallWireShape:
     """Regular function calls must still emit the legacy function_call shape."""
 

--- a/tests/test_responses_usage.py
+++ b/tests/test_responses_usage.py
@@ -1,0 +1,65 @@
+"""Tests for Responses API usage propagation."""
+
+import pytest
+
+from router_maestro.providers.base import ResponsesResponse as InternalResponsesResponse
+from router_maestro.server.routes import responses as responses_route
+from router_maestro.server.schemas import ResponsesUsage
+from router_maestro.server.schemas.responses import ResponsesRequest
+
+
+def test_responses_usage_schema_preserves_detail_fields():
+    """ResponsesUsage should serialize upstream detail fields."""
+    usage = ResponsesUsage(
+        input_tokens=100,
+        output_tokens=20,
+        total_tokens=120,
+        input_tokens_details={"cached_tokens": 60},
+        output_tokens_details={"reasoning_tokens": 9},
+    )
+
+    assert usage.model_dump(exclude_none=True) == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "total_tokens": 120,
+        "input_tokens_details": {"cached_tokens": 60},
+        "output_tokens_details": {"reasoning_tokens": 9},
+    }
+
+
+class _StubRouter:
+    async def rewrite_to_reasoning_variant(self, request):
+        return request
+
+    async def responses_completion(self, request):
+        return (
+            InternalResponsesResponse(
+                content="hello",
+                model=request.model,
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "total_tokens": 120,
+                    "input_tokens_details": {"cached_tokens": 60},
+                    "output_tokens_details": {"reasoning_tokens": 9},
+                },
+            ),
+            "github-copilot",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_response_preserves_usage_detail_fields(monkeypatch):
+    """Non-streaming Responses route should forward upstream detail fields."""
+    monkeypatch.setattr(responses_route, "get_router", lambda: _StubRouter())
+
+    response = await responses_route.create_response(
+        ResponsesRequest(model="github-copilot/gpt-5.5", input="hi")
+    )
+
+    assert response.usage is not None
+    assert response.usage.input_tokens == 100
+    assert response.usage.output_tokens == 20
+    assert response.usage.total_tokens == 120
+    assert response.usage.input_tokens_details == {"cached_tokens": 60}
+    assert response.usage.output_tokens_details == {"reasoning_tokens": 9}


### PR DESCRIPTION
## Summary
- Request usage chunks from Copilot chat streaming and emit OpenAI chat stream usage events
- Preserve prompt/completion token detail fields in OpenAI chat usage responses
- Preserve Responses API usage detail fields and ignore local .codex config

## Test Plan
- [x] uv run ruff check src/ tests/
- [x] uv run pytest tests/ -v