### PR TITLE
chore: release 0.3.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.17"
+version = "0.3.18"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.17"
+__version__ = "0.3.18"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.17"
+version = "0.3.18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Release 0.3.18.

- Bump `pyproject.toml` 0.3.17 → 0.3.18
- Bump `__version__` to 0.3.18
- Regenerate `uv.lock`

Ships #86 — `router-maestro config claude-code` now prompts for `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (y=upstream / n=skip / d=200K default), skipped for 1M-native Claude keys; `/api/admin/models` exposes upstream token limits so the CLI can show real numbers.

## Test plan

- [x] `uv run pytest tests/` — 826 pass
- [x] `uv run ruff check src/` clean
- [x] `uv lock` regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)