### PR TITLE
fix: align auto-compact upstream value with Copilot's picker display

### DIFF
--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -234,7 +234,8 @@ def _prompt_auto_compact_window(model: dict | None) -> int | None:
     Returns the chosen token count to write, or ``None`` to skip the env var.
 
     The prompt has three options:
-      * ``y`` — use the upstream ``max_prompt_tokens`` (if known)
+      * ``y`` — use the upstream context window (``max_prompt_tokens`` +
+        ``max_output_tokens``, matching what Copilot's own model picker shows)
       * ``n`` — skip; do not set the env var
       * ``d`` — set the default 200K (recommended for non-Claude models)
 
@@ -247,12 +248,12 @@ def _prompt_auto_compact_window(model: dict | None) -> int | None:
     if model_key in _CLAUDE_CODE_NATIVE_1M_KEYS:
         return None
 
-    upstream = model.get("max_prompt_tokens")
+    upstream = _upstream_context_window(model)
     default_value = _CLAUDE_CODE_DEFAULT_AUTO_COMPACT_WINDOW
     upstream_line = (
-        f"  Upstream max_prompt_tokens: {upstream}"
-        if isinstance(upstream, int) and upstream > 0
-        else "  Upstream max_prompt_tokens: (unknown)"
+        f"  Upstream context window: {upstream}"
+        if upstream is not None
+        else "  Upstream context window: (unknown)"
     )
 
     console.print()
@@ -266,7 +267,7 @@ def _prompt_auto_compact_window(model: dict | None) -> int | None:
     )
 
     choices = ["y", "n", "d"]
-    can_use_upstream = isinstance(upstream, int) and upstream > 0
+    can_use_upstream = upstream is not None
     if can_use_upstream:
         prompt_text = f"y = upstream: {upstream} / n = skip / d = default: {default_value}"
     else:
@@ -281,6 +282,24 @@ def _prompt_auto_compact_window(model: dict | None) -> int | None:
     if choice == "y" and can_use_upstream:
         return int(upstream)
     return default_value
+
+
+def _upstream_context_window(model: dict) -> int | None:
+    """Compute the displayed upstream context window for a Copilot model.
+
+    Mirrors what VS Code's Copilot model picker shows: prompt + output, which
+    matches the catalog's advertised window in most cases. Falls back to the
+    server-reported ``max_context_window_tokens`` if either component is
+    missing.
+    """
+    prompt = model.get("max_prompt_tokens")
+    output = model.get("max_output_tokens")
+    if isinstance(prompt, int) and prompt > 0 and isinstance(output, int) and output > 0:
+        return prompt + output
+    ctx = model.get("max_context_window_tokens")
+    if isinstance(ctx, int) and ctx > 0:
+        return ctx
+    return None
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary

The `y` option in `router-maestro config claude-code`'s `CLAUDE_CODE_AUTO_COMPACT_WINDOW` prompt now uses `max_prompt_tokens + max_output_tokens` instead of `max_prompt_tokens` alone, matching the value VS Code's Copilot model picker shows in its **Context Size** column.

## Why

VS Code Copilot's extension reports two separate fields to the VS Code LM API (`languageModelAccess.ts:331`):

\`\`\`ts
maxInputTokens: endpoint.modelMaxPromptTokens - baseCount - BaseTokensPerCompletion,
maxOutputTokens: endpoint.maxOutputTokens,
\`\`\`

The picker's **Context Size** column renders the sum. Verified against the live `/models` endpoint — 12/13 models match exactly:

| Model | prompt+output | VS Code |
|---|---|---|
| Opus 4.7 high | 168K + 64K = 232K | 232K |
| Opus 4.8 | 168K + 64K = 232K | 232K |
| Sonnet 4.5/4.6 | 168K + 32K = 200K | 200K |
| Haiku 4.5 | 136K + 64K = 200K | 200K |
| Gemini 3.5 Flash | 128K + 64K = 192K | 192K |
| GPT-5 mini | 128K + 64K = 192K | 192K |
| GPT-5.2 | 272K + 128K = 400K | 400K |
| MAI-Code-1-Flash | 128K + 128K = 256K | 256K |

(Opus 4.6/4.7 base shows 202K vs our 200K — a 2K rounding artifact in VS Code core that we can't observe from the extension layer; not material for auto-compact decisions.)

The previous behavior showed `168000` for Opus 4.7, which is the hard prompt-token ceiling but doesn't reflect the total window users see in their picker.

## Test plan

- [x] `uv run pytest tests/test_config.py` — 21 pass
- [x] `uv run ruff check src/` clean
- [ ] Pick `github-copilot/claude-opus-4.7` in `config claude-code`, confirm prompt shows `y = upstream: 200000`
- [ ] Pick `github-copilot/claude-opus-4.7-high`, confirm `y = upstream: 232000`
- [ ] Pick `github-copilot/gpt-5.2`, confirm `y = upstream: 400000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)