### PR TITLE
Revert PR #82: cache token passthrough causes downstream context inflation

### DIFF
--- a/src/router_maestro/server/translation.py
+++ b/src/router_maestro/server/translation.py
@@ -470,22 +470,11 @@ def translate_openai_to_anthropic(
         openai_reason = openai_response["choices"][0].get("finish_reason")
         finish_reason = map_openai_stop_reason_to_anthropic(openai_reason)
 
-    # Extract usage.
-    #
-    # OpenAI-wire usage reports cache hits under ``prompt_tokens_details.cached_tokens``.
-    # Map that onto Anthropic's ``cache_read_input_tokens`` so clients (e.g. Claude
-    # Code, which reads these fields to compute context-window pressure for
-    # auto-compact) see real cache numbers instead of nulls. OpenAI wire has no
-    # equivalent of cache *creation* tokens, so report 0 rather than null — the
-    # Anthropic spec treats this as an int.
-    openai_usage = openai_response.get("usage") or {}
-    prompt_details = openai_usage.get("prompt_tokens_details") or {}
-    cached_tokens = prompt_details.get("cached_tokens") or 0
+    # Extract usage
+    openai_usage = openai_response.get("usage", {})
     usage = AnthropicUsage(
         input_tokens=openai_usage.get("prompt_tokens", 0),
         output_tokens=openai_usage.get("completion_tokens", 0),
-        cache_creation_input_tokens=0,
-        cache_read_input_tokens=cached_tokens,
     )
 
     return AnthropicMessagesResponse(
@@ -513,11 +502,8 @@ def build_message_start_event(
         return None
 
     input_tokens = 0
-    cached_tokens = 0
     if state.last_usage:
         input_tokens = state.last_usage.get("prompt_tokens", 0)
-        details = state.last_usage.get("prompt_tokens_details") or {}
-        cached_tokens = details.get("cached_tokens") or 0
     elif state.estimated_input_tokens:
         input_tokens = state.estimated_input_tokens
 
@@ -535,8 +521,8 @@ def build_message_start_event(
             "usage": {
                 "input_tokens": input_tokens,
                 "output_tokens": 1,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": cached_tokens,
+                "cache_creation_input_tokens": None,
+                "cache_read_input_tokens": None,
                 "server_tool_use": None,
                 "service_tier": "standard",
             },
@@ -781,12 +767,6 @@ def translate_openai_chunk_to_anthropic_events(
             prompt_tokens if prompt_tokens > 0 else state.estimated_input_tokens
         )
 
-        # Pass through Copilot/OpenAI cached_tokens as Anthropic cache_read_input_tokens
-        # so Claude Code's HUD and auto-compact heuristic see real cache hits.
-        last_usage = chunk.get("usage") or state.last_usage or {}
-        details = last_usage.get("prompt_tokens_details") or {}
-        cached_tokens = details.get("cached_tokens") or 0
-
         events.append(
             {
                 "type": "message_delta",
@@ -798,7 +778,7 @@ def translate_openai_chunk_to_anthropic_events(
                     "input_tokens": input_tokens_for_display,
                     "output_tokens": completion_tokens,
                     "cache_creation_input_tokens": 0,
-                    "cache_read_input_tokens": cached_tokens,
+                    "cache_read_input_tokens": 0,
                     "server_tool_use": None,
                 },
             }

--- a/tests/test_translation_advanced.py
+++ b/tests/test_translation_advanced.py
@@ -607,42 +607,6 @@ class TestTranslateOpenAIToAnthropic:
         assert tool_blocks[0].name == "exec"
         assert tool_blocks[0].input == {"command": "hostname"}
 
-    def test_cache_token_fields_are_integers_not_null(self):
-        """Anthropic spec requires cache_*_input_tokens to be int — never null.
-
-        Claude Code reads these to compute context-window pressure for
-        auto-compact; passing null breaks the heuristic and auto-compact
-        never fires.
-        """
-        openai_response = {
-            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
-        }
-        result = translate_openai_to_anthropic(openai_response, "claude-3", "r1")
-
-        assert result.usage.cache_creation_input_tokens == 0
-        assert result.usage.cache_read_input_tokens == 0
-
-    def test_cached_tokens_mapped_to_cache_read_input_tokens(self):
-        """Copilot/OpenAI returns prompt_tokens_details.cached_tokens on cache hits.
-
-        Map it onto Anthropic's cache_read_input_tokens so Claude Code's HUD
-        shows real cache reuse instead of 0.
-        """
-        openai_response = {
-            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
-            "usage": {
-                "prompt_tokens": 3633,
-                "completion_tokens": 16,
-                "prompt_tokens_details": {"cached_tokens": 3613},
-            },
-        }
-        result = translate_openai_to_anthropic(openai_response, "claude-3", "r2")
-
-        assert result.usage.input_tokens == 3633
-        assert result.usage.cache_read_input_tokens == 3613
-        assert result.usage.cache_creation_input_tokens == 0
-
 
 class TestTranslateOpenAIChunkToAnthropicEvents:
     """Tests for streaming chunk translation."""
@@ -689,64 +653,6 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
         assert any(e["type"] == "message_delta" for e in events)
         assert any(e["type"] == "message_stop" for e in events)
         assert state.message_complete is True
-
-    def test_message_start_emits_integer_cache_tokens(self):
-        """message_start.usage cache_*_input_tokens must be ints, never null.
-
-        Claude Code's auto-compact heuristic short-circuits on null cache
-        fields and never fires.
-        """
-        state = AnthropicStreamState()
-        chunk = {"id": "chunk-1", "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]}
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
-        start = next(e for e in events if e["type"] == "message_start")
-
-        usage = start["message"]["usage"]
-        assert usage["cache_creation_input_tokens"] == 0
-        assert usage["cache_read_input_tokens"] == 0
-
-    def test_message_start_passes_through_cached_tokens(self):
-        """When last_usage carries cached_tokens, surface it as cache_read_input_tokens."""
-        state = AnthropicStreamState()
-        state.last_usage = {
-            "prompt_tokens": 3633,
-            "completion_tokens": 0,
-            "prompt_tokens_details": {"cached_tokens": 3613},
-        }
-        chunk = {"id": "chunk-1", "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]}
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
-        start = next(e for e in events if e["type"] == "message_start")
-
-        usage = start["message"]["usage"]
-        assert usage["input_tokens"] == 3633
-        assert usage["cache_read_input_tokens"] == 3613
-        assert usage["cache_creation_input_tokens"] == 0
-
-    def test_finish_message_delta_passes_through_cached_tokens(self):
-        """Final message_delta usage must surface cached_tokens from the same chunk."""
-        state = AnthropicStreamState()
-        state.message_start_sent = True
-        state.content_block_open = True
-
-        chunk = {
-            "id": "chunk-1",
-            "choices": [{"delta": {}, "finish_reason": "stop"}],
-            "usage": {
-                "prompt_tokens": 3633,
-                "completion_tokens": 16,
-                "prompt_tokens_details": {"cached_tokens": 3613},
-            },
-        }
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
-        delta = next(e for e in events if e["type"] == "message_delta")
-
-        assert delta["usage"]["input_tokens"] == 3633
-        assert delta["usage"]["output_tokens"] == 16
-        assert delta["usage"]["cache_read_input_tokens"] == 3613
-        assert delta["usage"]["cache_creation_input_tokens"] == 0
 
     def test_tool_call_events(self):
         """Test tool call event generation."""


### PR DESCRIPTION
## Summary

Reverts #82 (`fix: emit integer cache token fields on Anthropic responses`), shipped as 0.3.16.

## Why

PR #82 mapped Copilot's `prompt_tokens_details.cached_tokens` onto Anthropic's `cache_read_input_tokens` so Claude Code's auto-compact heuristic could see real cache hits. After deploying 0.3.16 to the container, Claude Code sessions showed abnormal context growth:

- Single turns jumped from ~20% context to 60%+
- Auto-compact fired against tiny payloads (e.g. compacting after a 690-token request) while `/context` reported numbers inconsistent with the actual conversation size

## Verification

A/B tested by rolling the container back to 0.3.15 (no cache passthrough) and re-running the same Claude Code workflow:

- 0.3.16 (with passthrough): 20% → 60%+ jumps reproducible, auto-compact misfires
- 0.3.15 (without passthrough): smooth linear context growth, auto-compact triggers at the configured threshold

The symptom pattern (monotonic per-turn accumulation that scales with conversation length) is consistent with a downstream consumer summing `input_tokens + cache_read_input_tokens` per turn instead of treating `cache_read_input_tokens` as a subset of `input_tokens`. Until we confirm the consumer-side accounting model, the safer state is no passthrough.

## What this restores

- `translation.py` non-streaming response: `AnthropicUsage` without cache fields
- `translation.py` `build_message_start_event`: `usage` without cache fields
- `translation.py` `message_delta` builder: `usage` without cache fields
- `tests/test_translation_advanced.py`: removes the 4 tests that asserted the cache passthrough

## Test plan

- [x] `uv run pytest tests/test_translation_advanced.py -v` — 49 passed
- [ ] Deploy to container, repeat the workflow that triggered 20→60% jumps, confirm linear growth restored
- [ ] Follow-up: investigate downstream accounting before reintroducing cache field emission

## Follow-up

Filing a separate issue to track the underlying question — does Claude Code (or the HUD) double-count when both `input_tokens` and `cache_read_input_tokens` are non-zero, or does it expect `cache_read_input_tokens` to be exclusive of `input_tokens`? The answer determines whether we re-land #82 with a corrected mapping or skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)