### PR TITLE
Expand live integration matrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,10 @@ uv run router-maestro auth login github-copilot
   provider APIs.
 - For local live-backend validation, use `make integration-test`; it runs the
   complete Copilot model matrix by default. To intentionally run a bounded
-  subset, use `RM_INTEGRATION_MAX_MODELS=<N> make integration-test`.
+  model subset, use `RM_INTEGRATION_MAX_MODELS=<N> make integration-test`. The
+  reasoning/thinking sweep defaults to one representative model per family; to
+  intentionally run that sweep across every available reasoning model, use
+  `RM_INTEGRATION_MAX_REASONING_MODELS=0 make integration-test`.
 - Run the narrowest relevant pytest target first, then broaden to the full
   suite when the change has wider risk.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,14 @@ uv run router-maestro auth login github-copilot
 
 Use `make integration-test` for the default live suite, which includes the full
 Copilot model matrix. Use `RM_INTEGRATION_MAX_MODELS=<N> make integration-test`
-only when you intentionally want a bounded model subset. The suite covers model
+only when you intentionally want a bounded model subset. The reasoning/thinking
+matrix defaults to one representative model per family to keep the local suite
+practical; use `RM_INTEGRATION_MAX_REASONING_MODELS=0 make integration-test`
+when you intentionally want the full reasoning sweep. The suite covers model
 invocation paths such as OpenAI Chat/Responses, Anthropic Messages/count_tokens,
-Gemini generateContent/stream/countTokens, streaming, tool calls, and usage
-accounting.
+Gemini generateContent/stream/countTokens, streaming, tool calls, usage
+accounting, Anthropic thinking budgets, OpenAI reasoning_effort, and
+Gemini-family model coverage.
 
 ### Docker Deployment
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Actions. They start a local Router-Maestro server, reuse your existing
 Router-Maestro config/auth files, and send requests to the real GitHub Copilot
 backend. The suite covers model invocation paths only: OpenAI Chat, OpenAI
 Responses, Anthropic Messages/count_tokens, Gemini generateContent/stream/countTokens,
-tool calls, streaming, usage accounting, and the full Copilot model matrix by
+tool calls, streaming, usage accounting, Anthropic thinking budgets, OpenAI
+reasoning_effort, Gemini-family API calls, and the full Copilot model matrix by
 default. Admin endpoints are intentionally not covered by these tests.
 
 Prerequisites:
@@ -303,6 +304,8 @@ RM_INTEGRATION_TOOL_MODEL=github-copilot/gpt-4o make integration-test
 RM_INTEGRATION_RESPONSES_MODEL=github-copilot/gpt-5.4-mini make integration-test
 RM_INTEGRATION_MODELS=github-copilot/gpt-4o,github-copilot/claude-sonnet-4.5 make integration-test
 RM_INTEGRATION_MAX_MODELS=8 make integration-test
+RM_INTEGRATION_MAX_REASONING_MODELS=3 make integration-test
+RM_INTEGRATION_MAX_REASONING_MODELS=0 make integration-test  # full reasoning sweep
 ```
 
 ## API Reference

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -26,10 +26,25 @@ STARTUP_TIMEOUT_SECONDS = 45.0
 REQUEST_TIMEOUT_SECONDS = 120.0
 STREAM_TIMEOUT_SECONDS = 180.0
 DEFAULT_MAX_MODEL_MATRIX = 0
+DEFAULT_MAX_REASONING_MATRIX = 1
 DEFAULT_API_KEY = "router-maestro-integration-test"
 COPILOT_PROVIDER = "github-copilot"
 TEXT_PROMPT = "Reply with exactly the word pong. Do not add punctuation or any other words."
 TOOL_PROMPT = "Use the provided get_weather tool for Shanghai. Do not answer directly."
+REASONING_PROMPT = (
+    "Three friends Alice, Bob, and Carol have ages summing to 60. "
+    "Alice is twice as old as Bob was when Alice was as old as Bob is now. "
+    "Carol is 4 years younger than Alice. Find each age, showing reasoning."
+)
+ANTHROPIC_THINKING_BUDGETS: tuple[int | None, ...] = (None, 1024, 4096, 16000)
+OPENAI_REASONING_EFFORTS: tuple[str | None, ...] = (None, "low", "medium", "high")
+STREAM_MODES: tuple[bool, ...] = (False, True)
+RESPONSES_ONLY_CHAT_MODELS = {
+    "gpt-5.2-codex",
+    "gpt-5.3-codex",
+    "gpt-5.4-mini",
+    "gpt-5.5",
+}
 
 
 @dataclass(frozen=True)
@@ -146,6 +161,50 @@ def model_matrix(copilot_models: list[str]) -> list[str]:
 
 
 @pytest.fixture(scope="session")
+def anthropic_thinking_models(copilot_models: list[str]) -> list[str]:
+    """Claude-family models for Anthropic thinking budget coverage."""
+    return _required_reasoning_subset(
+        copilot_models,
+        predicate=_is_anthropic_thinking_model,
+        description="Claude-family Copilot models",
+    )
+
+
+@pytest.fixture(scope="session")
+def anthropic_gpt5_bridge_models(copilot_models: list[str]) -> list[str]:
+    """Responses-eligible GPT-5 models for Anthropic bridge coverage."""
+    eligible = {f"{COPILOT_PROVIDER}/{model_id}" for model_id in RESPONSES_ELIGIBLE_MODELS}
+    return _required_reasoning_subset(
+        copilot_models,
+        predicate=lambda model: model in eligible,
+        description="Responses-eligible GPT-5 Copilot models",
+    )
+
+
+@pytest.fixture(scope="session")
+def openai_reasoning_models(copilot_models: list[str]) -> list[str]:
+    """OpenAI Chat models that accept reasoning_effort."""
+    return _required_reasoning_subset(
+        copilot_models,
+        predicate=_is_openai_chat_reasoning_model,
+        description="OpenAI Chat reasoning Copilot models",
+    )
+
+
+@pytest.fixture(scope="session")
+def gemini_family_models(copilot_models: list[str]) -> list[str]:
+    """Gemini-family models for explicit Gemini API surface coverage."""
+    selected = [
+        model
+        for model in _prioritize_models(copilot_models)
+        if bare_model(model).startswith("gemini-")
+    ]
+    if not selected:
+        pytest.skip("No Gemini-family Copilot models are available from GitHub Copilot")
+    return selected
+
+
+@pytest.fixture(scope="session")
 def chat_model(copilot_models: list[str]) -> str:
     """Model for OpenAI Chat, Anthropic, and Gemini compatibility paths."""
     requested = os.environ.get("RM_INTEGRATION_MODEL")
@@ -231,6 +290,26 @@ def model_matrix_chat_payload(model: str) -> dict[str, Any]:
     payload = openai_chat_payload(model)
     payload["max_tokens"] = 512
     payload["reasoning_effort"] = "low"
+    return payload
+
+
+def openai_reasoning_payload(
+    model: str,
+    *,
+    effort: str | None,
+    stream: bool = False,
+) -> dict[str, Any]:
+    """OpenAI Chat request for reasoning_effort matrix coverage."""
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": REASONING_PROMPT}],
+        "max_tokens": 4096,
+        "stream": stream,
+    }
+    if stream:
+        payload["stream_options"] = {"include_usage": True}
+    if effort is not None:
+        payload["reasoning_effort"] = effort
     return payload
 
 
@@ -330,6 +409,24 @@ def openai_responses_tool_payload(model: str, *, stream: bool = False) -> dict[s
     return payload
 
 
+def anthropic_reasoning_payload(
+    model: str,
+    *,
+    budget: int | None,
+    stream: bool = False,
+) -> dict[str, Any]:
+    """Anthropic Messages request for thinking budget matrix coverage."""
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": REASONING_PROMPT}],
+        "max_tokens": max(2048, min(16384, (budget or 0) + 1024)),
+        "stream": stream,
+    }
+    if budget is not None:
+        payload["thinking"] = {"type": "enabled", "budget_tokens": budget}
+    return payload
+
+
 def anthropic_tool_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
     """Anthropic payload that forces a tool_use block."""
     payload = anthropic_payload(model, stream=stream)
@@ -361,6 +458,14 @@ def gemini_tool_payload(*, max_output_tokens: int = 16) -> dict[str, Any]:
     ]
     payload["toolConfig"] = {"functionCallingConfig": {"mode": "ANY"}}
     return payload
+
+
+def gemini_reasoning_payload() -> dict[str, Any]:
+    """Gemini request used for explicit Gemini-family model coverage."""
+    return {
+        "contents": [{"role": "user", "parts": [{"text": TEXT_PROMPT}]}],
+        "generationConfig": {"temperature": 0, "maxOutputTokens": 512},
+    }
 
 
 def anthropic_count_tokens_payload(model: str) -> dict[str, Any]:
@@ -572,6 +677,44 @@ def _prioritize_models(models: list[str]) -> list[str]:
         )
     selected.extend(model for model in models if model not in selected)
     return selected
+
+
+def _required_reasoning_subset(
+    models: list[str],
+    *,
+    predicate,
+    description: str,
+) -> list[str]:
+    selected = [model for model in _prioritize_models(models) if predicate(model)]
+    if not selected:
+        pytest.skip(f"No {description} are available from GitHub Copilot")
+
+    max_models = _int_env("RM_INTEGRATION_MAX_REASONING_MODELS", DEFAULT_MAX_REASONING_MATRIX)
+    if max_models > 0:
+        selected = selected[:max_models]
+    return selected
+
+
+def _is_anthropic_thinking_model(model: str) -> bool:
+    bare = bare_model(model).lower()
+    if not bare.startswith("claude-"):
+        return False
+    return not bare.endswith(("-high", "-xhigh", "-1m-internal"))
+
+
+def _is_openai_chat_reasoning_model(model: str) -> bool:
+    bare = bare_model(model).lower()
+    if bare in RESPONSES_ONLY_CHAT_MODELS:
+        return False
+    return (
+        bare.startswith("gpt-5")
+        or bare.startswith("o1")
+        or bare.startswith("o3")
+        or bare.startswith("o4")
+        or bare.startswith("claude-opus-4.7")
+        or bare.startswith("claude-opus-4.6")
+        or bare.startswith("claude-sonnet-4.6")
+    )
 
 
 def _int_env(name: str, default: int) -> int:

--- a/integration_tests/test_live_gemini_matrix.py
+++ b/integration_tests/test_live_gemini_matrix.py
@@ -1,0 +1,104 @@
+"""Live Gemini-family model matrix checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from integration_tests.conftest import (
+    assert_gemini_usage,
+    assert_http_success,
+    assert_text_response,
+    bare_model,
+    event_payloads,
+    gemini_reasoning_payload,
+    parse_sse_events,
+)
+
+
+def test_gemini_family_generate_content_matrix(
+    client: httpx.Client,
+    gemini_family_models: list[str],
+):
+    """Every available Gemini-family Copilot model should serve Gemini API calls."""
+    failures: list[str] = []
+
+    for model in gemini_family_models:
+        for stream in (False, True):
+            cell = f"{bare_model(model)} {'stream' if stream else 'nonstream'}"
+            try:
+                if stream:
+                    data = _post_gemini_stream(client, model)
+                else:
+                    data = _post_gemini_non_stream(client, model)
+                _assert_gemini_matrix_result(data)
+            except AssertionError as exc:
+                failures.append(f"{cell}: {exc}")
+
+    assert not failures, "\n".join(failures)
+
+
+def _post_gemini_non_stream(client: httpx.Client, model: str) -> dict[str, Any]:
+    response = client.post(
+        f"/api/gemini/v1beta/models/{bare_model(model)}:generateContent",
+        json=gemini_reasoning_payload(),
+        timeout=240.0,
+    )
+    assert_http_success(response)
+    return response.json()
+
+
+def _post_gemini_stream(client: httpx.Client, model: str) -> dict[str, Any]:
+    with client.stream(
+        "POST",
+        f"/api/gemini/v1beta/models/{bare_model(model)}:streamGenerateContent",
+        json=gemini_reasoning_payload(),
+        timeout=240.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    text = "".join(
+        part.get("text", "")
+        for payload in payloads
+        for candidate in payload.get("candidates", [])
+        for part in (candidate.get("content") or {}).get("parts", [])
+        if "text" in part
+    )
+    finish = next(
+        (
+            candidate.get("finishReason")
+            for payload in reversed(payloads)
+            for candidate in payload.get("candidates", [])
+            if candidate.get("finishReason")
+        ),
+        None,
+    )
+    return {
+        "candidates": [{"finishReason": finish, "content": {"parts": [{"text": text}]}}],
+        "usageMetadata": next(
+            (
+                payload["usageMetadata"]
+                for payload in reversed(payloads)
+                if payload.get("usageMetadata")
+            ),
+            {},
+        ),
+    }
+
+
+def _assert_gemini_matrix_result(data: dict[str, Any]) -> None:
+    candidates = data.get("candidates") or []
+    assert candidates, data
+    candidate = candidates[0]
+    assert candidate.get("finishReason") in {"STOP", "MAX_TOKENS", "SAFETY", "OTHER", None}
+    text = "".join(
+        part.get("text", "")
+        for part in (candidate.get("content") or {}).get("parts", [])
+        if "text" in part
+    )
+    assert_text_response(text)
+    if data.get("usageMetadata"):
+        assert_gemini_usage(data["usageMetadata"])

--- a/integration_tests/test_live_reasoning_matrix.py
+++ b/integration_tests/test_live_reasoning_matrix.py
@@ -1,0 +1,256 @@
+"""Live reasoning and thinking matrix checks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from integration_tests.conftest import (
+    ANTHROPIC_THINKING_BUDGETS,
+    OPENAI_REASONING_EFFORTS,
+    STREAM_MODES,
+    anthropic_reasoning_payload,
+    assert_anthropic_usage,
+    assert_http_success,
+    assert_openai_usage,
+    assert_text_response,
+    bare_model,
+    event_payloads,
+    openai_reasoning_payload,
+    parse_sse_events,
+)
+
+
+def test_anthropic_claude_thinking_budget_matrix(
+    client: httpx.Client,
+    anthropic_thinking_models: list[str],
+):
+    """Claude-family Anthropic path should handle budget and stream combinations."""
+    failures: list[str] = []
+
+    for model in anthropic_thinking_models:
+        for budget in ANTHROPIC_THINKING_BUDGETS:
+            for stream in STREAM_MODES:
+                cell = _cell_id(model, budget=budget, stream=stream)
+                try:
+                    if stream:
+                        data = _post_anthropic_stream(client, model, budget)
+                    else:
+                        data = _post_anthropic_non_stream(client, model, budget)
+                    _assert_anthropic_reasoning_result(data)
+                except AssertionError as exc:
+                    failures.append(f"{cell}: {exc}")
+
+    assert not failures, "\n".join(failures)
+
+
+def test_anthropic_gpt5_responses_bridge_thinking_budget_matrix(
+    client: httpx.Client,
+    anthropic_gpt5_bridge_models: list[str],
+):
+    """Anthropic wire format should bridge GPT-5 models through GHC Responses."""
+    failures: list[str] = []
+
+    for model in anthropic_gpt5_bridge_models:
+        for budget in ANTHROPIC_THINKING_BUDGETS:
+            for stream in STREAM_MODES:
+                cell = _cell_id(model, budget=budget, stream=stream)
+                try:
+                    if stream:
+                        data = _post_anthropic_stream(client, model, budget)
+                    else:
+                        data = _post_anthropic_non_stream(client, model, budget)
+                    _assert_anthropic_reasoning_result(data)
+                except AssertionError as exc:
+                    failures.append(f"{cell}: {exc}")
+
+    assert not failures, "\n".join(failures)
+
+
+def test_openai_chat_reasoning_effort_matrix(
+    client: httpx.Client,
+    openai_reasoning_models: list[str],
+):
+    """OpenAI Chat should accept reasoning_effort across models and stream modes."""
+    failures: list[str] = []
+
+    for model in openai_reasoning_models:
+        for effort in OPENAI_REASONING_EFFORTS:
+            for stream in STREAM_MODES:
+                cell = _cell_id(model, effort=effort, stream=stream)
+                try:
+                    if stream:
+                        data = _post_openai_stream(client, model, effort)
+                    else:
+                        data = _post_openai_non_stream(client, model, effort)
+                    _assert_openai_reasoning_result(data)
+                except AssertionError as exc:
+                    failures.append(f"{cell}: {exc}")
+
+    assert not failures, "\n".join(failures)
+
+
+def _post_anthropic_non_stream(
+    client: httpx.Client,
+    model: str,
+    budget: int | None,
+) -> dict[str, Any]:
+    response = client.post(
+        "/api/anthropic/v1/messages",
+        json=anthropic_reasoning_payload(model, budget=budget),
+        timeout=240.0,
+    )
+    assert_http_success(response)
+    return response.json()
+
+
+def _post_anthropic_stream(
+    client: httpx.Client,
+    model: str,
+    budget: int | None,
+) -> dict[str, Any]:
+    with client.stream(
+        "POST",
+        "/api/anthropic/v1/messages",
+        json=anthropic_reasoning_payload(model, budget=budget, stream=True),
+        timeout=240.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    errors = [payload for payload in payloads if payload.get("type") == "error"]
+    assert not errors, errors
+    assert "message_stop" in [name for name, _payload in events]
+
+    blocks = [
+        payload.get("content_block", {})
+        for payload in payloads
+        if payload.get("type") == "content_block_start"
+    ]
+    text = "".join(
+        payload.get("delta", {}).get("text", "")
+        for payload in payloads
+        if payload.get("delta", {}).get("type") == "text_delta"
+    )
+    thinking = "".join(
+        payload.get("delta", {}).get("thinking", "")
+        for payload in payloads
+        if payload.get("delta", {}).get("type") == "thinking_delta"
+    )
+    message_delta = next(
+        payload for name, payload in events if name == "message_delta"
+    )
+    return {
+        "content": [
+            {"type": block.get("type"), "text": text, "thinking": thinking}
+            for block in blocks
+        ],
+        "usage": message_delta["usage"],
+        "stop_reason": message_delta["delta"].get("stop_reason"),
+    }
+
+
+def _post_openai_non_stream(
+    client: httpx.Client,
+    model: str,
+    effort: str | None,
+) -> dict[str, Any]:
+    response = client.post(
+        "/api/openai/v1/chat/completions",
+        json=openai_reasoning_payload(model, effort=effort),
+        timeout=240.0,
+    )
+    assert_http_success(response)
+    return response.json()
+
+
+def _post_openai_stream(
+    client: httpx.Client,
+    model: str,
+    effort: str | None,
+) -> dict[str, Any]:
+    with client.stream(
+        "POST",
+        "/api/openai/v1/chat/completions",
+        json=openai_reasoning_payload(model, effort=effort, stream=True),
+        timeout=240.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    assert events[-1][1] == "[DONE]"
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "".join(
+                        content
+                        for payload in payloads
+                        for choice in payload.get("choices", [])
+                        for content in [choice.get("delta", {}).get("content")]
+                        if isinstance(content, str)
+                    ),
+                },
+                "finish_reason": next(
+                    (
+                        choice.get("finish_reason")
+                        for payload in payloads
+                        for choice in payload.get("choices", [])
+                        if choice.get("finish_reason")
+                    ),
+                    None,
+                ),
+            }
+        ],
+        "usage": next(
+            (
+                payload["usage"]
+                for payload in reversed(payloads)
+                if payload.get("usage")
+            ),
+            None,
+        ),
+    }
+
+
+def _assert_anthropic_reasoning_result(data: dict[str, Any]) -> None:
+    blocks = data.get("content") or []
+    text = "".join(block.get("text", "") for block in blocks if block.get("type") == "text")
+    thinking = "".join(
+        block.get("thinking", "") for block in blocks if block.get("type") == "thinking"
+    )
+    assert text.strip() or thinking.strip(), data
+    assert data.get("stop_reason") in {
+        "end_turn",
+        "max_tokens",
+        "stop_sequence",
+        "tool_use",
+        "pause_turn",
+        "refusal",
+    }
+    assert_anthropic_usage(data["usage"])
+
+
+def _assert_openai_reasoning_result(data: dict[str, Any]) -> None:
+    choice = data["choices"][0]
+    assert choice["message"]["role"] == "assistant"
+    assert_text_response(choice["message"].get("content"))
+    assert choice.get("finish_reason") in {"stop", "length", "content_filter", None}
+    if data.get("usage"):
+        assert_openai_usage(data["usage"])
+
+
+def _cell_id(
+    model: str,
+    *,
+    budget: int | None = None,
+    effort: str | None = None,
+    stream: bool,
+) -> str:
+    knob = f"budget={budget}" if effort is None else f"effort={effort}"
+    mode = "stream" if stream else "nonstream"
+    return f"{bare_model(model)} {knob} {mode}"

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -65,9 +65,7 @@ def test_integration_tests_include_reasoning_and_gemini_family_matrices():
     """Local live tests should cover the e2e reasoning and Gemini family gaps."""
     integration_dir = ROOT / "integration_tests"
 
-    reasoning = (integration_dir / "test_live_reasoning_matrix.py").read_text(
-        encoding="utf-8"
-    )
+    reasoning = (integration_dir / "test_live_reasoning_matrix.py").read_text(encoding="utf-8")
     gemini = (integration_dir / "test_live_gemini_matrix.py").read_text(encoding="utf-8")
 
     assert "test_anthropic_claude_thinking_budget_matrix" in reasoning

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -40,6 +40,42 @@ def test_model_matrix_payload_has_reasoning_safe_output_budget():
     assert payload["reasoning_effort"] == "low"
 
 
+def test_reasoning_matrix_payloads_cover_budget_and_effort_controls():
+    """Live matrix helpers should exercise thinking budgets and reasoning effort."""
+    conftest = importlib.import_module("integration_tests.conftest")
+
+    anthropic = conftest.anthropic_reasoning_payload(
+        "github-copilot/claude-sonnet-4.6",
+        budget=4096,
+        stream=True,
+    )
+    openai = conftest.openai_reasoning_payload(
+        "github-copilot/gpt-5.4",
+        effort="high",
+        stream=True,
+    )
+
+    assert anthropic["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+    assert anthropic["max_tokens"] > 4096
+    assert openai["reasoning_effort"] == "high"
+    assert openai["stream_options"] == {"include_usage": True}
+
+
+def test_integration_tests_include_reasoning_and_gemini_family_matrices():
+    """Local live tests should cover the e2e reasoning and Gemini family gaps."""
+    integration_dir = ROOT / "integration_tests"
+
+    reasoning = (integration_dir / "test_live_reasoning_matrix.py").read_text(
+        encoding="utf-8"
+    )
+    gemini = (integration_dir / "test_live_gemini_matrix.py").read_text(encoding="utf-8")
+
+    assert "test_anthropic_claude_thinking_budget_matrix" in reasoning
+    assert "test_anthropic_gpt5_responses_bridge_thinking_budget_matrix" in reasoning
+    assert "test_openai_chat_reasoning_effort_matrix" in reasoning
+    assert "test_gemini_family_generate_content_matrix" in gemini
+
+
 def test_integration_harness_documents_existing_config_usage():
     """The harness should say it reuses the user's existing RM configuration."""
     conftest = (ROOT / "integration_tests" / "conftest.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add live reasoning/thinking matrix coverage for Anthropic Claude, Anthropic GPT-5 Responses bridge, and OpenAI Chat reasoning_effort paths
- add explicit Gemini-family generateContent and streamGenerateContent matrix coverage
- document the expanded local integration suite and reasoning sweep controls

## Test Plan
- uv run pytest tests/test_integration_harness.py -v
- uv run ruff check src/ tests/ integration_tests/
- git diff --check
- make integration-test