### PR TITLE
chore: release 0.3.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.16"
+version = "0.3.17"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.16"
+__version__ = "0.3.17"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.16"
+version = "0.3.17"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Bumps version to 0.3.17
- Captures the revert from #84 (cache token passthrough caused downstream context inflation in Claude Code)

## Test plan

- [x] \`uv lock\` clean
- [ ] Build + push Docker image after merge
- [ ] Deploy to container, confirm linear context growth restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)