### PR TITLE
fix: emit integer cache token fields on Anthropic responses

### DIFF
--- a/src/router_maestro/server/translation.py
+++ b/src/router_maestro/server/translation.py
@@ -470,11 +470,22 @@ def translate_openai_to_anthropic(
         openai_reason = openai_response["choices"][0].get("finish_reason")
         finish_reason = map_openai_stop_reason_to_anthropic(openai_reason)
 
-    # Extract usage
-    openai_usage = openai_response.get("usage", {})
+    # Extract usage.
+    #
+    # OpenAI-wire usage reports cache hits under ``prompt_tokens_details.cached_tokens``.
+    # Map that onto Anthropic's ``cache_read_input_tokens`` so clients (e.g. Claude
+    # Code, which reads these fields to compute context-window pressure for
+    # auto-compact) see real cache numbers instead of nulls. OpenAI wire has no
+    # equivalent of cache *creation* tokens, so report 0 rather than null — the
+    # Anthropic spec treats this as an int.
+    openai_usage = openai_response.get("usage") or {}
+    prompt_details = openai_usage.get("prompt_tokens_details") or {}
+    cached_tokens = prompt_details.get("cached_tokens") or 0
     usage = AnthropicUsage(
         input_tokens=openai_usage.get("prompt_tokens", 0),
         output_tokens=openai_usage.get("completion_tokens", 0),
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=cached_tokens,
     )
 
     return AnthropicMessagesResponse(
@@ -502,8 +513,11 @@ def build_message_start_event(
         return None
 
     input_tokens = 0
+    cached_tokens = 0
     if state.last_usage:
         input_tokens = state.last_usage.get("prompt_tokens", 0)
+        details = state.last_usage.get("prompt_tokens_details") or {}
+        cached_tokens = details.get("cached_tokens") or 0
     elif state.estimated_input_tokens:
         input_tokens = state.estimated_input_tokens
 
@@ -521,8 +535,8 @@ def build_message_start_event(
             "usage": {
                 "input_tokens": input_tokens,
                 "output_tokens": 1,
-                "cache_creation_input_tokens": None,
-                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": cached_tokens,
                 "server_tool_use": None,
                 "service_tier": "standard",
             },
@@ -767,6 +781,12 @@ def translate_openai_chunk_to_anthropic_events(
             prompt_tokens if prompt_tokens > 0 else state.estimated_input_tokens
         )
 
+        # Pass through Copilot/OpenAI cached_tokens as Anthropic cache_read_input_tokens
+        # so Claude Code's HUD and auto-compact heuristic see real cache hits.
+        last_usage = chunk.get("usage") or state.last_usage or {}
+        details = last_usage.get("prompt_tokens_details") or {}
+        cached_tokens = details.get("cached_tokens") or 0
+
         events.append(
             {
                 "type": "message_delta",
@@ -778,7 +798,7 @@ def translate_openai_chunk_to_anthropic_events(
                     "input_tokens": input_tokens_for_display,
                     "output_tokens": completion_tokens,
                     "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": 0,
+                    "cache_read_input_tokens": cached_tokens,
                     "server_tool_use": None,
                 },
             }

--- a/tests/test_translation_advanced.py
+++ b/tests/test_translation_advanced.py
@@ -607,6 +607,42 @@ class TestTranslateOpenAIToAnthropic:
         assert tool_blocks[0].name == "exec"
         assert tool_blocks[0].input == {"command": "hostname"}
 
+    def test_cache_token_fields_are_integers_not_null(self):
+        """Anthropic spec requires cache_*_input_tokens to be int — never null.
+
+        Claude Code reads these to compute context-window pressure for
+        auto-compact; passing null breaks the heuristic and auto-compact
+        never fires.
+        """
+        openai_response = {
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+        }
+        result = translate_openai_to_anthropic(openai_response, "claude-3", "r1")
+
+        assert result.usage.cache_creation_input_tokens == 0
+        assert result.usage.cache_read_input_tokens == 0
+
+    def test_cached_tokens_mapped_to_cache_read_input_tokens(self):
+        """Copilot/OpenAI returns prompt_tokens_details.cached_tokens on cache hits.
+
+        Map it onto Anthropic's cache_read_input_tokens so Claude Code's HUD
+        shows real cache reuse instead of 0.
+        """
+        openai_response = {
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 3633,
+                "completion_tokens": 16,
+                "prompt_tokens_details": {"cached_tokens": 3613},
+            },
+        }
+        result = translate_openai_to_anthropic(openai_response, "claude-3", "r2")
+
+        assert result.usage.input_tokens == 3633
+        assert result.usage.cache_read_input_tokens == 3613
+        assert result.usage.cache_creation_input_tokens == 0
+
 
 class TestTranslateOpenAIChunkToAnthropicEvents:
     """Tests for streaming chunk translation."""
@@ -653,6 +689,64 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
         assert any(e["type"] == "message_delta" for e in events)
         assert any(e["type"] == "message_stop" for e in events)
         assert state.message_complete is True
+
+    def test_message_start_emits_integer_cache_tokens(self):
+        """message_start.usage cache_*_input_tokens must be ints, never null.
+
+        Claude Code's auto-compact heuristic short-circuits on null cache
+        fields and never fires.
+        """
+        state = AnthropicStreamState()
+        chunk = {"id": "chunk-1", "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]}
+
+        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        start = next(e for e in events if e["type"] == "message_start")
+
+        usage = start["message"]["usage"]
+        assert usage["cache_creation_input_tokens"] == 0
+        assert usage["cache_read_input_tokens"] == 0
+
+    def test_message_start_passes_through_cached_tokens(self):
+        """When last_usage carries cached_tokens, surface it as cache_read_input_tokens."""
+        state = AnthropicStreamState()
+        state.last_usage = {
+            "prompt_tokens": 3633,
+            "completion_tokens": 0,
+            "prompt_tokens_details": {"cached_tokens": 3613},
+        }
+        chunk = {"id": "chunk-1", "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]}
+
+        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        start = next(e for e in events if e["type"] == "message_start")
+
+        usage = start["message"]["usage"]
+        assert usage["input_tokens"] == 3633
+        assert usage["cache_read_input_tokens"] == 3613
+        assert usage["cache_creation_input_tokens"] == 0
+
+    def test_finish_message_delta_passes_through_cached_tokens(self):
+        """Final message_delta usage must surface cached_tokens from the same chunk."""
+        state = AnthropicStreamState()
+        state.message_start_sent = True
+        state.content_block_open = True
+
+        chunk = {
+            "id": "chunk-1",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 3633,
+                "completion_tokens": 16,
+                "prompt_tokens_details": {"cached_tokens": 3613},
+            },
+        }
+
+        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        delta = next(e for e in events if e["type"] == "message_delta")
+
+        assert delta["usage"]["input_tokens"] == 3633
+        assert delta["usage"]["output_tokens"] == 16
+        assert delta["usage"]["cache_read_input_tokens"] == 3613
+        assert delta["usage"]["cache_creation_input_tokens"] == 0
 
     def test_tool_call_events(self):
         """Test tool call event generation."""


### PR DESCRIPTION
## Summary

- `usage.cache_creation_input_tokens` and `usage.cache_read_input_tokens` were being emitted as **`null`** on the Anthropic Messages endpoint (both non-streaming response and streaming `message_start`). Anthropic's spec requires these to be integers.
- This breaks Claude Code's auto-compact heuristic — the HUD shows context filling past the 92% threshold but compaction never fires, because the calculation short-circuits when cache fields are null.
- Additionally, OpenAI/Copilot returns real cache hits under `usage.prompt_tokens_details.cached_tokens`, but the translation layer ignored it. Now mapped onto `cache_read_input_tokens` so clients see actual cache reuse.

## Verification

Direct curl against Copilot's OpenAI endpoint shows the upstream provides the data; only the translation layer was dropping it:

| Call | `prompt_tokens` | `cached_tokens` |
|------|-----------------|-----------------|
| 1 (cold) | 3633 | 0 |
| 2 (warm) | 3633 | **3613** |
| 3 (warm) | 3633 | **3613** |

Before this PR, the same request via `/api/anthropic/v1/messages` returned `cache_read_input_tokens: null` regardless.

## Changes

- `translate_openai_to_anthropic` (non-streaming): emit `cache_creation_input_tokens=0` (no OpenAI-wire equivalent) and `cache_read_input_tokens` from `prompt_tokens_details.cached_tokens`.
- `build_message_start_event` (streaming start): same mapping from `state.last_usage`.
- `translate_openai_chunk_to_anthropic_events` terminal `message_delta`: pass through `cached_tokens` from the final usage chunk.

## Test plan

- [x] 5 new unit tests covering integer-not-null contract and `cached_tokens` passthrough across both wire formats
- [x] Full test suite (831 tests) passes
- [x] `ruff check` clean
- [ ] After merge: re-test Claude Code auto-compact at high context — `cache_read_input_tokens` should populate in the response usage, and compaction should fire at the configured threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)