### PR TITLE
chore: release 0.3.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.15"
+version = "0.3.16"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.15"
+__version__ = "0.3.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.15"
+version = "0.3.16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fix-only release containing #82:

- Emit integer `cache_creation_input_tokens` / `cache_read_input_tokens` on Anthropic responses (was `null`)
- Pass through Copilot's `prompt_tokens_details.cached_tokens` as `cache_read_input_tokens` so Claude Code's HUD and auto-compact see real cache numbers

## Test plan

- [x] Version bumped in `pyproject.toml`, `__init__.py`, `uv.lock`
- [ ] After merge: tag `v0.3.16`, build & push multi-arch Docker image
- [ ] Smoke-test Claude Code auto-compact against the released image

🤖 Generated with [Claude Code](https://claude.com/claude-code)