### PR TITLE
Fix Copilot endpoint metadata and full integration matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,10 @@ Run the local live-backend integration tests:
 make integration-test
 ```
 
-Run the full local integration test model matrix:
+Run a bounded local integration test model matrix:
 
 ```bash
-RM_INTEGRATION_MAX_MODELS=0 make integration-test
+RM_INTEGRATION_MAX_MODELS=8 make integration-test
 ```
 
 The integration tests start a local Router-Maestro server, reuse the existing
@@ -232,9 +232,9 @@ uv run router-maestro auth login github-copilot
 - For route behavior, use the existing FastAPI test patterns in `tests/`.
 - For provider behavior, mock upstream HTTP calls rather than calling real
   provider APIs.
-- For local live-backend validation, use `make integration-test`. To run the
-  complete Copilot model matrix instead of the default bounded subset, use
-  `RM_INTEGRATION_MAX_MODELS=0 make integration-test`.
+- For local live-backend validation, use `make integration-test`; it runs the
+  complete Copilot model matrix by default. To intentionally run a bounded
+  subset, use `RM_INTEGRATION_MAX_MODELS=<N> make integration-test`.
 - Run the narrowest relevant pytest target first, then broaden to the full
   suite when the change has wider risk.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@ uv run pytest tests/ -v
 # Run local live-backend integration tests
 make integration-test
 
-# Run the full local integration test model matrix
-RM_INTEGRATION_MAX_MODELS=0 make integration-test
+# Run a bounded local integration test model matrix
+RM_INTEGRATION_MAX_MODELS=8 make integration-test
 
 # Run a single test file
 uv run pytest tests/test_auth.py -v
@@ -54,11 +54,12 @@ require GitHub Copilot auth:
 uv run router-maestro auth login github-copilot
 ```
 
-Use `make integration-test` for the default live suite. Use
-`RM_INTEGRATION_MAX_MODELS=0 make integration-test` for the full Copilot model
-matrix. The suite covers model invocation paths such as OpenAI Chat/Responses,
-Anthropic Messages/count_tokens, Gemini generateContent/stream/countTokens,
-streaming, tool calls, and usage accounting.
+Use `make integration-test` for the default live suite, which includes the full
+Copilot model matrix. Use `RM_INTEGRATION_MAX_MODELS=<N> make integration-test`
+only when you intentionally want a bounded model subset. The suite covers model
+invocation paths such as OpenAI Chat/Responses, Anthropic Messages/count_tokens,
+Gemini generateContent/stream/countTokens, streaming, tool calls, and usage
+accounting.
 
 ### Docker Deployment
 

--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ Actions. They start a local Router-Maestro server, reuse your existing
 Router-Maestro config/auth files, and send requests to the real GitHub Copilot
 backend. The suite covers model invocation paths only: OpenAI Chat, OpenAI
 Responses, Anthropic Messages/count_tokens, Gemini generateContent/stream/countTokens,
-tool calls, streaming, usage accounting, and a configurable Copilot model
-matrix. Admin endpoints are intentionally not covered by these tests.
+tool calls, streaming, usage accounting, and the full Copilot model matrix by
+default. Admin endpoints are intentionally not covered by these tests.
 
 Prerequisites:
 
@@ -302,7 +302,7 @@ RM_INTEGRATION_MODEL=github-copilot/gpt-4o make integration-test
 RM_INTEGRATION_TOOL_MODEL=github-copilot/gpt-4o make integration-test
 RM_INTEGRATION_RESPONSES_MODEL=github-copilot/gpt-5.4-mini make integration-test
 RM_INTEGRATION_MODELS=github-copilot/gpt-4o,github-copilot/claude-sonnet-4.5 make integration-test
-RM_INTEGRATION_MAX_MODELS=0 make integration-test
+RM_INTEGRATION_MAX_MODELS=8 make integration-test
 ```
 
 ## API Reference

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -25,15 +25,11 @@ from router_maestro.utils.responses_bridge import RESPONSES_ELIGIBLE_MODELS
 STARTUP_TIMEOUT_SECONDS = 45.0
 REQUEST_TIMEOUT_SECONDS = 120.0
 STREAM_TIMEOUT_SECONDS = 180.0
-DEFAULT_MAX_MODEL_MATRIX = 8
+DEFAULT_MAX_MODEL_MATRIX = 0
 DEFAULT_API_KEY = "router-maestro-integration-test"
 COPILOT_PROVIDER = "github-copilot"
-TEXT_PROMPT = (
-    "Reply with exactly the word pong. Do not add punctuation or any other words."
-)
-TOOL_PROMPT = (
-    "Use the provided get_weather tool for Shanghai. Do not answer directly."
-)
+TEXT_PROMPT = "Reply with exactly the word pong. Do not add punctuation or any other words."
+TOOL_PROMPT = "Use the provided get_weather tool for Shanghai. Do not answer directly."
 
 
 @dataclass(frozen=True)
@@ -197,9 +193,7 @@ def responses_model(copilot_models: list[str]) -> str:
             f"RM_INTEGRATION_RESPONSES_MODEL={requested!r} is not in available Copilot models"
         )
 
-    eligible = {
-        f"{COPILOT_PROVIDER}/{model_id}" for model_id in RESPONSES_ELIGIBLE_MODELS
-    }
+    eligible = {f"{COPILOT_PROVIDER}/{model_id}" for model_id in RESPONSES_ELIGIBLE_MODELS}
     preferred = (
         "github-copilot/gpt-5.4-mini",
         "github-copilot/gpt-5.4",
@@ -224,6 +218,20 @@ def openai_chat_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
         "max_tokens": 16,
         "stream": stream,
     }
+
+
+def model_matrix_chat_payload(model: str) -> dict[str, Any]:
+    """OpenAI Chat payload for the full live model matrix.
+
+    Reasoning-heavy models such as Gemini can spend the first dozens of output
+    tokens on hidden reasoning. Keep the matrix prompt small but give enough
+    output budget for visible text so the test validates model invocation
+    rather than failing on a too-small local cap.
+    """
+    payload = openai_chat_payload(model)
+    payload["max_tokens"] = 512
+    payload["reasoning_effort"] = "low"
+    return payload
 
 
 def openai_responses_payload(model: str, *, stream: bool = False) -> dict[str, Any]:

--- a/integration_tests/test_live_model_matrix.py
+++ b/integration_tests/test_live_model_matrix.py
@@ -10,7 +10,7 @@ from integration_tests.conftest import (
     assert_responses_usage,
     assert_text_response,
     is_responses_eligible_model,
-    openai_chat_payload,
+    model_matrix_chat_payload,
     openai_responses_payload,
 )
 
@@ -36,7 +36,7 @@ def test_copilot_model_matrix_openai_chat(
             else:
                 response = client.post(
                     "/api/openai/v1/chat/completions",
-                    json=openai_chat_payload(model),
+                    json=model_matrix_chat_payload(model),
                 )
                 assert_http_success(response)
                 data = response.json()

--- a/src/router_maestro/auth/github_oauth.py
+++ b/src/router_maestro/auth/github_oauth.py
@@ -41,12 +41,20 @@ class CopilotTokenResponse:
     token: str
     expires_at: int
     refresh_in: int
+    api_endpoint: str | None = None
 
 
 class GitHubOAuthError(Exception):
     """Error during GitHub OAuth flow."""
 
     pass
+
+
+def _is_retryable_token_error(error: httpx.HTTPError) -> bool:
+    """Whether a Copilot token refresh error is likely transient."""
+    if isinstance(error, httpx.HTTPStatusError):
+        return error.response.status_code == 429 or error.response.status_code >= 500
+    return True
 
 
 async def request_device_code(client: httpx.AsyncClient) -> DeviceCodeResponse:
@@ -160,17 +168,35 @@ async def get_copilot_token(
         "X-Vscode-User-Agent-Library-Version": "electron-fetch",
     }
 
-    response = await client.get(
-        COPILOT_TOKEN_URL,
-        headers=headers,
-    )
-    response.raise_for_status()
+    response: httpx.Response | None = None
+    max_attempts = 3
+    for attempt in range(max_attempts):
+        try:
+            response = await client.get(
+                COPILOT_TOKEN_URL,
+                headers=headers,
+            )
+            response.raise_for_status()
+            break
+        except httpx.HTTPError as e:
+            if attempt == max_attempts - 1 or not _is_retryable_token_error(e):
+                raise
+            await _async_sleep(0.2 * (attempt + 1))
+
+    if response is None:
+        raise GitHubOAuthError("Failed to exchange GitHub token for Copilot token")
+
     data = response.json()
+    endpoints = data.get("endpoints")
+    api_endpoint = None
+    if isinstance(endpoints, dict) and isinstance(endpoints.get("api"), str):
+        api_endpoint = endpoints["api"]
 
     return CopilotTokenResponse(
         token=data["token"],
         expires_at=data["expires_at"],
         refresh_in=data.get("refresh_in", 1800000),  # Default 30 minutes in ms
+        api_endpoint=api_endpoint,
     )
 
 

--- a/src/router_maestro/auth/manager.py
+++ b/src/router_maestro/auth/manager.py
@@ -106,6 +106,7 @@ class AuthManager:
                     refresh=access_token.access_token,  # GitHub token for refresh
                     access=copilot_token.token,  # Copilot token for API calls
                     expires=copilot_token.expires_at,
+                    api_endpoint=copilot_token.api_endpoint,
                 ),
             )
             self.save()

--- a/src/router_maestro/auth/storage.py
+++ b/src/router_maestro/auth/storage.py
@@ -24,6 +24,10 @@ class OAuthCredential(BaseModel):
     refresh: str = Field(..., description="Refresh token")
     access: str = Field(..., description="Access token")
     expires: int = Field(default=0, description="Expiration timestamp (0 = never)")
+    api_endpoint: str | None = Field(
+        default=None,
+        description="Provider API endpoint returned with the OAuth token",
+    )
 
 
 class ApiKeyCredential(BaseModel):

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -4,6 +4,8 @@ import contextlib
 import json
 import time
 from collections.abc import AsyncIterator
+from typing import Any
+from uuid import uuid4
 
 import httpx
 
@@ -16,6 +18,7 @@ from router_maestro.providers.base import (
     ChatRequest,
     ChatResponse,
     ChatStreamChunk,
+    Message,
     ModelInfo,
     ProviderError,
     ResponsesRequest,
@@ -31,9 +34,9 @@ from router_maestro.utils.reasoning import budget_to_effort, downgrade_for_upstr
 logger = get_logger("providers.copilot")
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
-COPILOT_CHAT_URL = f"{COPILOT_BASE_URL}/chat/completions"
-COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
-COPILOT_RESPONSES_URL = f"{COPILOT_BASE_URL}/responses"
+COPILOT_CHAT_PATH = "/chat/completions"
+COPILOT_MODELS_PATH = "/models"
+COPILOT_RESPONSES_PATH = "/responses"
 
 # Upstream /responses events we intentionally don't consume because the route
 # (server/routes/responses.py) synthesizes its own equivalents from the deltas
@@ -254,6 +257,7 @@ class CopilotProvider(BaseProvider):
         self.auth_manager = AuthManager()
         self._cached_token: str | None = None
         self._token_expires: int = 0
+        self._api_base = COPILOT_BASE_URL
         # Model cache
         self._models_ttl_cache: TTLCache[list[ModelInfo]] = TTLCache(MODELS_CACHE_TTL)
         # Reusable HTTP client
@@ -270,6 +274,9 @@ class CopilotProvider(BaseProvider):
         if not cred or not isinstance(cred, OAuthCredential):
             logger.error("Not authenticated with GitHub Copilot")
             raise ProviderError("Not authenticated with GitHub Copilot", status_code=401)
+
+        if cred.api_endpoint:
+            self._api_base = cred.api_endpoint
 
         current_time = int(time.time())
 
@@ -289,18 +296,53 @@ class CopilotProvider(BaseProvider):
 
         self._cached_token = copilot_token.token
         self._token_expires = copilot_token.expires_at
+        self._api_base = copilot_token.api_endpoint or self._api_base or COPILOT_BASE_URL
 
         # Update stored credential with new access token (immutable pattern)
         updated_cred = OAuthCredential(
             refresh=cred.refresh,
             access=copilot_token.token,
             expires=copilot_token.expires_at,
+            api_endpoint=copilot_token.api_endpoint or cred.api_endpoint,
         )
         self.auth_manager.storage.set("github-copilot", updated_cred)
         self.auth_manager.save()
         logger.debug("Copilot token refreshed, expires at %d", copilot_token.expires_at)
 
-    def _get_headers(self, vision_request: bool = False) -> dict[str, str]:
+    def _url(self, path: str) -> str:
+        """Build a Copilot API URL from the token-advertised API base."""
+        return f"{self._api_base.rstrip('/')}/{path.lstrip('/')}"
+
+    @staticmethod
+    def _chat_initiator(messages: list[Message] | None) -> str:
+        """Infer Copilot X-Initiator for chat-completions payloads."""
+        if not messages:
+            return "user"
+        for message in messages:
+            if message.role in ("assistant", "tool"):
+                return "agent"
+        return "user"
+
+    @staticmethod
+    def _responses_initiator(response_input: str | list[dict[str, Any]] | None) -> str:
+        """Infer Copilot X-Initiator for Responses API payloads."""
+        if isinstance(response_input, str) or not response_input:
+            return "user"
+        for item in response_input:
+            if not isinstance(item, dict):
+                continue
+            role = item.get("role")
+            if not role or (isinstance(role, str) and role.lower() == "assistant"):
+                return "agent"
+        return "user"
+
+    def _get_headers(
+        self,
+        vision_request: bool = False,
+        *,
+        messages: list[Message] | None = None,
+        response_input: str | list[dict[str, Any]] | None = None,
+    ) -> dict[str, str]:
         """Get headers for Copilot API requests.
 
         Args:
@@ -312,10 +354,19 @@ class CopilotProvider(BaseProvider):
         headers = {
             "Authorization": f"Bearer {self._cached_token}",
             "Content-Type": "application/json",
-            "Editor-Version": "vscode/1.85.0",
-            "Editor-Plugin-Version": "copilot/1.0.0",
+            "Editor-Version": "vscode/1.95.0",
+            "Editor-Plugin-Version": "copilot-chat/0.26.7",
             "Copilot-Integration-Id": "vscode-chat",
+            "User-Agent": "GitHubCopilotChat/0.26.7",
+            "OpenAI-Intent": "conversation-panel",
+            "X-GitHub-Api-Version": "2025-04-01",
+            "X-Request-Id": str(uuid4()),
+            "X-Vscode-User-Agent-Library-Version": "electron-fetch",
         }
+        if response_input is not None:
+            headers["X-Initiator"] = self._responses_initiator(response_input)
+        elif messages is not None:
+            headers["X-Initiator"] = self._chat_initiator(messages)
 
         if vision_request:
             headers["Copilot-Vision-Request"] = "true"
@@ -411,6 +462,24 @@ class CopilotProvider(BaseProvider):
 
         return messages, has_images
 
+    def _responses_input_has_vision(self, value: Any, depth: int = 0) -> bool:
+        """Whether a Responses API input contains an image block."""
+        if depth > 32 or value is None:
+            return False
+        if isinstance(value, list):
+            return any(self._responses_input_has_vision(item, depth + 1) for item in value)
+        if not isinstance(value, dict):
+            return False
+        item_type = value.get("type")
+        if isinstance(item_type, str) and item_type.lower() in ("input_image", "image_url"):
+            return True
+        if "image_url" in value:
+            return True
+        content = value.get("content")
+        if isinstance(content, list):
+            return any(self._responses_input_has_vision(item, depth + 1) for item in content)
+        return False
+
     async def chat_completion(self, request: ChatRequest) -> ChatResponse:
         """Generate a chat completion via Copilot."""
         # Experimental: route GPT-5.x ChatRequests through /responses when the
@@ -467,9 +536,9 @@ class CopilotProvider(BaseProvider):
         client = self._get_client()
         try:
             response = await client.post(
-                COPILOT_CHAT_URL,
+                self._url(COPILOT_CHAT_PATH),
                 json=payload,
-                headers=self._get_headers(vision_request=has_images),
+                headers=self._get_headers(vision_request=has_images, messages=request.messages),
                 timeout=TIMEOUT_NON_STREAMING,
             )
             response.raise_for_status()
@@ -633,9 +702,9 @@ class CopilotProvider(BaseProvider):
         try:
             async with client.stream(
                 "POST",
-                COPILOT_CHAT_URL,
+                self._url(COPILOT_CHAT_PATH),
                 json=payload,
-                headers=self._get_headers(vision_request=has_images),
+                headers=self._get_headers(vision_request=has_images, messages=request.messages),
             ) as response:
                 # Streamed responses defer body reads; if the upstream returns
                 # an error status, pull the body *inside* the stream context
@@ -727,7 +796,7 @@ class CopilotProvider(BaseProvider):
                 type(e).__name__,
                 e,
                 json.dumps(payload, default=str)[:2000],
-                COPILOT_CHAT_URL,
+                self._url(COPILOT_CHAT_PATH),
                 headers,
                 resp_text,
             )
@@ -757,7 +826,7 @@ class CopilotProvider(BaseProvider):
         try:
             async with httpx.AsyncClient(timeout=TIMEOUT_NON_STREAMING) as client:
                 response = await client.get(
-                    COPILOT_MODELS_URL,
+                    self._url(COPILOT_MODELS_PATH),
                     headers=self._get_headers(),
                 )
                 response.raise_for_status()
@@ -768,6 +837,12 @@ class CopilotProvider(BaseProvider):
                 # Only include models that are enabled in model picker
                 if model.get("model_picker_enabled", True):
                     caps = model.get("capabilities", {})
+                    if caps.get("type") == "completion":
+                        logger.debug(
+                            "Skipping Copilot completion-only model without RM route: %s",
+                            model.get("id"),
+                        )
+                        continue
                     limits = caps.get("limits", {})
                     supports = caps.get("supports", {})
                     reasoning_values = supports.get("reasoning_effort")
@@ -994,9 +1069,14 @@ class CopilotProvider(BaseProvider):
         client = self._get_client()
         try:
             response = await client.post(
-                COPILOT_RESPONSES_URL,
+                self._url(COPILOT_RESPONSES_PATH),
                 json=payload,
-                headers=self._get_headers(),
+                headers=self._get_headers(
+                    vision_request=self._responses_input_has_vision(request.input),
+                    response_input=(
+                        request.input if isinstance(request.input, (str, list)) else None
+                    ),
+                ),
                 timeout=TIMEOUT_NON_STREAMING,
             )
             response.raise_for_status()
@@ -1063,9 +1143,14 @@ class CopilotProvider(BaseProvider):
         try:
             async with client.stream(
                 "POST",
-                COPILOT_RESPONSES_URL,
+                self._url(COPILOT_RESPONSES_PATH),
                 json=payload,
-                headers=self._get_headers(),
+                headers=self._get_headers(
+                    vision_request=self._responses_input_has_vision(request.input),
+                    response_input=(
+                        request.input if isinstance(request.input, (str, list)) else None
+                    ),
+                ),
             ) as response:
                 # Check for errors before processing stream
                 if response.status_code >= 400:

--- a/tests/test_auth_advanced.py
+++ b/tests/test_auth_advanced.py
@@ -2,8 +2,18 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
+import pytest
+
+from router_maestro.auth.github_oauth import (
+    AccessTokenResponse,
+    CopilotTokenResponse,
+    DeviceCodeResponse,
+    get_copilot_token,
+)
+from router_maestro.auth.manager import AuthManager
 from router_maestro.auth.storage import (
     ApiKeyCredential,
     AuthStorage,
@@ -46,6 +56,140 @@ class TestOAuthCredential:
             access="access-token",
         )
         assert cred.expires == 0
+
+    def test_copilot_api_endpoint_metadata(self):
+        """OAuth credentials can persist the Copilot API endpoint returned with the token."""
+        cred = OAuthCredential(
+            refresh="refresh-token",
+            access="access-token",
+            expires=1234567890,
+            api_endpoint="https://api.enterprise.githubcopilot.com",
+        )
+
+        assert cred.api_endpoint == "https://api.enterprise.githubcopilot.com"
+
+
+class TestGitHubOAuth:
+    """Tests for GitHub Copilot OAuth token exchange."""
+
+    @pytest.mark.asyncio
+    async def test_get_copilot_token_includes_endpoint_metadata(self):
+        """Copilot token exchange keeps endpoint metadata for model calls."""
+        response = httpx.Response(
+            200,
+            json={
+                "token": "copilot-token",
+                "expires_at": 1234567890,
+                "refresh_in": 1000,
+                "endpoints": {"api": "https://api.enterprise.githubcopilot.com"},
+            },
+            request=httpx.Request("GET", "https://api.github.com/copilot_internal/v2/token"),
+        )
+        client = AsyncMock()
+        client.get.return_value = response
+
+        token = await get_copilot_token(client, "github-token")
+
+        assert token.token == "copilot-token"
+        assert token.api_endpoint == "https://api.enterprise.githubcopilot.com"
+
+    @pytest.mark.asyncio
+    async def test_get_copilot_token_retries_transient_errors(self):
+        """Transient refresh failures should be retried before surfacing to callers."""
+        ok = httpx.Response(
+            200,
+            json={
+                "token": "copilot-token",
+                "expires_at": 1234567890,
+                "refresh_in": 1000,
+            },
+            request=httpx.Request("GET", "https://api.github.com/copilot_internal/v2/token"),
+        )
+        client = AsyncMock()
+        client.get.side_effect = [
+            httpx.ConnectError("temporary"),
+            ok,
+        ]
+
+        with patch("router_maestro.auth.github_oauth._async_sleep", new=AsyncMock()):
+            token = await get_copilot_token(client, "github-token")
+
+        assert token.token == "copilot-token"
+        assert client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_copilot_token_does_not_retry_auth_errors(self):
+        """Permanent auth failures should surface immediately instead of being retried."""
+        response = httpx.Response(
+            401,
+            json={"message": "bad credentials"},
+            request=httpx.Request("GET", "https://api.github.com/copilot_internal/v2/token"),
+        )
+        client = AsyncMock()
+        client.get.return_value = response
+        sleep = AsyncMock()
+
+        with (
+            patch("router_maestro.auth.github_oauth._async_sleep", new=sleep),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await get_copilot_token(client, "github-token")
+
+        assert client.get.call_count == 1
+        sleep.assert_not_called()
+
+
+class TestAuthManager:
+    """Tests for provider auth flows."""
+
+    @pytest.mark.asyncio
+    async def test_login_copilot_persists_endpoint_metadata(self):
+        """Initial Copilot login should persist the API endpoint returned with the token."""
+        manager = AuthManager.__new__(AuthManager)
+        manager.storage = AuthStorage()
+        manager.save = Mock()  # type: ignore[method-assign]
+
+        with (
+            patch(
+                "router_maestro.auth.manager.request_device_code",
+                new=AsyncMock(
+                    return_value=DeviceCodeResponse(
+                        device_code="device-code",
+                        user_code="user-code",
+                        verification_uri="https://github.com/login/device",
+                        expires_in=900,
+                        interval=1,
+                    )
+                ),
+            ),
+            patch(
+                "router_maestro.auth.manager.poll_access_token",
+                new=AsyncMock(
+                    return_value=AccessTokenResponse(
+                        access_token="github-token",
+                        token_type="bearer",
+                        scope="read:user",
+                    )
+                ),
+            ),
+            patch(
+                "router_maestro.auth.manager.get_copilot_token",
+                new=AsyncMock(
+                    return_value=CopilotTokenResponse(
+                        token="copilot-token",
+                        expires_at=1234567890,
+                        refresh_in=1000,
+                        api_endpoint="https://api.enterprise.githubcopilot.com",
+                    )
+                ),
+            ),
+        ):
+            assert await manager.login_copilot()
+
+        cred = manager.storage.get("github-copilot")
+        assert isinstance(cred, OAuthCredential)
+        assert cred.api_endpoint == "https://api.enterprise.githubcopilot.com"
+        manager.save.assert_called_once()
 
 
 class TestApiKeyCredential:
@@ -121,6 +265,7 @@ class TestAuthStorage:
                     refresh="refresh",
                     access="access",
                     expires=12345,
+                    api_endpoint="https://api.enterprise.githubcopilot.com",
                 ),
             )
             storage.save(path)
@@ -135,6 +280,7 @@ class TestAuthStorage:
             copilot_cred = loaded.get("github-copilot")
             assert copilot_cred is not None
             assert copilot_cred.type == AuthType.OAUTH
+            assert copilot_cred.api_endpoint == "https://api.enterprise.githubcopilot.com"
         finally:
             path.unlink(missing_ok=True)
 

--- a/tests/test_chat_stream_usage.py
+++ b/tests/test_chat_stream_usage.py
@@ -99,7 +99,7 @@ async def test_copilot_chat_stream_requests_usage_from_upstream():
     provider = CopilotProvider()
     provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     provider.ensure_token = _noop  # type: ignore[method-assign]
-    provider._get_headers = lambda vision_request=False: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+    provider._get_headers = lambda *args, **kwargs: {"authorization": "Bearer test"}  # type: ignore[method-assign]
 
     request = ChatRequest(
         model="gpt-4o",
@@ -132,7 +132,7 @@ async def test_copilot_chat_stream_tool_calls_force_tool_calls_finish_reason():
     provider = CopilotProvider()
     provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     provider.ensure_token = _noop  # type: ignore[method-assign]
-    provider._get_headers = lambda vision_request=False: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+    provider._get_headers = lambda *args, **kwargs: {"authorization": "Bearer test"}  # type: ignore[method-assign]
 
     request = ChatRequest(
         model="gpt-4o",

--- a/tests/test_copilot_responses_stream.py
+++ b/tests/test_copilot_responses_stream.py
@@ -43,7 +43,7 @@ def _make_provider_with_stream(body: bytes) -> CopilotProvider:
     provider._client = httpx.AsyncClient(transport=transport)
     # Skip token refresh entirely — tests run offline.
     provider.ensure_token = _noop  # type: ignore[method-assign]
-    provider._get_headers = lambda: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+    provider._get_headers = lambda *args, **kwargs: {"authorization": "Bearer test"}  # type: ignore[method-assign]
     return provider
 
 

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -1,5 +1,6 @@
 """Tests for the local-only integration test harness."""
 
+import importlib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,6 +21,23 @@ def test_makefile_exposes_explicit_integration_test_target():
 
     assert "integration-test:" in makefile
     assert "uv run pytest integration_tests/ -v" in makefile
+
+
+def test_integration_model_matrix_defaults_to_full():
+    """The default integration suite should cover the full Copilot model matrix."""
+    conftest = (ROOT / "integration_tests" / "conftest.py").read_text(encoding="utf-8")
+
+    assert "DEFAULT_MAX_MODEL_MATRIX = 0" in conftest
+
+
+def test_model_matrix_payload_has_reasoning_safe_output_budget():
+    """The full matrix should give reasoning-heavy models enough output budget."""
+    conftest = importlib.import_module("integration_tests.conftest")
+
+    payload = conftest.model_matrix_chat_payload("github-copilot/gemini-2.5-pro")
+
+    assert payload["max_tokens"] >= 512
+    assert payload["reasoning_effort"] == "low"
 
 
 def test_integration_harness_documents_existing_config_usage():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,12 @@
 """Tests for providers module."""
 
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from router_maestro.auth.github_oauth import CopilotTokenResponse
+from router_maestro.auth.storage import AuthStorage, OAuthCredential
 from router_maestro.providers import (
     AnthropicProvider,
     ChatRequest,
@@ -20,6 +27,154 @@ class TestProviderBase:
         # Note: is_authenticated() depends on whether GitHub Copilot credentials
         # are stored in the system. We only test the provider initializes correctly.
         assert isinstance(provider.is_authenticated(), bool)
+
+    def test_copilot_api_base_defaults_to_public_endpoint(self):
+        """Copilot calls default to the public API endpoint."""
+        provider = CopilotProvider()
+
+        assert provider._api_base == "https://api.githubcopilot.com"
+        assert provider._url("/chat/completions") == (
+            "https://api.githubcopilot.com/chat/completions"
+        )
+
+    def test_copilot_api_base_uses_token_endpoint_metadata(self):
+        """Copilot calls use the API base returned by the token endpoint."""
+        provider = CopilotProvider()
+        provider._api_base = "https://api.enterprise.githubcopilot.com/"
+
+        assert provider._url("/models") == "https://api.enterprise.githubcopilot.com/models"
+
+    @pytest.mark.asyncio
+    async def test_copilot_api_base_uses_persisted_endpoint_metadata(self):
+        """Token refresh should keep using a previously persisted API endpoint."""
+        provider = CopilotProvider()
+        provider.auth_manager.storage = AuthStorage()
+        provider.auth_manager.storage.set(
+            "github-copilot",
+            OAuthCredential(
+                refresh="github-token",
+                access="old-copilot-token",
+                expires=0,
+                api_endpoint="https://api.enterprise.githubcopilot.com",
+            ),
+        )
+        provider.auth_manager.save = Mock()  # type: ignore[method-assign]
+
+        with patch(
+            "router_maestro.providers.copilot.get_copilot_token",
+            new=AsyncMock(
+                return_value=CopilotTokenResponse(
+                    token="new-copilot-token",
+                    expires_at=1234567890,
+                    refresh_in=1000,
+                    api_endpoint=None,
+                )
+            ),
+        ):
+            await provider.ensure_token()
+
+        assert provider._api_base == "https://api.enterprise.githubcopilot.com"
+
+    def test_copilot_headers_include_standard_metadata(self):
+        """Copilot requests carry the same compatibility headers as reference clients."""
+        provider = CopilotProvider()
+        provider._cached_token = "token"
+
+        headers = provider._get_headers()
+
+        assert headers["Authorization"] == "Bearer token"
+        assert headers["Copilot-Integration-Id"] == "vscode-chat"
+        assert headers["User-Agent"] == "GitHubCopilotChat/0.26.7"
+        assert headers["OpenAI-Intent"] == "conversation-panel"
+        assert headers["X-GitHub-Api-Version"] == "2025-04-01"
+        assert headers["X-Vscode-User-Agent-Library-Version"] == "electron-fetch"
+        assert "X-Request-Id" in headers
+
+    @pytest.mark.parametrize(
+        ("messages", "expected"),
+        [
+            ([Message(role="user", content="hi")], "user"),
+            ([Message(role="assistant", content="previous")], "agent"),
+            ([Message(role="tool", content="result", tool_call_id="call_1")], "agent"),
+        ],
+    )
+    def test_copilot_headers_include_initiator_for_chat(self, messages, expected):
+        """Chat calls mark whether the request continues an agent/tool turn."""
+        provider = CopilotProvider()
+        provider._cached_token = "token"
+
+        headers = provider._get_headers(messages=messages)
+
+        assert headers["X-Initiator"] == expected
+
+    def test_copilot_response_headers_include_initiator_for_input_items(self):
+        """Responses calls mark role-less items such as function_call as agent turns."""
+        provider = CopilotProvider()
+        provider._cached_token = "token"
+
+        headers = provider._get_headers(
+            response_input=[
+                {"type": "message", "role": "user", "content": "hi"},
+                {"type": "function_call", "call_id": "call_1", "name": "lookup"},
+            ]
+        )
+
+        assert headers["X-Initiator"] == "agent"
+
+    def test_copilot_response_vision_detection_is_recursive(self):
+        """Responses input_image blocks require the Copilot vision header."""
+        provider = CopilotProvider()
+
+        assert provider._responses_input_has_vision(
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {"type": "input_image", "image_url": "https://example/image.png"},
+                    ],
+                }
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_copilot_models_skip_completion_only_catalog_entries(self):
+        """Completion-only Copilot catalog models should not be exposed as chat models."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "gpt-41-copilot",
+                            "name": "GPT-4.1 Copilot",
+                            "model_picker_enabled": True,
+                            "capabilities": {"type": "completion", "supports": {}},
+                        },
+                        {
+                            "id": "gpt-4o",
+                            "name": "GPT-4o",
+                            "model_picker_enabled": True,
+                            "capabilities": {"type": "chat", "supports": {}},
+                        },
+                    ]
+                },
+                request=httpx.Request("GET", "https://api.githubcopilot.com/models"),
+            )
+
+        provider = CopilotProvider()
+        provider._cached_token = "token"
+        provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
+
+        with patch(
+            "httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        ):
+            models = await provider.list_models(force_refresh=True)
+
+        assert [model.id for model in models] == ["gpt-4o"]
 
     def test_openai_provider_init(self):
         """Test OpenAIProvider initialization."""


### PR DESCRIPTION
## Summary
- Persist Copilot token endpoint metadata and use it for chat, models, and responses requests.
- Align Copilot request headers with reference clients, including X-Initiator and recursive Responses vision detection.
- Make local integration tests run the full Copilot model matrix by default, with stable reasoning-heavy Gemini payloads and completion-only catalog filtering.

## Test Plan
- uv run pytest tests/ -q
- uv run ruff check src/ tests/ integration_tests/
- make integration-test