### PR TITLE
Clarify deployment API key setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ CF_DNS_API_TOKEN=your_cloudflare_api_token
 # Let's Encrypt email for certificate notifications
 ACME_EMAIL=your-email@example.com
 
-# Router-Maestro API key (generate a secure random string)
-ROUTER_MAESTRO_API_KEY=your_secure_api_key_here
+# Router-Maestro server API key.
+# Leave blank to let the server generate and persist a sk-rm-... key on first start.
+# Set a fixed value only when your deployment automation needs one.
+ROUTER_MAESTRO_API_KEY=
 
 # Log level (DEBUG, INFO, WARNING, ERROR)
 ROUTER_MAESTRO_LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Router-Maestro acts as a proxy that gives you access to models from multiple pro
 - **Fuzzy model matching**: No need to type exact model IDs. Subagents, agent teams, and tools that hardcode model names (e.g. `opus-4-6`, `claude-sonnet-4.5`) are resolved automatically to the correct provider model
 - **Multi-provider support**: GitHub Copilot (OAuth), OpenAI, Anthropic, and custom OpenAI-compatible endpoints
 - **Intelligent routing**: Priority-based model selection with automatic fallback on failure
-- **Dual API compatibility**: Both OpenAI (`/v1/...`) and Anthropic (`/v1/messages`) API formats
+- **Dual API compatibility**: Both OpenAI (`/api/openai/v1/...`) and Anthropic (`/v1/messages`) API formats
 - **Gemini API compatibility**: Gemini REST API format (`/api/gemini/v1beta/...`) for Gemini CLI/SDK
 - **Cross-provider translation**: Seamlessly route OpenAI requests to Anthropic providers and vice versa
 - **Configuration hot-reload**: Auto-reload config files every 5 minutes without server restart
@@ -39,6 +39,7 @@ Router-Maestro acts as a proxy that gives you access to models from multiple pro
 - [Configuration](#configuration)
 - [Deployment](#deployment)
   - [Architecture](#architecture)
+  - [Server and Client API Keys](#server-and-client-api-keys)
   - [Option A: Simple Docker (No HTTPS)](#option-a-simple-docker-no-https)
   - [Option B: Production (Docker Compose + Traefik + HTTPS)](#option-b-production-docker-compose--traefik--https)
   - [Remote Management](#remote-management)
@@ -57,30 +58,49 @@ Get up and running in 4 steps:
 #### Docker (recommended)
 
 ```bash
-docker run -d -p 8080:8080 \
+docker run -d --name router-maestro \
+  -p 8080:8080 \
   -v ~/.local/share/router-maestro:/home/maestro/.local/share/router-maestro \
   -v ~/.config/router-maestro:/home/maestro/.config/router-maestro \
   likanwen/router-maestro:latest
+
+# The server generates an API key on first start if none is provided.
+docker exec router-maestro router-maestro server show-key
 ```
 
 #### Install locally
+
+Terminal 1:
 
 ```bash
 pip install router-maestro
 router-maestro server start --port 8080
 ```
 
-### 2. Set Context (for Docker or Remote)
-
-When running via Docker in remote VPS, set up a context to communicate with the containerized server:
+Terminal 2:
 
 ```bash
-pip install router-maestro  # Install CLI locally
-router-maestro context add docker --endpoint http://localhost:8080
-router-maestro context set docker
+router-maestro server show-key
 ```
 
-> **What's a context?** A context is a named connection profile (endpoint + API key) that lets you manage local or remote Router-Maestro servers. See [Contexts](#contexts) for details.
+### 2. Set Client Context
+
+A context is stored on the machine running the client CLI. If the server runs in Docker, on a VPS, or on another machine, install the CLI on the client machine and save the server endpoint plus the same server API key:
+
+```bash
+pip install router-maestro  # Run on the client machine, not necessarily on the server
+
+router-maestro context add my-router \
+  --endpoint http://localhost:8080 \
+  --api-key "sk-rm-..."
+
+router-maestro context set my-router
+
+# Verifies the endpoint and API key against a protected admin route.
+router-maestro auth list
+```
+
+Use the endpoint that the client can reach, for example `http://localhost:8080` for a local Docker container or `https://api.example.com` for a remote VPS. If you started the server locally with `router-maestro server start` on the same machine, the `local` context may already contain the generated key.
 
 ### 3. Authenticate with GitHub Copilot
 
@@ -99,34 +119,31 @@ router-maestro auth login github-copilot
 
 ```bash
 router-maestro config claude-code
-# Follow the wizard to select models
+# Follow the wizard to select models.
+# The active context's endpoint and API key are written to Claude Code settings.
 ```
 
 #### OpenAI Codex (CLI, Extension, App)
 
 ```bash
 router-maestro config codex
-# Follow the wizard to select models
+# Follow the wizard to select models.
+# Codex reads the API key from this client-side environment variable.
+# Add it to the client shell profile or app/extension environment:
+export ROUTER_MAESTRO_API_KEY="sk-rm-..."
 ```
 
 #### Gemini CLI
 
 ```bash
 router-maestro config gemini
-# Follow the wizard to select models
+# Follow the wizard to select models.
+# The active context's endpoint and API key are written to Gemini CLI config.
 ```
 
-After configuration, set the API key environment variable:
+The API key is the Router-Maestro server key, not an OpenAI, Anthropic, Gemini, or GitHub token. Every remote client, generated tool config, or raw API call must use the same key that the server generated or was started with.
 
-```bash
-# Get your API key
-router-maestro server show-key
-
-# Set the environment variable (add to your shell profile)
-export ROUTER_MAESTRO_API_KEY="your-api-key-here"
-```
-
-**Done!** Now run `claude` or `codex` and your requests will route through Router-Maestro.
+**Done!** Now run `claude`, `codex`, or `gemini` and your requests will route through Router-Maestro.
 
 > **For production deployment**, see the [Deployment](#deployment) section.
 
@@ -170,8 +187,8 @@ The router will try models in priority order and fall back to the next on failur
 
 ```bash
 # Set priorities
-router-maestro model priority github-copilot/claude-sonnet-4 --position 1
-router-maestro model priority github-copilot/gpt-4o --position 2
+router-maestro model priority add github-copilot/claude-sonnet-4 --position 1
+router-maestro model priority add github-copilot/gpt-4o --position 2
 
 # View priorities
 router-maestro model priority list
@@ -203,12 +220,12 @@ Router-Maestro automatically translates between OpenAI and Anthropic formats:
 POST /v1/messages  {"model": "openai/gpt-4o", ...}
 
 # Use OpenAI API with Anthropic provider
-POST /v1/chat/completions  {"model": "anthropic/claude-3-5-sonnet", ...}
+POST /api/openai/v1/chat/completions  {"model": "anthropic/claude-3-5-sonnet", ...}
 ```
 
 ### Contexts
 
-A **context** is a named connection profile that stores an endpoint URL and API key. Contexts let you manage multiple Router-Maestro deployments from a single CLI.
+A **context** is a named connection profile stored on the client machine. It contains the endpoint URL and Router-Maestro server API key for one deployment, so the same CLI can manage local Docker containers, remote VPS deployments, and other Router-Maestro servers.
 
 | Context  | Use Case                                   |
 | -------- | ------------------------------------------ |
@@ -217,8 +234,8 @@ A **context** is a named connection profile that stores an endpoint URL and API 
 | `my-vps` | Connect to a remote VPS deployment |
 
 ```bash
-# Add a context
-router-maestro context add my-vps --endpoint https://api.example.com --api-key xxx
+# Add a context with the server API key from `server show-key`
+router-maestro context add my-vps --endpoint https://api.example.com --api-key sk-rm-...
 
 # Switch contexts
 router-maestro context set my-vps
@@ -234,8 +251,8 @@ router-maestro model list
 | Command                    | Description        |
 | -------------------------- | ------------------ |
 | `server start --port 8080` | Start the server   |
-| `server stop` | Stop the server |
-| `server info` | Show server status |
+| `server status` | Show server status |
+| `server show-key` | Show current context API key |
 
 ### Authentication
 
@@ -252,14 +269,14 @@ router-maestro model list
 | `model list`                       | List available models  |
 | `model refresh` | Refresh models cache |
 | `model priority list` | Show priorities |
-| `model priority <model> --position <n>` | Set priority |
+| `model priority add <model> --position <n>` | Add or move a priority |
 | `model fallback show` | Show fallback config |
 
 ### Contexts (Remote Management)
 
 | Command                                              | Description          |
 | ---------------------------------------------------- | -------------------- |
-| `context show`                                       | Show current context |
+| `context current`                                    | Show current context |
 | `context list` | List all contexts |
 | `context set <name>` | Switch context |
 | `context add <name> --endpoint <url> --api-key <key>` | Add remote context |
@@ -314,7 +331,7 @@ RM_INTEGRATION_MAX_REASONING_MODELS=0 make integration-test  # full reasoning sw
 
 ```bash
 # Chat completions
-POST /v1/chat/completions
+POST /api/openai/v1/chat/completions
 {
   "model": "github-copilot/gpt-4o",
   "messages": [{"role": "user", "content": "Hello"}],
@@ -322,7 +339,7 @@ POST /v1/chat/completions
 }
 
 # List models
-GET /v1/models
+GET /api/openai/v1/models
 ```
 
 ### Anthropic-Compatible
@@ -383,7 +400,7 @@ Following XDG Base Directory specification:
 | | `contexts.json` | Deployment contexts |
 | **Data** | `~/.local/share/router-maestro/` | |
 | | `auth.json` | OAuth tokens |
-| | `server.json` | Server state |
+| | `server.json` | Legacy server state; current server API keys are stored in `contexts.json` |
 
 ### Custom Providers
 
@@ -447,31 +464,67 @@ graph TD
 - **Traefik** — reverse proxy that handles TLS termination and auto-renews HTTPS certificates via Let's Encrypt. Only needed for public-facing deployments.
 - **Router-Maestro** — the API server. Listens on port 8080, requires an API key for all requests, and routes them to configured LLM providers.
 
+### Server and Client API Keys
+
+Router-Maestro has one server API key. The server uses it to protect every API route except public health/status endpoints, and every client must send that same key.
+
+You can provide the key explicitly with `ROUTER_MAESTRO_API_KEY` or `router-maestro server start --api-key ...`. If you do not provide one, `router-maestro server start` generates a `sk-rm-...` key on first start and stores it in the server-side `local` context. This works in Docker too because the image starts the server with the same CLI command.
+
+When server and client are on different machines, do not assume the server host has the `router-maestro` CLI outside Docker. Use one of these server-side commands to read the key, then copy it into the client machine's context:
+
+```bash
+# Docker run deployment
+docker exec router-maestro router-maestro server show-key
+
+# Docker Compose deployment
+docker compose exec router-maestro router-maestro server show-key
+
+# Non-Docker local install
+router-maestro server show-key
+```
+
+On each client machine:
+
+```bash
+pip install router-maestro
+
+router-maestro context add my-vps \
+  --endpoint https://api.example.com \
+  --api-key "sk-rm-..."
+
+router-maestro context set my-vps
+router-maestro auth list
+```
+
+Run `router-maestro config claude-code`, `router-maestro config codex`, or `router-maestro config gemini` from the client machine after selecting the context. The config commands use the active context endpoint; Claude Code and Gemini receive the API key in their generated config, while Codex uses `env_key = "ROUTER_MAESTRO_API_KEY"`, so set that environment variable on the Codex client machine to the same server key and keep it available when Codex runs.
+
 ### Option A: Simple Docker (No HTTPS)
 
 **Use when:** local testing, running behind an existing reverse proxy (Nginx, Caddy, etc.), or on an internal network.
 
 **Prerequisites:** Docker installed.
 
-**Step 1 — Generate an API key**
-
-```bash
-export ROUTER_MAESTRO_API_KEY=$(openssl rand -hex 32)
-echo "Save this key: $ROUTER_MAESTRO_API_KEY"
-```
-
-**Step 2 — Start the container**
+**Step 1 — Start the container**
 
 ```bash
 docker run -d --name router-maestro \
   -p 8080:8080 \
-  -e ROUTER_MAESTRO_API_KEY="$ROUTER_MAESTRO_API_KEY" \
   -v ~/.local/share/router-maestro:/home/maestro/.local/share/router-maestro \
   -v ~/.config/router-maestro:/home/maestro/.config/router-maestro \
   likanwen/router-maestro:latest
 ```
 
-**Step 3 — Authenticate with GitHub Copilot**
+This command does not set `ROUTER_MAESTRO_API_KEY`; the server generates and persists one automatically. If you need a fixed key for automation, add `-e ROUTER_MAESTRO_API_KEY="sk-rm-..."`.
+
+**Step 2 — Read the server API key**
+
+```bash
+docker exec router-maestro router-maestro server show-key
+```
+
+Save this key for client contexts and API calls.
+
+**Step 3 — Authenticate with GitHub Copilot on the server**
 
 ```bash
 docker exec -it router-maestro router-maestro auth login github-copilot
@@ -480,14 +533,31 @@ docker exec -it router-maestro router-maestro auth login github-copilot
 # 3. Authorize "GitHub Copilot Chat"
 ```
 
-**Step 4 — Verify**
+**Step 4 — Configure each client machine**
+
+Install the CLI on the client machine, not necessarily on the Docker host:
+
+```bash
+pip install router-maestro
+
+router-maestro context add docker \
+  --endpoint http://localhost:8080 \
+  --api-key "sk-rm-..."
+
+router-maestro context set docker
+router-maestro config claude-code  # or: config codex / config gemini
+```
+
+For remote Docker hosts, replace `http://localhost:8080` with the URL reachable from the client.
+
+**Step 5 — Verify**
 
 ```bash
 curl http://localhost:8080/health
-# Expected: {"status":"ok"}
+# Expected: {"status":"healthy"}
 
 curl http://localhost:8080/api/openai/v1/models \
-  -H "Authorization: Bearer $ROUTER_MAESTRO_API_KEY"
+  -H "Authorization: Bearer sk-rm-..."
 # Expected: JSON list of available models
 ```
 
@@ -520,7 +590,7 @@ Edit `.env` with your values:
 | `DOMAIN` | Your domain pointing to this VPS | `api.example.com` |
 | `CF_DNS_API_TOKEN` | Cloudflare API token with `Zone:DNS:Edit` permission. [Generate here](https://dash.cloudflare.com/profile/api-tokens) | `abc123...` |
 | `ACME_EMAIL` | Email for Let's Encrypt certificate expiry notifications | `you@example.com` |
-| `ROUTER_MAESTRO_API_KEY` | API key clients use to authenticate. Generate with `openssl rand -hex 32` | `a1b2c3...` |
+| `ROUTER_MAESTRO_API_KEY` | Optional fixed server API key. Leave blank, and do not set it in the shell running Docker Compose, to let the server generate and persist one. | `sk-rm-...` |
 | `ROUTER_MAESTRO_LOG_LEVEL` | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
 | `TRAEFIK_DASHBOARD_AUTH` | (Optional) Basic auth for Traefik dashboard. Generate with `htpasswd -nB admin`, then escape `$` as `$$` | `admin:$$2y$$05$$...` |
 
@@ -532,7 +602,15 @@ docker compose up -d
 
 This starts both Traefik (reverse proxy) and Router-Maestro. Traefik will automatically obtain an HTTPS certificate for your domain.
 
-**Step 4 — Authenticate with GitHub Copilot**
+**Step 4 — Read the server API key**
+
+```bash
+docker compose exec router-maestro router-maestro server show-key
+```
+
+If you set `ROUTER_MAESTRO_API_KEY` in `.env` or in the shell running Docker Compose, this prints that key. If you left it blank and it was not set in the shell, this prints the generated key stored in the server's mounted config.
+
+**Step 5 — Authenticate with GitHub Copilot on the server**
 
 ```bash
 docker compose exec router-maestro router-maestro auth login github-copilot
@@ -541,16 +619,17 @@ docker compose exec router-maestro router-maestro auth login github-copilot
 # 3. Authorize "GitHub Copilot Chat"
 ```
 
-**Step 5 — Set up remote management (on your local machine)**
+**Step 6 — Set up remote management and client config**
 
 ```bash
-pip install router-maestro   # install CLI locally if not already installed
+pip install router-maestro   # run on the client machine
 
 router-maestro context add my-vps \
   --endpoint https://api.example.com \
-  --api-key YOUR_API_KEY
+  --api-key "sk-rm-..."
 
 router-maestro context set my-vps
+router-maestro auth list
 ```
 
 Now all CLI commands run against your VPS:
@@ -559,16 +638,23 @@ Now all CLI commands run against your VPS:
 router-maestro model list          # list models on VPS
 router-maestro auth list           # check auth status on VPS
 router-maestro config claude-code  # configure Claude Code to use VPS
+router-maestro config codex        # configure Codex; also export ROUTER_MAESTRO_API_KEY
 ```
 
-**Step 6 — Verify**
+For Codex clients, add the same key to the client shell profile or app/extension environment because the generated Codex config references `ROUTER_MAESTRO_API_KEY`:
+
+```bash
+export ROUTER_MAESTRO_API_KEY="sk-rm-..."
+```
+
+**Step 7 — Verify**
 
 ```bash
 curl https://api.example.com/health
-# Expected: {"status":"ok"}
+# Expected: {"status":"healthy"}
 
 curl https://api.example.com/api/openai/v1/models \
-  -H "Authorization: Bearer YOUR_API_KEY"
+  -H "Authorization: Bearer sk-rm-..."
 # Expected: JSON list of available models
 ```
 
@@ -577,8 +663,8 @@ curl https://api.example.com/api/openai/v1/models \
 Contexts let you manage any Router-Maestro server (local or remote) from your local CLI:
 
 ```bash
-# Add a remote server
-router-maestro context add my-vps --endpoint https://api.example.com --api-key YOUR_KEY
+# Add a remote server with the server API key from `server show-key`
+router-maestro context add my-vps --endpoint https://api.example.com --api-key sk-rm-...
 
 # Switch between servers
 router-maestro context set my-vps     # target remote VPS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     container_name: router-maestro
     restart: unless-stopped
     environment:
-      - ROUTER_MAESTRO_API_KEY=${ROUTER_MAESTRO_API_KEY}
+      - ROUTER_MAESTRO_API_KEY=${ROUTER_MAESTRO_API_KEY:-}
       - ROUTER_MAESTRO_LOG_LEVEL=${ROUTER_MAESTRO_LOG_LEVEL:-INFO}
     volumes:
       # Persist auth and config (bind mounts)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -181,15 +181,19 @@ TRAEFIK_DASHBOARD_AUTH=admin:$$2y$$05$$your_hash_here
 |----------|-------------|----------|
 | `DOMAIN` | Your domain (e.g., `api.example.com`) | Yes |
 | `ACME_EMAIL` | Email for Let's Encrypt notifications | Yes |
-| `ROUTER_MAESTRO_API_KEY` | API key for Router-Maestro | Yes |
+| `ROUTER_MAESTRO_API_KEY` | Optional fixed Router-Maestro server API key. Leave blank, and do not set it in the shell running Docker Compose, to auto-generate on first start. | No |
 | `CF_DNS_API_TOKEN` | Cloudflare API token (if using Cloudflare) | Conditional |
 | `TRAEFIK_DASHBOARD_AUTH` | Basic auth for Traefik dashboard | No |
 
-### Generating a Secure API Key
+### Router-Maestro API Key
+
+Router-Maestro protects API routes with one server API key. If `ROUTER_MAESTRO_API_KEY` is blank or unset in both `.env` and the shell running Docker Compose, the server generates a `sk-rm-...` key on first start and stores it in the mounted Router-Maestro config. Read it from inside the container:
 
 ```bash
-openssl rand -hex 32
+docker compose exec router-maestro router-maestro server show-key
 ```
+
+Use that same key in remote client contexts and raw API calls. If deployment automation needs a stable pre-provisioned value, set `ROUTER_MAESTRO_API_KEY` in `.env` before starting the service.
 
 ### Complete .env Example
 
@@ -199,7 +203,7 @@ DOMAIN=api.example.com
 ACME_EMAIL=admin@example.com
 
 # Router-Maestro
-ROUTER_MAESTRO_API_KEY=your_secure_random_key
+ROUTER_MAESTRO_API_KEY=
 
 # Cloudflare (default DNS provider)
 CF_DNS_API_TOKEN=your_cloudflare_api_token


### PR DESCRIPTION
## Summary
- Clarify that Router-Maestro can auto-generate the server API key and stores it in the server-side local context
- Separate server-side Docker/Compose key retrieval from client-side context configuration
- Fix README command/path drift for OpenAI API routes, CLI commands, and Codex API key persistence

## Test Plan
- git diff --check
- uv run ruff check src/ tests/
- uv run pytest tests/ -v
- env -u ROUTER_MAESTRO_API_KEY docker compose --env-file .env.example config
- stale README/deployment string scan for old API key placeholders and invalid commands