### PR TITLE
chore: release 0.3.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.18"
+version = "0.3.19"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.18"
+__version__ = "0.3.19"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.18"
+version = "0.3.19"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Release 0.3.19.

Ships #88 — `router-maestro config claude-code`'s `y` choice now writes `max_prompt_tokens + max_output_tokens` to `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, matching the Context Size column in VS Code's Copilot model picker.

## Test plan

- [x] `uv run pytest tests/` passes
- [x] `uv run ruff check src/` clean
- [x] `uv lock` regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)