### PR TITLE
Fix provider issues and add live integration coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,27 @@ Run all tests:
 uv run pytest tests/ -v
 ```
 
+Run the local live-backend integration tests:
+
+```bash
+make integration-test
+```
+
+Run the full local integration test model matrix:
+
+```bash
+RM_INTEGRATION_MAX_MODELS=0 make integration-test
+```
+
+The integration tests start a local Router-Maestro server, reuse the existing
+local config/auth files, and send model-call requests to the real GitHub
+Copilot backend. They require GitHub Copilot auth and are intentionally
+local-only, not part of GitHub Actions:
+
+```bash
+uv run router-maestro auth login github-copilot
+```
+
 Run a single test file:
 
 ```bash
@@ -211,6 +232,9 @@ uv run router-maestro auth login github-copilot
 - For route behavior, use the existing FastAPI test patterns in `tests/`.
 - For provider behavior, mock upstream HTTP calls rather than calling real
   provider APIs.
+- For local live-backend validation, use `make integration-test`. To run the
+  complete Copilot model matrix instead of the default bounded subset, use
+  `RM_INTEGRATION_MAX_MODELS=0 make integration-test`.
 - Run the narrowest relevant pytest target first, then broaden to the full
   suite when the change has wider risk.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,12 @@ ROUTER_MAESTRO_API_KEY="sk-rm-..." uv run router-maestro server start --port 808
 # Run all tests
 uv run pytest tests/ -v
 
+# Run local live-backend integration tests
+make integration-test
+
+# Run the full local integration test model matrix
+RM_INTEGRATION_MAX_MODELS=0 make integration-test
+
 # Run a single test file
 uv run pytest tests/test_auth.py -v
 
@@ -36,6 +42,23 @@ make build-multiarch
 ### Local Server Startup
 
 The API key is configured via `ROUTER_MAESTRO_API_KEY` env var. For VS Code debugging, see `.vscode/launch.json` which has the key pre-configured. The server runs on uvicorn and requires authenticated GitHub Copilot (via `router-maestro auth login copilot`) for most models.
+
+### Local Integration Tests
+
+The integration tests are local-only and are not part of GitHub Actions. They
+start a local Router-Maestro server, reuse the existing local config/auth
+files, and send model-call requests to the real GitHub Copilot backend. They
+require GitHub Copilot auth:
+
+```bash
+uv run router-maestro auth login github-copilot
+```
+
+Use `make integration-test` for the default live suite. Use
+`RM_INTEGRATION_MAX_MODELS=0 make integration-test` for the full Copilot model
+matrix. The suite covers model invocation paths such as OpenAI Chat/Responses,
+Anthropic Messages/count_tokens, Gemini generateContent/stream/countTokens,
+streaming, tool calls, and usage accounting.
 
 ### Docker Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev test lint format clean build push run stop logs shell docker-up docker-down docker-logs buildx-setup build-multiarch dist publish publish-test dev-up dev-down dev-logs dev-build
+.PHONY: help install dev test integration-test lint format clean build push run stop logs shell docker-up docker-down docker-logs buildx-setup build-multiarch dist publish publish-test dev-up dev-down dev-logs dev-build
 
 # Variables
 VERSION := $(shell grep '^version' pyproject.toml | head -1 | cut -d'"' -f2)
@@ -14,6 +14,7 @@ help:
 	@echo "  make install     Install dependencies"
 	@echo "  make dev         Install with dev dependencies"
 	@echo "  make test        Run tests"
+	@echo "  make integration-test  Run local live-backend integration tests"
 	@echo "  make lint        Run linter (ruff check)"
 	@echo "  make format      Format code (ruff format)"
 	@echo "  make clean       Clean build artifacts"
@@ -57,6 +58,9 @@ dev:
 
 test:
 	uv run pytest tests/ -v
+
+integration-test:
+	uv run pytest integration_tests/ -v
 
 lint:
 	uv run ruff check src/ tests/

--- a/README.md
+++ b/README.md
@@ -273,6 +273,38 @@ router-maestro model list
 | `config codex`       | Generate Codex config (CLI/Extension/App) |
 | `config gemini`      | Generate Gemini CLI .env      |
 
+## Local Integration Tests
+
+The live-backend integration tests are local-only and are not part of GitHub
+Actions. They start a local Router-Maestro server, reuse your existing
+Router-Maestro config/auth files, and send requests to the real GitHub Copilot
+backend. The suite covers model invocation paths only: OpenAI Chat, OpenAI
+Responses, Anthropic Messages/count_tokens, Gemini generateContent/stream/countTokens,
+tool calls, streaming, usage accounting, and a configurable Copilot model
+matrix. Admin endpoints are intentionally not covered by these tests.
+
+Prerequisites:
+
+```bash
+uv run router-maestro auth login github-copilot
+```
+
+Run them explicitly:
+
+```bash
+make integration-test
+```
+
+Optional overrides:
+
+```bash
+RM_INTEGRATION_MODEL=github-copilot/gpt-4o make integration-test
+RM_INTEGRATION_TOOL_MODEL=github-copilot/gpt-4o make integration-test
+RM_INTEGRATION_RESPONSES_MODEL=github-copilot/gpt-5.4-mini make integration-test
+RM_INTEGRATION_MODELS=github-copilot/gpt-4o,github-copilot/claude-sonnet-4.5 make integration-test
+RM_INTEGRATION_MAX_MODELS=0 make integration-test
+```
+
 ## API Reference
 
 ### OpenAI-Compatible

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Local-only integration tests for Router-Maestro."""

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,0 +1,630 @@
+"""Fixtures for local live-backend integration tests.
+
+These tests intentionally reuse the developer's existing Router-Maestro
+configuration and GitHub Copilot auth files. They are outside the default
+pytest tree and are only run with ``uv run pytest integration_tests/ -v``.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+from router_maestro.auth import AuthManager
+from router_maestro.config.server import get_current_context_api_key
+from router_maestro.utils.responses_bridge import RESPONSES_ELIGIBLE_MODELS
+
+STARTUP_TIMEOUT_SECONDS = 45.0
+REQUEST_TIMEOUT_SECONDS = 120.0
+STREAM_TIMEOUT_SECONDS = 180.0
+DEFAULT_MAX_MODEL_MATRIX = 8
+DEFAULT_API_KEY = "router-maestro-integration-test"
+COPILOT_PROVIDER = "github-copilot"
+TEXT_PROMPT = (
+    "Reply with exactly the word pong. Do not add punctuation or any other words."
+)
+TOOL_PROMPT = (
+    "Use the provided get_weather tool for Shanghai. Do not answer directly."
+)
+
+
+@dataclass(frozen=True)
+class LiveServer:
+    """Connection details for the locally started Router-Maestro server."""
+
+    base_url: str
+    api_key: str
+    process: subprocess.Popen[str]
+
+
+@pytest.fixture(scope="session")
+def live_server() -> Iterator[LiveServer]:
+    """Start a local RM server against the user's existing config/auth files."""
+    _require_github_copilot_auth()
+
+    api_key = os.environ.get("RM_INTEGRATION_API_KEY") or get_current_context_api_key()
+    if not api_key:
+        api_key = DEFAULT_API_KEY
+
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    env["ROUTER_MAESTRO_API_KEY"] = api_key
+    env.setdefault("ROUTER_MAESTRO_LOG_LEVEL", "INFO")
+    if env.get("RM_INTEGRATION_RESPONSES_CHAT") is None:
+        env["ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API"] = "1"
+
+    process = subprocess.Popen(
+        [
+            "uv",
+            "run",
+            "uvicorn",
+            "router_maestro.server:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            env["ROUTER_MAESTRO_LOG_LEVEL"].lower(),
+        ],
+        cwd=_repo_root(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    try:
+        _wait_for_health(base_url, process)
+        yield LiveServer(base_url=base_url, api_key=api_key, process=process)
+    finally:
+        _terminate_process(process)
+
+
+@pytest.fixture(scope="session")
+def client(live_server: LiveServer) -> Iterator[httpx.Client]:
+    """HTTP client authenticated against the local RM server."""
+    headers = {"Authorization": f"Bearer {live_server.api_key}"}
+    with httpx.Client(
+        base_url=live_server.base_url,
+        headers=headers,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    ) as http_client:
+        yield http_client
+
+
+@pytest.fixture(scope="session")
+def unauthenticated_client(live_server: LiveServer) -> Iterator[httpx.Client]:
+    """HTTP client without the Router-Maestro API key."""
+    with httpx.Client(
+        base_url=live_server.base_url,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    ) as http_client:
+        yield http_client
+
+
+@pytest.fixture(scope="session")
+def copilot_models(client: httpx.Client) -> list[str]:
+    """Return provider-qualified GitHub Copilot model names from the model API."""
+    response = client.get("/api/openai/v1/models")
+    response.raise_for_status()
+    models = response.json()["data"]
+    ids = [
+        _provider_model_id(model["owned_by"], model["id"])
+        for model in models
+        if model.get("owned_by") == COPILOT_PROVIDER
+    ]
+    if not ids:
+        pytest.fail(
+            "No github-copilot models are available. Run "
+            "`uv run router-maestro auth login github-copilot` first."
+        )
+    return ids
+
+
+@pytest.fixture(scope="session")
+def model_matrix(copilot_models: list[str]) -> list[str]:
+    """Model subset used for broad live model coverage."""
+    requested = os.environ.get("RM_INTEGRATION_MODELS")
+    if requested:
+        models = [item.strip() for item in requested.split(",") if item.strip()]
+        missing = [model for model in models if model not in copilot_models]
+        if missing:
+            pytest.fail(f"RM_INTEGRATION_MODELS contains unavailable models: {missing}")
+        return models
+
+    max_models = _int_env("RM_INTEGRATION_MAX_MODELS", DEFAULT_MAX_MODEL_MATRIX)
+    if max_models <= 0:
+        return copilot_models
+
+    ordered = _prioritize_models(copilot_models)
+    return ordered[:max_models]
+
+
+@pytest.fixture(scope="session")
+def chat_model(copilot_models: list[str]) -> str:
+    """Model for OpenAI Chat, Anthropic, and Gemini compatibility paths."""
+    requested = os.environ.get("RM_INTEGRATION_MODEL")
+    if requested:
+        if requested in copilot_models:
+            return requested
+        pytest.fail(f"RM_INTEGRATION_MODEL={requested!r} is not in available Copilot models")
+
+    preferred = (
+        "github-copilot/gpt-4o-mini",
+        "github-copilot/gpt-4o",
+        "github-copilot/claude-haiku-4.5",
+        "github-copilot/claude-sonnet-4.5",
+    )
+    return _first_available(copilot_models, preferred) or copilot_models[0]
+
+
+@pytest.fixture(scope="session")
+def tool_model(copilot_models: list[str]) -> str:
+    """Model selected for forced tool-call scenarios."""
+    requested = os.environ.get("RM_INTEGRATION_TOOL_MODEL")
+    if requested:
+        if requested in copilot_models:
+            return requested
+        pytest.fail(f"RM_INTEGRATION_TOOL_MODEL={requested!r} is not in available Copilot models")
+
+    preferred = (
+        "github-copilot/gpt-4o",
+        "github-copilot/gpt-4o-mini",
+        "github-copilot/gpt-5.4-mini",
+        "github-copilot/gpt-5.4",
+        "github-copilot/claude-sonnet-4.5",
+    )
+    return _first_available(copilot_models, preferred) or copilot_models[0]
+
+
+@pytest.fixture(scope="session")
+def responses_model(copilot_models: list[str]) -> str:
+    """Model for the OpenAI Responses path."""
+    requested = os.environ.get("RM_INTEGRATION_RESPONSES_MODEL")
+    if requested:
+        if requested in copilot_models:
+            return requested
+        pytest.fail(
+            f"RM_INTEGRATION_RESPONSES_MODEL={requested!r} is not in available Copilot models"
+        )
+
+    eligible = {
+        f"{COPILOT_PROVIDER}/{model_id}" for model_id in RESPONSES_ELIGIBLE_MODELS
+    }
+    preferred = (
+        "github-copilot/gpt-5.4-mini",
+        "github-copilot/gpt-5.4",
+        "github-copilot/gpt-5.3-codex",
+        "github-copilot/gpt-5.2",
+    )
+    selected = _first_available(copilot_models, preferred)
+    if selected:
+        return selected
+    selected = next((model for model in copilot_models if model in eligible), None)
+    if selected:
+        return selected
+    pytest.skip("No Copilot model available for the /responses endpoint")
+
+
+def openai_chat_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """Small deterministic OpenAI Chat request."""
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": TEXT_PROMPT}],
+        "temperature": 0,
+        "max_tokens": 16,
+        "stream": stream,
+    }
+
+
+def openai_responses_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """Small deterministic OpenAI Responses request."""
+    return {
+        "model": model,
+        "input": TEXT_PROMPT,
+        "instructions": "Return only the requested word.",
+        "max_output_tokens": 512,
+        "stream": stream,
+    }
+
+
+def anthropic_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """Small deterministic Anthropic Messages request."""
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": TEXT_PROMPT}],
+        "max_tokens": 16,
+        "temperature": 0,
+        "stream": stream,
+    }
+
+
+def anthropic_compat_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """Anthropic request exercising common compatibility fields."""
+    payload = anthropic_payload(model, stream=stream)
+    payload.update(
+        {
+            "system": "Return concise answers.",
+            "top_p": 1,
+            "stop_sequences": ["\n\nHuman:"],
+            "metadata": {"user_id": "router-maestro-integration"},
+        }
+    )
+    return payload
+
+
+def gemini_payload(*, max_output_tokens: int = 16) -> dict[str, Any]:
+    """Small deterministic Gemini request."""
+    return {
+        "contents": [{"role": "user", "parts": [{"text": TEXT_PROMPT}]}],
+        "generationConfig": {"temperature": 0, "maxOutputTokens": max_output_tokens},
+    }
+
+
+def gemini_compat_payload(*, max_output_tokens: int = 16) -> dict[str, Any]:
+    """Gemini request exercising systemInstruction and generationConfig."""
+    payload = gemini_payload(max_output_tokens=max_output_tokens)
+    payload.update(
+        {
+            "systemInstruction": {"parts": [{"text": "Return concise answers."}]},
+            "generationConfig": {
+                "temperature": 0,
+                "topP": 1,
+                "maxOutputTokens": max_output_tokens,
+                "stopSequences": ["\n\n"],
+            },
+        }
+    )
+    return payload
+
+
+def openai_chat_usage_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """OpenAI Chat payload with compatibility fields and usage assertions."""
+    payload = openai_chat_payload(model, stream=stream)
+    payload.update(
+        {
+            "top_p": 1,
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+            "stop": ["\n\n"],
+            "user": "router-maestro-integration",
+        }
+    )
+    return payload
+
+
+def openai_chat_tool_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """OpenAI Chat payload that forces a function tool call."""
+    payload = openai_chat_payload(model, stream=stream)
+    payload["messages"] = [{"role": "user", "content": TOOL_PROMPT}]
+    payload["max_tokens"] = 128
+    payload["tools"] = [openai_weather_tool()]
+    payload["tool_choice"] = {"type": "function", "function": {"name": "get_weather"}}
+    return payload
+
+
+def openai_responses_tool_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """OpenAI Responses payload that forces a function tool call."""
+    payload = openai_responses_payload(model, stream=stream)
+    payload["input"] = TOOL_PROMPT
+    payload["max_output_tokens"] = 512
+    payload["tools"] = [responses_weather_tool()]
+    payload["tool_choice"] = "required"
+    return payload
+
+
+def anthropic_tool_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
+    """Anthropic payload that forces a tool_use block."""
+    payload = anthropic_payload(model, stream=stream)
+    payload["messages"] = [{"role": "user", "content": TOOL_PROMPT}]
+    payload["max_tokens"] = 128
+    payload["tools"] = [anthropic_weather_tool()]
+    payload["tool_choice"] = {"type": "tool", "name": "get_weather"}
+    return payload
+
+
+def gemini_tool_payload(*, max_output_tokens: int = 16) -> dict[str, Any]:
+    """Gemini payload that requires a function call."""
+    payload = gemini_payload(max_output_tokens=max_output_tokens)
+    payload["contents"] = [{"role": "user", "parts": [{"text": TOOL_PROMPT}]}]
+    payload["tools"] = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            ]
+        }
+    ]
+    payload["toolConfig"] = {"functionCallingConfig": {"mode": "ANY"}}
+    return payload
+
+
+def anthropic_count_tokens_payload(model: str) -> dict[str, Any]:
+    """Anthropic count_tokens payload."""
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": TEXT_PROMPT}],
+    }
+
+
+def openai_weather_tool() -> dict[str, Any]:
+    """OpenAI Chat function tool."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+
+
+def responses_weather_tool() -> dict[str, Any]:
+    """OpenAI Responses function tool."""
+    return {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    }
+
+
+def anthropic_weather_tool() -> dict[str, Any]:
+    """Anthropic function tool."""
+    return {
+        "name": "get_weather",
+        "description": "Get weather for a city.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    }
+
+
+def parse_sse_events(response: httpx.Response) -> list[tuple[str | None, Any]]:
+    """Parse an SSE response into ``(event_name, data)`` tuples."""
+    events: list[tuple[str | None, Any]] = []
+    event_name: str | None = None
+    data_lines: list[str] = []
+
+    for line in response.iter_lines():
+        if line == "":
+            if data_lines:
+                raw_data = "\n".join(data_lines)
+                if raw_data == "[DONE]":
+                    events.append((event_name, raw_data))
+                else:
+                    events.append((event_name, _json_or_raw(raw_data)))
+                event_name = None
+                data_lines = []
+            continue
+        if line.startswith("event: "):
+            event_name = line[len("event: ") :]
+        elif line.startswith("data: "):
+            data_lines.append(line[len("data: ") :])
+
+    if data_lines:
+        raw_data = "\n".join(data_lines)
+        events.append((event_name, _json_or_raw(raw_data)))
+    return events
+
+
+def assert_text_response(text: str | None) -> None:
+    """Assert the live backend returned visible assistant text."""
+    assert isinstance(text, str)
+    assert text.strip()
+
+
+def assert_http_success(response: httpx.Response) -> None:
+    """Assert an HTTP response succeeded, preserving body context on failure."""
+    assert response.status_code == 200, response.text
+
+
+def bare_model(model: str) -> str:
+    """Strip a provider prefix from a model name for Gemini path parameters."""
+    return model.split("/", 1)[1] if "/" in model else model
+
+
+def is_responses_eligible_model(model: str) -> bool:
+    """Whether the selected Copilot model should be invoked via Responses."""
+    return bare_model(model) in RESPONSES_ELIGIBLE_MODELS
+
+
+def event_payloads(events: list[tuple[str | None, Any]]) -> list[Any]:
+    """Return parsed data payloads from SSE events, excluding ``[DONE]``."""
+    return [payload for _name, payload in events if payload != "[DONE]"]
+
+
+def assert_tool_call_name(tool_call: dict[str, Any], expected_name: str) -> None:
+    """Assert a tool-call object names the expected function."""
+    assert tool_call.get("type", "function") == "function"
+    function = tool_call.get("function", {})
+    assert function.get("name") == expected_name
+    assert function.get("arguments") is not None
+
+
+def assert_response_has_function_call(data: dict[str, Any], expected_name: str) -> None:
+    """Assert an OpenAI Responses payload contains a function_call item."""
+    calls = [item for item in data.get("output", []) if item.get("type") == "function_call"]
+    assert calls, data
+    assert any(call.get("name") == expected_name for call in calls)
+
+
+def assert_anthropic_has_tool_use(data: dict[str, Any], expected_name: str) -> None:
+    """Assert an Anthropic message contains a tool_use block."""
+    blocks = [block for block in data.get("content", []) if block.get("type") == "tool_use"]
+    assert blocks, data
+    assert any(block.get("name") == expected_name for block in blocks)
+
+
+def assert_gemini_has_function_call(data: dict[str, Any], expected_name: str) -> None:
+    """Assert a Gemini response contains a functionCall part."""
+    calls = []
+    for candidate in data.get("candidates", []):
+        content = candidate.get("content") or {}
+        for part in content.get("parts", []):
+            if "functionCall" in part:
+                calls.append(part["functionCall"])
+    assert calls, data
+    assert any(call.get("name") == expected_name for call in calls)
+
+
+def assert_openai_usage(usage: dict[str, Any] | None) -> None:
+    """Assert OpenAI chat usage has positive total tokens."""
+    assert isinstance(usage, dict)
+    assert usage["prompt_tokens"] > 0
+    assert usage["completion_tokens"] >= 0
+    assert usage["total_tokens"] >= usage["prompt_tokens"]
+
+
+def assert_responses_usage(usage: dict[str, Any] | None) -> None:
+    """Assert OpenAI Responses usage has positive total tokens."""
+    assert isinstance(usage, dict)
+    assert usage["input_tokens"] > 0
+    assert usage["output_tokens"] >= 0
+    assert usage["total_tokens"] >= usage["input_tokens"]
+
+
+def assert_anthropic_usage(usage: dict[str, Any] | None) -> None:
+    """Assert Anthropic usage has positive input tokens."""
+    assert isinstance(usage, dict)
+    assert usage["input_tokens"] > 0
+    assert usage["output_tokens"] >= 0
+
+
+def assert_gemini_usage(usage: dict[str, Any] | None) -> None:
+    """Assert Gemini usageMetadata has positive total tokens."""
+    assert isinstance(usage, dict)
+    assert usage["promptTokenCount"] > 0
+    assert usage["totalTokenCount"] >= usage["promptTokenCount"]
+
+
+def _json_or_raw(raw_data: str) -> Any:
+    try:
+        import json
+
+        return json.loads(raw_data)
+    except ValueError:
+        return raw_data
+
+
+def _require_github_copilot_auth() -> None:
+    manager = AuthManager()
+    if not manager.is_authenticated(COPILOT_PROVIDER):
+        pytest.skip(
+            "GitHub Copilot auth is not configured. Run "
+            f"`uv run router-maestro auth login {COPILOT_PROVIDER}` first."
+        )
+
+
+def _provider_model_id(provider: str, model_id: str) -> str:
+    return model_id if "/" in model_id else f"{provider}/{model_id}"
+
+
+def _prioritize_models(models: list[str]) -> list[str]:
+    preferred_prefixes = (
+        "github-copilot/gpt-4o-mini",
+        "github-copilot/gpt-4o",
+        "github-copilot/gpt-5.4-mini",
+        "github-copilot/gpt-5.4",
+        "github-copilot/gpt-5.3-codex",
+        "github-copilot/claude-haiku",
+        "github-copilot/claude-sonnet",
+        "github-copilot/claude-opus",
+    )
+    selected: list[str] = []
+    for prefix in preferred_prefixes:
+        selected.extend(
+            model for model in models if model.startswith(prefix) and model not in selected
+        )
+    selected.extend(model for model in models if model not in selected)
+    return selected
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        pytest.fail(f"{name} must be an integer, got {raw!r}")
+
+
+def _first_available(models: list[str], preferred: tuple[str, ...]) -> str | None:
+    available = set(models)
+    return next((model for model in preferred if model in available), None)
+
+
+def _repo_root() -> str:
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_health(base_url: str, process: subprocess.Popen[str]) -> None:
+    deadline = time.time() + STARTUP_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+    with httpx.Client(timeout=2.0) as startup_client:
+        while time.time() < deadline:
+            if process.poll() is not None:
+                output = _read_process_output(process)
+                pytest.fail(f"Router-Maestro server exited during startup:\n{output}")
+            try:
+                response = startup_client.get(f"{base_url}/health")
+                if response.status_code == 200:
+                    return
+            except httpx.HTTPError as exc:
+                last_error = exc
+            time.sleep(0.25)
+
+    output = _read_process_output(process)
+    pytest.fail(f"Router-Maestro server did not become healthy: {last_error}\n{output}")
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def _read_process_output(process: subprocess.Popen[str]) -> str:
+    if process.stdout is None:
+        return ""
+    try:
+        return process.stdout.read() or ""
+    except Exception:
+        return ""

--- a/integration_tests/test_live_anthropic_paths.py
+++ b/integration_tests/test_live_anthropic_paths.py
@@ -1,0 +1,182 @@
+"""Live Anthropic-compatible model invocation paths."""
+
+from __future__ import annotations
+
+import httpx
+
+from integration_tests.conftest import (
+    anthropic_compat_payload,
+    anthropic_count_tokens_payload,
+    anthropic_payload,
+    anthropic_tool_payload,
+    assert_anthropic_has_tool_use,
+    assert_anthropic_usage,
+    assert_http_success,
+    assert_text_response,
+    event_payloads,
+    parse_sse_events,
+)
+
+
+def test_anthropic_messages_non_streaming_api_prefix(
+    client: httpx.Client,
+    chat_model: str,
+):
+    """The prefixed Anthropic Messages path should route to GHC."""
+    response = client.post(
+        "/api/anthropic/v1/messages",
+        json=anthropic_compat_payload(chat_model),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["model"]
+    assert data["stop_reason"] in {
+        "end_turn",
+        "max_tokens",
+        "stop_sequence",
+        "tool_use",
+        "pause_turn",
+        "refusal",
+    }
+    text_blocks = [block for block in data["content"] if block["type"] == "text"]
+    assert text_blocks, data
+    assert_text_response(text_blocks[0]["text"])
+    assert_anthropic_usage(data["usage"])
+
+
+def test_anthropic_messages_non_streaming_root_path(
+    client: httpx.Client,
+    chat_model: str,
+):
+    """The Claude-compatible /v1/messages path should route to GHC."""
+    response = client.post("/v1/messages", json=anthropic_payload(chat_model))
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert_anthropic_usage(data["usage"])
+
+
+def test_anthropic_messages_streaming_api_prefix(
+    client: httpx.Client,
+    chat_model: str,
+):
+    """The prefixed Anthropic stream should emit Anthropic protocol events."""
+    with client.stream(
+        "POST",
+        "/api/anthropic/v1/messages",
+        json=anthropic_payload(chat_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    payloads = event_payloads(events)
+
+    assert "message_start" in event_names
+    assert "content_block_start" in event_names
+    assert "content_block_delta" in event_names
+    assert "message_delta" in event_names
+    assert "message_stop" in event_names
+    assert any(
+        payload.get("delta", {}).get("type") == "text_delta"
+        for payload in payloads
+        if isinstance(payload, dict)
+    )
+    message_delta = next(
+        payload for name, payload in events if name == "message_delta"
+    )
+    assert_anthropic_usage(message_delta["usage"])
+
+
+def test_anthropic_messages_streaming_root_path(
+    client: httpx.Client,
+    chat_model: str,
+):
+    """The /v1/messages stream should emit Anthropic protocol events."""
+    with client.stream(
+        "POST",
+        "/v1/messages",
+        json=anthropic_payload(chat_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    assert "message_start" in event_names
+    assert "message_stop" in event_names
+
+
+def test_anthropic_count_tokens_api_prefix(client: httpx.Client, chat_model: str):
+    """The prefixed Anthropic count_tokens path should estimate input tokens."""
+    response = client.post(
+        "/api/anthropic/v1/messages/count_tokens",
+        json=anthropic_count_tokens_payload(chat_model),
+    )
+    assert_http_success(response)
+    assert response.json()["input_tokens"] > 0
+
+
+def test_anthropic_count_tokens_root_path(client: httpx.Client, chat_model: str):
+    """The /v1/messages/count_tokens path should estimate input tokens."""
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json=anthropic_count_tokens_payload(chat_model),
+    )
+    assert_http_success(response)
+    assert response.json()["input_tokens"] > 0
+
+
+def test_anthropic_forced_tool_call(client: httpx.Client, tool_model: str):
+    """Anthropic Messages should translate OpenAI tool calls to tool_use blocks."""
+    response = client.post(
+        "/api/anthropic/v1/messages",
+        json=anthropic_tool_payload(tool_model),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["stop_reason"] == "tool_use"
+    assert_anthropic_has_tool_use(data, "get_weather")
+    assert_anthropic_usage(data["usage"])
+
+
+def test_anthropic_forced_tool_call_streaming(
+    client: httpx.Client,
+    tool_model: str,
+):
+    """Anthropic streaming should expose tool_use block events."""
+    with client.stream(
+        "POST",
+        "/api/anthropic/v1/messages",
+        json=anthropic_tool_payload(tool_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    tool_start = [
+        payload
+        for payload in payloads
+        if isinstance(payload, dict)
+        and payload.get("type") == "content_block_start"
+        and payload.get("content_block", {}).get("type") == "tool_use"
+    ]
+    assert tool_start, payloads
+    assert any(
+        payload.get("delta", {}).get("type") == "input_json_delta"
+        for payload in payloads
+        if isinstance(payload, dict)
+    )
+    message_delta = next(
+        payload for name, payload in events if name == "message_delta"
+    )
+    assert message_delta["delta"]["stop_reason"] == "tool_use"
+    assert_anthropic_usage(message_delta["usage"])

--- a/integration_tests/test_live_discovery_and_auth.py
+++ b/integration_tests/test_live_discovery_and_auth.py
@@ -1,0 +1,60 @@
+"""Live service discovery and authenticated model-list checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from integration_tests.conftest import assert_http_success
+
+
+def test_public_health_endpoints(live_server):
+    """The local service should start and expose public health metadata."""
+    response = httpx.get(f"{live_server.base_url}/health", timeout=10.0)
+    assert_http_success(response)
+    assert response.json() == {"status": "healthy"}
+
+    root = httpx.get(f"{live_server.base_url}/", timeout=10.0)
+    assert_http_success(root)
+    assert root.json()["status"] == "running"
+
+
+def test_model_endpoint_requires_authentication(unauthenticated_client: httpx.Client):
+    """Model endpoints are part of the authenticated model-call surface."""
+    response = unauthenticated_client.get("/api/openai/v1/models")
+    assert response.status_code == 401
+
+
+def test_openai_models_include_github_copilot_models(client: httpx.Client):
+    """OpenAI-compatible model listing should expose Copilot model metadata."""
+    response = client.get("/api/openai/v1/models")
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["object"] == "list"
+    copilot_models = [
+        model for model in data["data"] if model.get("owned_by") == "github-copilot"
+    ]
+    assert copilot_models, data
+    assert all(model["object"] == "model" for model in copilot_models)
+    assert all(model["id"] for model in copilot_models)
+    assert any(
+        model.get("max_context_window_tokens") or model.get("max_prompt_tokens")
+        for model in copilot_models
+    )
+
+
+def test_anthropic_models_include_github_copilot_models(client: httpx.Client):
+    """Anthropic-compatible model listing should expose Copilot model metadata."""
+    response = client.get("/api/anthropic/v1/models")
+    assert_http_success(response)
+    data: dict[str, Any] = response.json()
+
+    assert data["data"], data
+    assert any(model["id"] for model in data["data"])
+    assert all(model["type"] == "model" for model in data["data"])
+    assert any(
+        model.get("max_context_window_tokens") or model.get("max_prompt_tokens")
+        for model in data["data"]
+    )

--- a/integration_tests/test_live_gemini_paths.py
+++ b/integration_tests/test_live_gemini_paths.py
@@ -1,0 +1,110 @@
+"""Live Gemini-compatible model invocation paths."""
+
+from __future__ import annotations
+
+import httpx
+
+from integration_tests.conftest import (
+    assert_gemini_has_function_call,
+    assert_gemini_usage,
+    assert_http_success,
+    assert_text_response,
+    bare_model,
+    event_payloads,
+    gemini_compat_payload,
+    gemini_payload,
+    gemini_tool_payload,
+    parse_sse_events,
+)
+
+
+def test_gemini_generate_content(client: httpx.Client, chat_model: str):
+    """Gemini generateContent should route to GHC with a bare path model."""
+    response = client.post(
+        f"/api/gemini/v1beta/models/{bare_model(chat_model)}:generateContent",
+        json=gemini_compat_payload(),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["modelVersion"] == bare_model(chat_model)
+    assert data["candidates"], data
+    candidate = data["candidates"][0]
+    assert candidate["finishReason"] in {"STOP", "MAX_TOKENS", "SAFETY", "OTHER"}
+    text = "".join(
+        part.get("text", "")
+        for part in candidate["content"]["parts"]
+        if "text" in part
+    )
+    assert_text_response(text)
+    assert_gemini_usage(data["usageMetadata"])
+
+
+def test_gemini_stream_generate_content(client: httpx.Client, chat_model: str):
+    """Gemini streamGenerateContent should emit text chunks and final usage."""
+    with client.stream(
+        "POST",
+        f"/api/gemini/v1beta/models/{bare_model(chat_model)}:streamGenerateContent",
+        json=gemini_payload(),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    assert payloads, events
+    assert any(
+        part.get("text")
+        for payload in payloads
+        for candidate in payload.get("candidates", [])
+        for part in (candidate.get("content") or {}).get("parts", [])
+    )
+    final_with_usage = [payload for payload in payloads if payload.get("usageMetadata")]
+    assert final_with_usage, payloads
+    assert_gemini_usage(final_with_usage[-1]["usageMetadata"])
+
+
+def test_gemini_count_tokens(client: httpx.Client, chat_model: str):
+    """Gemini countTokens should return a local token estimate."""
+    response = client.post(
+        f"/api/gemini/v1beta/models/{bare_model(chat_model)}:countTokens",
+        json=gemini_payload(),
+    )
+    assert_http_success(response)
+    assert response.json()["totalTokens"] > 0
+
+
+def test_gemini_forced_tool_call(client: httpx.Client, tool_model: str):
+    """Gemini generateContent should translate forced tools to functionCall."""
+    response = client.post(
+        f"/api/gemini/v1beta/models/{bare_model(tool_model)}:generateContent",
+        json=gemini_tool_payload(),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert_gemini_has_function_call(data, "get_weather")
+    assert_gemini_usage(data["usageMetadata"])
+
+
+def test_gemini_forced_tool_call_streaming(client: httpx.Client, tool_model: str):
+    """Gemini streaming should emit functionCall parts for forced tools."""
+    with client.stream(
+        "POST",
+        f"/api/gemini/v1beta/models/{bare_model(tool_model)}:streamGenerateContent",
+        json=gemini_tool_payload(),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    assert any(
+        part.get("functionCall", {}).get("name") == "get_weather"
+        for payload in payloads
+        for candidate in payload.get("candidates", [])
+        for part in (candidate.get("content") or {}).get("parts", [])
+    ), payloads
+    final_with_usage = [payload for payload in payloads if payload.get("usageMetadata")]
+    assert final_with_usage, payloads
+    assert_gemini_usage(final_with_usage[-1]["usageMetadata"])

--- a/integration_tests/test_live_model_matrix.py
+++ b/integration_tests/test_live_model_matrix.py
@@ -1,0 +1,50 @@
+"""Broad live GHC model matrix checks through model invocation paths."""
+
+from __future__ import annotations
+
+import httpx
+
+from integration_tests.conftest import (
+    assert_http_success,
+    assert_openai_usage,
+    assert_responses_usage,
+    assert_text_response,
+    is_responses_eligible_model,
+    openai_chat_payload,
+    openai_responses_payload,
+)
+
+
+def test_copilot_model_matrix_openai_chat(
+    client: httpx.Client,
+    model_matrix: list[str],
+):
+    """Exercise the selected Copilot model matrix through OpenAI Chat."""
+    failures: list[str] = []
+
+    for model in model_matrix:
+        try:
+            if is_responses_eligible_model(model):
+                response = client.post(
+                    "/api/openai/v1/responses",
+                    json=openai_responses_payload(model),
+                )
+                assert_http_success(response)
+                data = response.json()
+                assert data["status"] == "completed"
+                assert_responses_usage(data["usage"])
+            else:
+                response = client.post(
+                    "/api/openai/v1/chat/completions",
+                    json=openai_chat_payload(model),
+                )
+                assert_http_success(response)
+                data = response.json()
+                choice = data["choices"][0]
+                assert choice["message"]["role"] == "assistant"
+                assert_text_response(choice["message"].get("content"))
+                assert_openai_usage(data["usage"])
+        except AssertionError as exc:
+            failures.append(f"{model}: {exc}")
+
+    assert not failures, "\n".join(failures)

--- a/integration_tests/test_live_openai_paths.py
+++ b/integration_tests/test_live_openai_paths.py
@@ -1,0 +1,231 @@
+"""Live OpenAI-compatible model invocation paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from integration_tests.conftest import (
+    assert_http_success,
+    assert_openai_usage,
+    assert_response_has_function_call,
+    assert_responses_usage,
+    assert_text_response,
+    assert_tool_call_name,
+    event_payloads,
+    openai_chat_tool_payload,
+    openai_chat_usage_payload,
+    openai_responses_payload,
+    openai_responses_tool_payload,
+    parse_sse_events,
+)
+
+
+def test_openai_chat_completion_non_streaming_returns_usage(
+    client: httpx.Client,
+    chat_model: str,
+):
+    """OpenAI Chat non-streaming should route to GHC and return usage."""
+    response = client.post(
+        "/api/openai/v1/chat/completions",
+        json=openai_chat_usage_payload(chat_model),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["object"] == "chat.completion"
+    assert data["model"]
+    assert len(data["choices"]) == 1
+    message = data["choices"][0]["message"]
+    assert message["role"] == "assistant"
+    assert_text_response(message["content"])
+    assert_openai_usage(data["usage"])
+
+
+def test_openai_chat_completion_streaming_returns_chunks_and_done(
+    client: httpx.Client,
+    chat_model: str,
+):
+    """OpenAI Chat streaming should return SSE chunks and the [DONE] sentinel."""
+    with client.stream(
+        "POST",
+        "/api/openai/v1/chat/completions",
+        json=openai_chat_usage_payload(chat_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    assert events[-1][1] == "[DONE]"
+    assert any(payload.get("object") == "chat.completion.chunk" for payload in payloads)
+    assert any(
+        choice.get("delta", {}).get("role") == "assistant"
+        for payload in payloads
+        for choice in payload.get("choices", [])
+    )
+    assert any(
+        choice.get("delta", {}).get("content")
+        for payload in payloads
+        for choice in payload.get("choices", [])
+    )
+    usage_payloads = [payload for payload in payloads if payload.get("usage")]
+    if usage_payloads:
+        assert_openai_usage(usage_payloads[-1]["usage"])
+
+
+def test_openai_chat_forced_tool_call(client: httpx.Client, tool_model: str):
+    """OpenAI Chat should preserve forced function tool calls from GHC."""
+    response = client.post(
+        "/api/openai/v1/chat/completions",
+        json=openai_chat_tool_payload(tool_model),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    choice = data["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tool_calls = choice["message"].get("tool_calls") or []
+    assert tool_calls, data
+    assert_tool_call_name(tool_calls[0], "get_weather")
+    assert_openai_usage(data["usage"])
+
+
+def test_openai_chat_forced_tool_call_streaming(client: httpx.Client, tool_model: str):
+    """OpenAI Chat stream should expose tool_call deltas and final usage."""
+    with client.stream(
+        "POST",
+        "/api/openai/v1/chat/completions",
+        json=openai_chat_tool_payload(tool_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    tool_chunks = [
+        tool_call
+        for payload in payloads
+        for choice in payload.get("choices", [])
+        for tool_call in choice.get("delta", {}).get("tool_calls") or []
+    ]
+    assert tool_chunks, payloads
+    assert any(
+        choice.get("finish_reason") == "tool_calls"
+        for payload in payloads
+        for choice in payload.get("choices", [])
+    )
+    usage_payloads = [payload for payload in payloads if payload.get("usage")]
+    if usage_payloads:
+        assert_openai_usage(usage_payloads[-1]["usage"])
+
+
+def test_openai_responses_non_streaming_returns_output_and_usage(
+    client: httpx.Client,
+    responses_model: str,
+):
+    """OpenAI Responses non-streaming should route to GHC /responses."""
+    response = client.post(
+        "/api/openai/v1/responses",
+        json=openai_responses_payload(responses_model),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["object"] == "response"
+    assert data["status"] == "completed"
+    message_items = [item for item in data["output"] if item.get("type") == "message"]
+    reasoning_items = [item for item in data["output"] if item.get("type") == "reasoning"]
+    assert message_items or reasoning_items, data
+    if message_items:
+        assert_text_response(_response_output_text(message_items[0]))
+    assert_responses_usage(data["usage"])
+
+
+def test_openai_responses_streaming_returns_lifecycle_events(
+    client: httpx.Client,
+    responses_model: str,
+):
+    """OpenAI Responses streaming should expose the core lifecycle events."""
+    with client.stream(
+        "POST",
+        "/api/openai/v1/responses",
+        json=openai_responses_payload(responses_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    payloads = event_payloads(events)
+
+    assert "response.created" in event_names
+    assert "response.in_progress" in event_names
+    assert "response.completed" in event_names
+    completed = next(
+        payload for name, payload in events if name == "response.completed"
+    )
+    assert completed["response"]["status"] == "completed"
+    usage = completed["response"].get("usage")
+    if usage:
+        assert_responses_usage(usage)
+    assert any(
+        payload.get("type") in {
+            "response.output_text.delta",
+            "response.reasoning_summary_text.delta",
+        }
+        for payload in payloads
+    )
+
+
+def test_openai_responses_forced_tool_call(client: httpx.Client, responses_model: str):
+    """OpenAI Responses should preserve forced function_call output items."""
+    response = client.post(
+        "/api/openai/v1/responses",
+        json=openai_responses_tool_payload(responses_model),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["status"] == "completed"
+    assert_response_has_function_call(data, "get_weather")
+    assert_responses_usage(data["usage"])
+
+
+def test_openai_responses_forced_tool_call_streaming(
+    client: httpx.Client,
+    responses_model: str,
+):
+    """OpenAI Responses stream should expose function-call argument events."""
+    with client.stream(
+        "POST",
+        "/api/openai/v1/responses",
+        json=openai_responses_tool_payload(responses_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    function_items = [
+        payload["item"]
+        for payload in payloads
+        if payload.get("type") == "response.output_item.done"
+        and payload.get("item", {}).get("type") == "function_call"
+    ]
+    assert function_items, payloads
+    assert any(item.get("name") == "get_weather" for item in function_items)
+    completed = next(
+        payload for name, payload in events if name == "response.completed"
+    )
+    usage = completed["response"].get("usage")
+    if usage:
+        assert_responses_usage(usage)
+
+
+def _response_output_text(message_item: dict[str, Any]) -> str:
+    content = message_item.get("content", [])
+    return "".join(
+        item.get("text", "") for item in content if item.get("type") == "output_text"
+    )

--- a/src/router_maestro/auth/storage.py
+++ b/src/router_maestro/auth/storage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from router_maestro.config.paths import AUTH_FILE
+from router_maestro.config.settings import write_json_owner_only
 
 
 class AuthType(StrEnum):
@@ -61,15 +62,12 @@ class AuthStorage(BaseModel):
 
     def save(self, path: Path = AUTH_FILE) -> None:
         """Save credentials to file."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-
         # Convert to dict format matching the spec
         data = {}
         for name, cred in self.credentials.items():
             data[name] = cred.model_dump(mode="json")
 
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
+        write_json_owner_only(path, data)
 
     def get(self, provider: str) -> Credential | None:
         """Get credential for a provider."""

--- a/src/router_maestro/config/settings.py
+++ b/src/router_maestro/config/settings.py
@@ -1,8 +1,10 @@
 """Global settings and configuration management."""
 
 import json
+import os
+from contextlib import suppress
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
@@ -12,6 +14,25 @@ from router_maestro.config.priorities import PrioritiesConfig
 from router_maestro.config.providers import ProvidersConfig
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def write_json_owner_only(path: Path, data: Any) -> None:
+    """Write JSON with owner-only permissions."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.chmod(0o600)
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+    except Exception:
+        with suppress(OSError):
+            os.close(fd)
+        raise
+
+    path.chmod(0o600)
 
 
 def load_config(path: Path, model: type[T], default_factory: callable) -> T:
@@ -41,9 +62,7 @@ def save_config(path: Path, config: BaseModel) -> None:
         path: Path to configuration file
         config: Configuration object to save
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(config.model_dump(mode="json"), f, indent=2, ensure_ascii=False)
+    write_json_owner_only(path, config.model_dump(mode="json"))
 
 
 def load_providers_config() -> ProvidersConfig:

--- a/src/router_maestro/providers/anthropic.py
+++ b/src/router_maestro/providers/anthropic.py
@@ -65,13 +65,46 @@ class AnthropicProvider(BaseProvider):
         for msg in messages:
             if msg.role == "system":
                 system_prompt = msg.content
+            elif msg.role == "tool":
+                converted.append(
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": msg.tool_call_id or "",
+                                "content": msg.content,
+                            }
+                        ],
+                    }
+                )
+            elif msg.role == "assistant" and msg.tool_calls:
+                content = []
+                if msg.content:
+                    content.append({"type": "text", "text": msg.content})
+                for tool_call in msg.tool_calls:
+                    function = tool_call.get("function", {})
+                    arguments = function.get("arguments", "{}")
+                    try:
+                        tool_input = json.loads(arguments) if arguments else {}
+                    except json.JSONDecodeError:
+                        tool_input = {}
+                    content.append(
+                        {
+                            "type": "tool_use",
+                            "id": tool_call.get("id", ""),
+                            "name": function.get("name", ""),
+                            "input": tool_input,
+                        }
+                    )
+                converted.append({"role": "assistant", "content": content})
             else:
                 converted.append({"role": msg.role, "content": msg.content})
 
         return system_prompt, converted
 
-    async def chat_completion(self, request: ChatRequest) -> ChatResponse:
-        """Generate a chat completion via Anthropic."""
+    def _build_payload(self, request: ChatRequest, *, stream: bool = False) -> dict:
+        """Build an Anthropic messages payload."""
         system_prompt, messages = self._convert_messages(request.messages)
 
         payload = {
@@ -79,6 +112,8 @@ class AnthropicProvider(BaseProvider):
             "messages": messages,
             "max_tokens": request.max_tokens or 4096,
         }
+        if stream:
+            payload["stream"] = True
         if system_prompt:
             payload["system"] = system_prompt
         if request.temperature != 1.0:
@@ -92,6 +127,11 @@ class AnthropicProvider(BaseProvider):
             payload["tools"] = request.tools
         if request.tool_choice:
             payload["tool_choice"] = request.tool_choice
+        return payload
+
+    async def chat_completion(self, request: ChatRequest) -> ChatResponse:
+        """Generate a chat completion via Anthropic."""
+        payload = self._build_payload(request)
 
         logger.debug("Anthropic chat completion: model=%s", request.model)
         async with httpx.AsyncClient() as client:
@@ -154,23 +194,7 @@ class AnthropicProvider(BaseProvider):
 
     async def chat_completion_stream(self, request: ChatRequest) -> AsyncIterator[ChatStreamChunk]:
         """Generate a streaming chat completion via Anthropic."""
-        system_prompt, messages = self._convert_messages(request.messages)
-
-        payload = {
-            "model": request.model,
-            "messages": messages,
-            "max_tokens": request.max_tokens or 4096,
-            "stream": True,
-        }
-        if system_prompt:
-            payload["system"] = system_prompt
-        if request.temperature != 1.0:
-            payload["temperature"] = request.temperature
-        if request.thinking_type and request.thinking_type != "disabled":
-            thinking_config: dict = {"type": request.thinking_type}
-            if request.thinking_budget:
-                thinking_config["budget_tokens"] = request.thinking_budget
-            payload["thinking"] = thinking_config
+        payload = self._build_payload(request, stream=True)
 
         logger.debug("Anthropic streaming chat: model=%s", request.model)
         async with httpx.AsyncClient() as client:

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -558,6 +558,8 @@ class CopilotProvider(BaseProvider):
             content, tool_calls = recover_tool_calls_from_content(
                 content, tool_calls, finish_reason
             )
+            if tool_calls and finish_reason in (None, "stop"):
+                finish_reason = "tool_calls"
 
             return ChatResponse(
                 content=content,
@@ -647,6 +649,7 @@ class CopilotProvider(BaseProvider):
                 response.raise_for_status()
 
                 stream_finished = False
+                emitted_tool_call = False
                 async for line in response.aiter_lines():
                     if stream_finished:
                         break
@@ -668,6 +671,10 @@ class CopilotProvider(BaseProvider):
                         content = delta.get("content", "")
                         finish_reason = data["choices"][0].get("finish_reason")
                         tool_calls = delta.get("tool_calls")
+                        if tool_calls:
+                            emitted_tool_call = True
+                        if finish_reason == "stop" and emitted_tool_call:
+                            finish_reason = "tool_calls"
                         if _thinking_requested(request):
                             thinking_text, thinking_sig = _extract_reasoning_from_chunk(delta)
                         else:

--- a/src/router_maestro/providers/openai_base.py
+++ b/src/router_maestro/providers/openai_base.py
@@ -33,7 +33,7 @@ class OpenAIChatProvider(BaseProvider, ABC):
 
     def _get_payload_extra(self, request: ChatRequest) -> dict:
         """Return extra payload fields for the request."""
-        return {}
+        return request.extra
 
     def _error_label(self) -> str:
         return self.name

--- a/src/router_maestro/providers/openai_compat.py
+++ b/src/router_maestro/providers/openai_compat.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-from router_maestro.providers.base import ChatRequest, ModelInfo
+from router_maestro.providers.base import ModelInfo
 from router_maestro.providers.openai_base import OpenAIChatProvider
 from router_maestro.utils import get_logger
 
@@ -42,9 +42,6 @@ class OpenAICompatibleProvider(OpenAIChatProvider):
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-
-    def _get_payload_extra(self, request: ChatRequest) -> dict:
-        return request.extra
 
     def _error_label(self) -> str:
         return self.name

--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -464,7 +464,7 @@ class Router:
                 provider = self.providers.get(provider_name)
                 if provider and provider.is_authenticated():
                     logger.debug("Fuzzy cache hit: '%s' -> '%s'", model_id, matched_key)
-                    return provider_name, matched_key, provider
+                    return provider_name, self._parse_model_key(matched_key)[1], provider
 
         # Fuzzy matching fallback
         matched_key = fuzzy_match_model(model_id, self._models_cache)
@@ -479,7 +479,7 @@ class Router:
                     matched_key,
                     provider_name,
                 )
-                return provider_name, matched_key, provider
+                return provider_name, self._parse_model_key(matched_key)[1], provider
 
         return None
 
@@ -677,10 +677,26 @@ class Router:
 
         actual_request = build_request(request, actual_model_id)
 
+        if is_stream and fallback:
+            priorities_config = self._get_priorities_config()
+            fallback_config = priorities_config.fallback
+            if fallback_config.strategy != FallbackStrategy.NONE:
+                candidates = self._get_fallback_candidates(
+                    provider_name, actual_model_id, fallback_config.strategy
+                )[: fallback_config.maxRetries]
+                return await self._open_stream_with_fallback(
+                    candidates=[(provider_name, actual_model_id, provider), *candidates],
+                    request=request,
+                    build_request=build_request,
+                    call_stream=call_stream,
+                    log_prefix=log_prefix,
+                )
+
         try:
             await provider.ensure_token()
             if is_stream:
                 stream = call_stream(provider, actual_request)
+                stream = self._wrap_stream_errors(stream, provider_name, _with_prefix)
                 logger.info(_with_prefix("stream request routed to %s"), provider_name)
                 return stream, provider_name
             response = await call_nonstream(provider, actual_request)
@@ -712,6 +728,7 @@ class Router:
                     await other_provider.ensure_token()
                     if is_stream:
                         stream = call_stream(other_provider, fallback_request)
+                        stream = self._wrap_stream_errors(stream, other_name, _with_prefix)
                         logger.info(_with_prefix("stream fallback succeeded via %s"), other_name)
                         return stream, other_name
                     response = await call_nonstream(other_provider, fallback_request)
@@ -722,6 +739,74 @@ class Router:
                         _with_prefix("fallback %s failed: %s"), other_name, fallback_error
                     )
                     continue
+            raise
+
+    async def _open_stream_with_fallback(
+        self,
+        candidates: list[tuple[str, str, BaseProvider]],
+        request: RequestT,
+        build_request: Callable[[RequestT, str], RequestT],
+        call_stream: Callable[[BaseProvider, RequestT], AsyncIterator[ChunkT]],
+        log_prefix: str,
+    ) -> tuple[AsyncIterator[ChunkT], str]:
+        """Open a stream and retry fallback providers before the first chunk."""
+
+        def _with_prefix(message: str) -> str:
+            return f"{log_prefix} {message}".strip()
+
+        last_error: ProviderError | None = None
+
+        for index, (candidate_name, candidate_model, candidate_provider) in enumerate(candidates):
+            if index > 0:
+                logger.info(_with_prefix("trying fallback: %s/%s"), candidate_name, candidate_model)
+
+            candidate_request = build_request(request, candidate_model)
+            try:
+                await candidate_provider.ensure_token()
+                stream = call_stream(candidate_provider, candidate_request)
+                first_chunk = await anext(stream, None)
+            except ProviderError as error:
+                logger.warning(_with_prefix("provider %s failed: %s"), candidate_name, error)
+                if not error.retryable:
+                    raise
+                last_error = error
+                continue
+
+            if index > 0:
+                logger.info(_with_prefix("stream fallback succeeded via %s"), candidate_name)
+            else:
+                logger.info(_with_prefix("stream request routed to %s"), candidate_name)
+
+            return self._chain_first_chunk(
+                first_chunk,
+                self._wrap_stream_errors(stream, candidate_name, _with_prefix),
+            ), candidate_name
+
+        if last_error is not None:
+            raise last_error
+        raise ProviderError("No stream fallback candidates available", status_code=503)
+
+    async def _chain_first_chunk(
+        self, first_chunk: ChunkT | None, stream: AsyncIterator[ChunkT]
+    ) -> AsyncIterator[ChunkT]:
+        """Yield a primed first chunk followed by the rest of the stream."""
+        if first_chunk is not None:
+            yield first_chunk
+        async for chunk in stream:
+            yield chunk
+
+    async def _wrap_stream_errors(
+        self,
+        stream: AsyncIterator[ChunkT],
+        provider_name: str,
+        format_message: Callable[[str], str],
+    ) -> AsyncIterator[ChunkT]:
+        """Log provider errors that occur after stream delivery has started."""
+        try:
+            async for chunk in stream:
+                yield chunk
+        except ProviderError as error:
+            logger.warning(format_message("stream provider %s failed: %s"), provider_name, error)
             raise
 
     async def responses_completion(

--- a/src/router_maestro/server/middleware/auth.py
+++ b/src/router_maestro/server/middleware/auth.py
@@ -25,13 +25,15 @@ async def verify_api_key(
     """
     server_api_key = get_server_api_key()
 
-    if server_api_key is None:
-        # No API key configured, allow all requests
-        return
-
     # Skip auth for health and root endpoints
     if request.url.path in ("/", "/health", "/docs", "/openapi.json", "/redoc"):
         return
+
+    if server_api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Server API key is not configured",
+        )
 
     # Get API key from header
     api_key: str | None = None

--- a/src/router_maestro/server/routes/chat.py
+++ b/src/router_maestro/server/routes/chat.py
@@ -69,6 +69,18 @@ async def chat_completions(request: ChatCompletionRequest):
             )
         )
 
+    extra = {
+        key: value
+        for key, value in {
+            "top_p": request.top_p,
+            "frequency_penalty": request.frequency_penalty,
+            "presence_penalty": request.presence_penalty,
+            "stop": request.stop,
+            "user": request.user,
+        }.items()
+        if value is not None
+    }
+
     chat_request = ChatRequest(
         model=request.model,
         messages=messages,
@@ -77,6 +89,7 @@ async def chat_completions(request: ChatCompletionRequest):
         stream=request.stream,
         tools=request.tools,
         tool_choice=request.tool_choice,
+        extra=extra,
     )
 
     # Reasoning / thinking passthrough.

--- a/src/router_maestro/server/routes/models.py
+++ b/src/router_maestro/server/routes/models.py
@@ -4,15 +4,10 @@ import time
 
 from fastapi import APIRouter
 
-from router_maestro.routing import Router
+from router_maestro.routing import get_router
 from router_maestro.server.schemas import ModelList, ModelObject
 
 router = APIRouter()
-
-
-def get_router() -> Router:
-    """Get the router instance."""
-    return Router()
 
 
 @router.get("/api/openai/v1/models")

--- a/tests/test_auth_advanced.py
+++ b/tests/test_auth_advanced.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from router_maestro.auth.storage import (
     ApiKeyCredential,
@@ -136,6 +137,17 @@ class TestAuthStorage:
             assert copilot_cred.type == AuthType.OAUTH
         finally:
             path.unlink(missing_ok=True)
+
+    def test_save_writes_owner_only_permissions(self, tmp_path):
+        """auth.json contains tokens and API keys, so it must not be group/world-readable."""
+        path = tmp_path / "auth.json"
+        storage = AuthStorage()
+        storage.set("openai", ApiKeyCredential(key="test-key"))
+
+        with patch("os.umask", return_value=0):
+            storage.save(path)
+
+        assert path.stat().st_mode & 0o777 == 0o600
 
     def test_load_nonexistent_returns_empty(self):
         """Test loading from nonexistent file returns empty storage."""

--- a/tests/test_chat_route_options.py
+++ b/tests/test_chat_route_options.py
@@ -1,0 +1,48 @@
+"""Tests for OpenAI chat route option passthrough."""
+
+import pytest
+
+from router_maestro.providers import ChatResponse
+from router_maestro.server.routes.chat import chat_completions
+from router_maestro.server.schemas import ChatCompletionRequest, ChatMessage
+
+
+class _CapturingRouter:
+    def __init__(self):
+        self.request = None
+
+    async def rewrite_to_reasoning_variant(self, request):
+        return request
+
+    async def chat_completion(self, request):
+        self.request = request
+        return ChatResponse(content="ok", model=request.model), "test-provider"
+
+
+@pytest.mark.anyio
+async def test_openai_chat_route_preserves_supported_extra_options(monkeypatch):
+    """Accepted OpenAI chat fields should reach provider-facing ChatRequest.extra."""
+    router = _CapturingRouter()
+    monkeypatch.setattr("router_maestro.server.routes.chat.get_router", lambda: router)
+
+    request = ChatCompletionRequest(
+        model="openai/gpt-4o",
+        messages=[ChatMessage(role="user", content="Hello")],
+        top_p=0.25,
+        frequency_penalty=0.1,
+        presence_penalty=0.2,
+        stop=["END"],
+        user="user-123",
+    )
+
+    response = await chat_completions(request)
+
+    assert response.choices[0].message.content == "ok"
+    assert router.request is not None
+    assert router.request.extra == {
+        "top_p": 0.25,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+        "stop": ["END"],
+        "user": "user-123",
+    }

--- a/tests/test_chat_stream_usage.py
+++ b/tests/test_chat_stream_usage.py
@@ -110,3 +110,47 @@ async def test_copilot_chat_stream_requests_usage_from_upstream():
 
     assert chunks[-1].finish_reason == "stop"
     assert captured_payloads[0]["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.asyncio
+async def test_copilot_chat_stream_tool_calls_force_tool_calls_finish_reason():
+    """Copilot can stream tool_calls with finish_reason=stop; normalize it."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        body = (
+            b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+            b'"type":"function","function":{"name":"test_tool","arguments":"{}"}}]},'
+            b'"finish_reason":null}]}\n\n'
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+        )
+        return httpx.Response(
+            status_code=200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = CopilotProvider()
+    provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider.ensure_token = _noop  # type: ignore[method-assign]
+    provider._get_headers = lambda vision_request=False: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+
+    request = ChatRequest(
+        model="gpt-4o",
+        messages=[Message(role="user", content="Use the test tool")],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "test_tool",
+                    "description": "A test tool",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        tool_choice={"type": "function", "function": {"name": "test_tool"}},
+        stream=True,
+    )
+    chunks = [chunk async for chunk in provider.chat_completion_stream(request)]
+
+    assert any(chunk.tool_calls for chunk in chunks)
+    assert chunks[-1].finish_reason == "tool_calls"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 import tempfile
 import tomllib
 from pathlib import Path
+from unittest.mock import patch
 
 import tomlkit
 
@@ -84,6 +85,19 @@ class TestConfigIO:
             # Load and verify
             loaded = load_config(path, ProvidersConfig, ProvidersConfig.get_default)
             assert loaded.providers.keys() == original.providers.keys()
+
+    def test_save_config_writes_owner_only_permissions(self, tmp_path):
+        """Config files may contain API keys and should be owner-readable only."""
+        path = tmp_path / "contexts.json"
+        config = ContextsConfig(
+            current="local",
+            contexts={"local": ContextConfig(endpoint="http://localhost:8080", api_key="sk-test")},
+        )
+
+        with patch("os.umask", return_value=0):
+            save_config(path, config)
+
+        assert path.stat().st_mode & 0o777 == 0o600
 
     def test_load_creates_default(self):
         """Test that loading non-existent file creates default."""

--- a/tests/test_gemini_routes.py
+++ b/tests/test_gemini_routes.py
@@ -1062,3 +1062,10 @@ class TestGoogApiKeyAuth:
         """x-api-key header should still work."""
         response = auth_client.get("/test", headers={"x-api-key": "test-key-123"})
         assert response.status_code == 200
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_server_api_key_rejects_protected_routes(self, auth_client):
+        """Protected routes must not become public when server API key is unset."""
+        response = auth_client.get("/test", headers={"Authorization": "Bearer any-key"})
+        assert response.status_code == 500
+        assert "not configured" in response.json()["detail"]

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -1,0 +1,40 @@
+"""Tests for the local-only integration test harness."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_integration_tests_are_outside_default_pytest_tree():
+    """Integration tests should not be discovered by the default tests/ run."""
+    integration_dir = ROOT / "integration_tests"
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert integration_dir.is_dir()
+    assert 'testpaths = ["tests"]' in pyproject
+
+
+def test_makefile_exposes_explicit_integration_test_target():
+    """Local live-backend tests should have an explicit Makefile entrypoint."""
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+    assert "integration-test:" in makefile
+    assert "uv run pytest integration_tests/ -v" in makefile
+
+
+def test_integration_harness_documents_existing_config_usage():
+    """The harness should say it reuses the user's existing RM configuration."""
+    conftest = (ROOT / "integration_tests" / "conftest.py").read_text(encoding="utf-8")
+
+    assert "get_current_context_api_key" in conftest
+    assert "ROUTER_MAESTRO_API_KEY" in conftest
+    assert "router_maestro.server:app" in conftest
+
+
+def test_integration_tests_do_not_cover_admin_endpoints():
+    """Live integration tests should cover model calls, not admin endpoints."""
+    integration_dir = ROOT / "integration_tests"
+
+    for path in integration_dir.rglob("*.py"):
+        content = path.read_text(encoding="utf-8")
+        assert "/api/admin/" not in content, path

--- a/tests/test_models_route.py
+++ b/tests/test_models_route.py
@@ -1,0 +1,24 @@
+"""Tests for the OpenAI-compatible models route."""
+
+import pytest
+
+from router_maestro.providers import ModelInfo
+from router_maestro.server.routes.models import list_models
+
+
+class _FakeRouter:
+    async def list_models(self):
+        return [ModelInfo(id="gpt-4o", name="GPT-4o", provider="openai")]
+
+
+@pytest.mark.anyio
+async def test_openai_models_route_uses_routing_singleton(monkeypatch):
+    """The models route should reuse the routing singleton instead of constructing Router."""
+    fake_router = _FakeRouter()
+
+    monkeypatch.setattr("router_maestro.routing.router._router_instance", fake_router)
+
+    response = await list_models()
+
+    assert len(response.data) == 1
+    assert response.data[0].id == "gpt-4o"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -111,3 +111,64 @@ class TestAnthropicMessageConversion:
 
         assert system is None
         assert len(converted) == 2
+
+    def test_assistant_tool_calls_convert_to_tool_use_blocks(self):
+        """Assistant tool calls must be sent in Anthropic content block format."""
+        provider = AnthropicProvider()
+
+        messages = [
+            Message(role="user", content="Check the weather"),
+            Message(
+                role="assistant",
+                content="I'll check.",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location":"Shanghai"}',
+                        },
+                    }
+                ],
+            ),
+        ]
+
+        system, converted = provider._convert_messages(messages)
+
+        assert system is None
+        assert converted[1] == {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I'll check."},
+                {
+                    "type": "tool_use",
+                    "id": "call_1",
+                    "name": "get_weather",
+                    "input": {"location": "Shanghai"},
+                },
+            ],
+        }
+
+    def test_tool_messages_convert_to_user_tool_result_blocks(self):
+        """Internal tool-role messages must become Anthropic user tool_result blocks."""
+        provider = AnthropicProvider()
+
+        messages = [
+            Message(role="tool", content='{"temperature":22}', tool_call_id="call_1"),
+        ]
+
+        _system, converted = provider._convert_messages(messages)
+
+        assert converted == [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": '{"temperature":22}',
+                    }
+                ],
+            }
+        ]

--- a/tests/test_providers_advanced.py
+++ b/tests/test_providers_advanced.py
@@ -407,3 +407,26 @@ class TestOpenAIChatProviderBuildPayload:
         tool_msg = payload["messages"][2]
         assert tool_msg["tool_call_id"] == "call_1"
         assert tool_msg["role"] == "tool"
+
+    def test_payload_includes_supported_extra_fields(self):
+        """OpenAI-compatible chat providers should forward route-level OpenAI options."""
+        provider = self._make_provider()
+        request = ChatRequest(
+            model="gpt-4o",
+            messages=[Message(role="user", content="hi")],
+            extra={
+                "top_p": 0.25,
+                "frequency_penalty": 0.1,
+                "presence_penalty": 0.2,
+                "stop": ["END"],
+                "user": "user-123",
+            },
+        )
+
+        payload = provider._build_payload(request, stream=False)
+
+        assert payload["top_p"] == 0.25
+        assert payload["frequency_penalty"] == 0.1
+        assert payload["presence_penalty"] == 0.2
+        assert payload["stop"] == ["END"]
+        assert payload["user"] == "user-123"

--- a/tests/test_router_advanced.py
+++ b/tests/test_router_advanced.py
@@ -244,6 +244,36 @@ class TestRouterModelResolutionAsync:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_provider_scoped_fuzzy_match_uses_bare_upstream_model(self):
+        """Provider-scoped fuzzy matches must not pass provider/model upstream."""
+        router = Router.__new__(Router)
+        anthropic = MockProvider(
+            name="anthropic",
+            models=[
+                ModelInfo(
+                    id="claude-sonnet-4-5-20250929",
+                    name="Claude Sonnet 4.5",
+                    provider="anthropic",
+                )
+            ],
+        )
+        router.providers = {"anthropic": anthropic}
+        _init_router_empty(router)
+        router._models_cache = {
+            "claude-sonnet-4-5-20250929": ("anthropic", anthropic._models[0]),
+            "anthropic/claude-sonnet-4-5-20250929": ("anthropic", anthropic._models[0]),
+        }
+        _mark_models_cached(router)
+        _mark_providers_fresh(router)
+
+        result = await router._find_model_in_cache("anthropic/sonnet-4-5")
+
+        assert result is not None
+        provider_name, model_id, _provider = result
+        assert provider_name == "anthropic"
+        assert model_id == "claude-sonnet-4-5-20250929"
+
+    @pytest.mark.asyncio
     async def test_resolve_auto_route_model(self, router_with_providers):
         """Test resolving auto-route model."""
         _set_priorities(
@@ -432,6 +462,42 @@ class TestRouterFallback:
         candidates = router._get_fallback_candidates("primary", "model-1", FallbackStrategy.NONE)
 
         assert len(candidates) == 0
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_falls_back_when_primary_fails_before_first_chunk(
+        self, router_with_fallback
+    ):
+        """Streaming fallback should handle retryable errors raised when iteration starts."""
+        router, primary, secondary = router_with_fallback
+        request = ChatRequest(
+            model="model-1",
+            messages=[Message(role="user", content="Hello")],
+            stream=True,
+        )
+
+        stream, provider_name = await router.chat_completion_stream(request)
+        chunks = [chunk async for chunk in stream]
+
+        assert provider_name == "secondary"
+        assert primary._request_count == 1
+        assert secondary._request_count == 1
+        assert chunks[0].content == "Hello "
+
+    @pytest.mark.asyncio
+    async def test_responses_stream_falls_back_when_primary_fails_before_first_chunk(
+        self, router_with_fallback
+    ):
+        """Responses streams should use the same initial-error fallback behavior."""
+        router, primary, secondary = router_with_fallback
+        request = ResponsesRequest(model="model-1", input="Hello", stream=True)
+
+        stream, provider_name = await router.responses_completion_stream(request)
+        chunks = [chunk async for chunk in stream]
+
+        assert provider_name == "secondary"
+        assert primary._request_count == 1
+        assert secondary._request_count == 1
+        assert chunks[0].content == "Hello "
 
 
 class TestRouterListModels:

--- a/tests/test_thinking_passthrough.py
+++ b/tests/test_thinking_passthrough.py
@@ -235,6 +235,69 @@ class TestCopilotNonstreamingTools:
         assert "tool_choice" in captured_payload
         assert captured_payload["tool_choice"] == "auto"
 
+    @pytest.mark.asyncio
+    async def test_copilot_tool_calls_force_tool_calls_finish_reason(self):
+        """Copilot can return tool_calls with finish_reason=stop; normalize it."""
+        from router_maestro.providers.copilot import CopilotProvider
+
+        provider = CopilotProvider()
+        provider._cached_token = "test-token"
+        provider._token_expires = 9999999999
+
+        request = ChatRequest(
+            model="gpt-4o",
+            messages=[Message(role="user", content="Use the test tool")],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool",
+                        "description": "A test tool",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            tool_choice={"type": "function", "function": {"name": "test_tool"}},
+        )
+
+        async def mock_post(url, json=None, headers=None, timeout=None):
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = lambda: None
+            mock_response.json = lambda: {
+                "choices": [
+                    {
+                        "message": {
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "test_tool",
+                                        "arguments": "{}",
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "model": "gpt-4o",
+            }
+            return mock_response
+
+        mock_client = AsyncMock()
+        mock_client.post = mock_post
+        mock_client.is_closed = False
+        provider._client = mock_client
+
+        with patch.object(provider, "ensure_token", new_callable=AsyncMock):
+            response = await provider.chat_completion(request)
+
+        assert response.tool_calls is not None
+        assert response.finish_reason == "tool_calls"
+
 
 class TestRouterPreservesThinkingFields:
     """Tests for thinking fields preserved through router model-swap."""
@@ -358,3 +421,33 @@ class TestAnthropicProviderThinking:
                 await provider.chat_completion(request)
 
         assert "thinking" not in captured_payload
+
+    @pytest.mark.asyncio
+    async def test_anthropic_streaming_forwards_tools_and_tool_choice(self):
+        """Streaming Anthropic requests should preserve tool declarations."""
+        from router_maestro.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            }
+        ]
+
+        request = ChatRequest(
+            model="claude-sonnet-4-20250514",
+            messages=[Message(role="user", content="Hello")],
+            tools=tools,
+            tool_choice={"type": "tool", "name": "get_weather"},
+        )
+
+        payload = provider._build_payload(request, stream=True)
+
+        assert payload["stream"] is True
+        assert payload["tools"] == tools
+        assert payload["tool_choice"] == {"type": "tool", "name": "get_weather"}


### PR DESCRIPTION
## Summary
- Fix high/medium review issues around provider routing, streaming fallback, API key handling, config/auth file permissions, and OpenAI/Anthropic/Gemini compatibility.
- Add local-only live integration tests that start Router-Maestro and exercise real GitHub Copilot model invocation paths across OpenAI Chat, Responses, Anthropic, Gemini, streaming, tool calls, usage, and a configurable model matrix.
- Document integration test commands in README, AGENTS.md, and CLAUDE.md, including full matrix execution with RM_INTEGRATION_MAX_MODELS=0.

## Test Plan
- uv run ruff check src/ tests/ integration_tests/
- uv run pytest tests/ -q
- make integration-test