### PR TITLE
Release 0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.3.15 (2026-05-21)
+
+### Fixes
+
+- **GitHub Copilot requests now honor endpoint metadata from the token response.**
+  Router-Maestro persists Copilot's advertised API endpoint during login and token
+  refresh, then uses that endpoint for chat, model listing, and Responses API calls.
+  Copilot requests also carry the expanded compatibility headers, `X-Initiator`,
+  recursive Responses vision detection, and a narrower retry/backoff path for
+  transient token-refresh failures.
+- **Local integration tests now run the full Copilot model matrix by default.**
+  `make integration-test` covers the full available Copilot matrix unless
+  `RM_INTEGRATION_MAX_MODELS=<N>` is set intentionally. The matrix now gives
+  reasoning-heavy Gemini models enough output budget and avoids exposing
+  completion-only Copilot catalog entries as Router-Maestro chat models.
+
+---
+
 ## v0.3.14 (2026-05-21)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.14"
+version = "0.3.15"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.14"
+__version__ = "0.3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.14"
+version = "0.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- Bump Router-Maestro to 0.3.15.
- Add changelog notes for Copilot endpoint metadata support and full integration matrix defaults.
- Refresh uv.lock for the new package version.

## Test Plan
- uv run pytest tests/ -q
- uv run ruff check src/ tests/ integration_tests/