### PR TITLE
feat(copilot): reasoning_effort=max + 1M context keys for Opus 4.8 / Sonnet 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Router-Maestro acts as a proxy that gives you access to models from multiple pro
 
 ### Advanced
 
-- **1M context support**: Activate Opus 4.6 *or* Opus 4.7 with a 1M context window via GitHub Copilot — just select `claude-opus-4-6[1m]` or `claude-opus-4-7[1m]` during `config claude-code` setup. Claude Code's `[1m]` beta header is auto-mapped to the right Copilot variant (`claude-opus-4.6-1m` / `claude-opus-4.7-1m-internal`).
-- **Transparent reasoning-tier routing**: Requests for `claude-opus-4.7` with `reasoning_effort: "high"` or `"xhigh"` (or an Anthropic-style `thinking.budget_tokens` ≥ 8192) are auto-rewritten to the dedicated Copilot variants `claude-opus-4.7-high` / `claude-opus-4.7-xhigh` — no client changes needed.
+- **1M context support**: Activate Opus 4.6, Opus 4.7, Opus 4.8, *or* Sonnet 4.6 with a 1M context window via GitHub Copilot — just select `claude-opus-4-6[1m]`, `claude-opus-4-7[1m]`, `claude-opus-4-8[1m]`, or `claude-sonnet-4-6[1m]` during `config claude-code` setup. For 4.6 / 4.7 the `[1m]` beta header is auto-mapped to a dedicated Copilot variant (`claude-opus-4.6-1m` / `claude-opus-4.7-1m-internal`); for 4.8 and Sonnet 4.6 the base catalog entry already advertises 1M, so the synthetic `[1m]` key just raises Claude Code's auto-compact threshold (`CLAUDE_CODE_AUTO_COMPACT_WINDOW`) to 1M.
+- **Transparent reasoning-tier routing**: Requests for `claude-opus-4.7` with `reasoning_effort: "high"` or `"xhigh"` (or an Anthropic-style `thinking.budget_tokens` ≥ 8192) are auto-rewritten to the dedicated Copilot variants `claude-opus-4.7-high` / `claude-opus-4.7-xhigh` — no client changes needed. The newly-opened `reasoning_effort: "max"` tier (Opus 4.6 / 4.7 / 4.8 on Copilot) is also passed through verbatim when the model catalog advertises it.
 
 ## Table of Contents
 

--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -43,6 +43,15 @@ _OPUS_1M_NATIVE_KEY = "claude-opus-4-6[1m]"
 _OPUS_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.6-1m"
 _OPUS_47_1M_NATIVE_KEY = "claude-opus-4-7[1m]"
 _OPUS_47_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.7-1m-internal"
+# Opus 4.8 and Sonnet 4.6 don't ship a dedicated `-1m` variant — their base
+# catalog entry already advertises max_context_window_tokens=1000000, so the
+# native key maps straight to the base id. The `[1m]` suffix here only exists
+# so Claude Code raises its auto-compact threshold to ~1M instead of clamping
+# at the default 200K.
+_OPUS_48_1M_NATIVE_KEY = "claude-opus-4-8[1m]"
+_OPUS_48_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.8"
+_SONNET_46_1M_NATIVE_KEY = "claude-sonnet-4-6[1m]"
+_SONNET_46_1M_SOURCE_MODEL = "github-copilot/claude-sonnet-4.6"
 
 _INJECTABLE_1M_VARIANTS: tuple[tuple[str, str, str, str], ...] = (
     # (source_model, native_key, bare_id, display_name)
@@ -57,6 +66,18 @@ _INJECTABLE_1M_VARIANTS: tuple[tuple[str, str, str, str], ...] = (
         _OPUS_47_1M_NATIVE_KEY,
         "claude-opus-4.7-1m-internal",
         "Opus 4.7 1M Internal (Auto-activated)",
+    ),
+    (
+        _OPUS_48_1M_SOURCE_MODEL,
+        _OPUS_48_1M_NATIVE_KEY,
+        "claude-opus-4.8",
+        "Opus 4.8 1M (Auto-activated)",
+    ),
+    (
+        _SONNET_46_1M_SOURCE_MODEL,
+        _SONNET_46_1M_NATIVE_KEY,
+        "claude-sonnet-4.6",
+        "Sonnet 4.6 1M (Auto-activated)",
     ),
 )
 
@@ -221,7 +242,12 @@ def _model_key(model: dict) -> str:
 # ones we inject via `_maybe_inject_opus_1m`) — the prompt offers a 1M default
 # for them instead of the upstream-value option.
 _CLAUDE_CODE_NATIVE_1M_KEYS: frozenset[str] = frozenset(
-    {_OPUS_1M_NATIVE_KEY, _OPUS_47_1M_NATIVE_KEY}
+    {
+        _OPUS_1M_NATIVE_KEY,
+        _OPUS_47_1M_NATIVE_KEY,
+        _OPUS_48_1M_NATIVE_KEY,
+        _SONNET_46_1M_NATIVE_KEY,
+    }
 )
 
 # Default CLAUDE_CODE_AUTO_COMPACT_WINDOW for non-Claude models. Matches

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -80,11 +80,11 @@ def _claude_supports_reasoning(bare_lower: str) -> bool:
     )
 
 
-_EFFORT_ORDER = ("low", "medium", "high", "xhigh")
+_EFFORT_ORDER = ("low", "medium", "high", "xhigh", "max")
 
 
 def _pick_closest_effort(desired: str, allowed: list[str]) -> str | None:
-    """Pick the value from ``allowed`` closest to ``desired`` on the L/M/H/XH ladder.
+    """Pick the value from ``allowed`` closest to ``desired`` on the L/M/H/XH/MAX ladder.
 
     Strategy when an exact match is unavailable: prefer the next *higher* tier
     (the user asked for thinking — give them more, not less), and fall back to
@@ -109,6 +109,14 @@ def _pick_closest_effort(desired: str, allowed: list[str]) -> str | None:
     return allowed[0]
 
 
+def _catalog_top_effort(allowed: list[str]) -> str | None:
+    """Return the highest tier from ``allowed`` per the L/M/H/XH/MAX ladder."""
+    ranked = [v for v in allowed if v in _EFFORT_ORDER]
+    if not ranked:
+        return allowed[0] if allowed else None
+    return max(ranked, key=lambda v: _EFFORT_ORDER.index(v))
+
+
 def apply_copilot_chat_reasoning(
     payload: dict,
     model: str,
@@ -127,10 +135,11 @@ def apply_copilot_chat_reasoning(
     When the catalog says nothing (``None``), we fall back to the hardcoded
     per-family heuristic:
 
-    * ``claude-opus-4.6*`` / ``claude-sonnet-4.6`` accept ``low``/``medium``/``high``.
-    * ``claude-opus-4.7`` only accepts ``medium`` (clamp).
+    * ``claude-opus-4.6+`` / ``claude-sonnet-4.6`` accept ``low``/``medium``/``high``
+      (and tolerate ``max`` being downgraded into the same set).
     * Older Claudes (4.5 / sonnet-4 / haiku) take no reasoning field.
-    * ``gpt-5*`` / ``o1`` / ``o3`` / ``o4`` accept ``low``/``medium``/``high``/``xhigh``.
+    * ``gpt-5*`` / ``o1`` / ``o3`` / ``o4`` accept ``low``/``medium``/``high``/``xhigh``
+      (``max`` is downgraded to ``xhigh``).
     * ``gpt-4*``, ``gemini-*`` take no reasoning field.
 
     For ``gpt-5.4*`` the gateway also requires ``max_completion_tokens`` instead
@@ -155,9 +164,10 @@ def apply_copilot_chat_reasoning(
         else:
             desired = reasoning_effort or budget_to_effort(thinking_budget)
             if desired is None and thinking_budget is not None:
-                # Client asked for thinking without a clear effort — be
-                # aggressive and aim for the top of the catalog.
-                desired = "high"
+                # Client asked for thinking without a clear effort — aim for
+                # the top tier the catalog actually advertises (e.g. "max" on
+                # opus-4.6+, "xhigh" on gpt-5.x).
+                desired = _catalog_top_effort(catalog_effort_values)
             if desired is not None:
                 picked = _pick_closest_effort(desired, catalog_effort_values)
                 if picked is not None:
@@ -174,24 +184,22 @@ def apply_copilot_chat_reasoning(
             pass
         else:
             effort = reasoning_effort or budget_to_effort(thinking_budget)
-            if effort == "xhigh":
-                effort = "high"  # Claude effort enum tops out at high
+            # Claude on Copilot tops out at "high" on the cold-start path
+            # (xhigh/max only kick in via catalog advertisement). Don't block
+            # the request — downgrade so it still goes through.
+            if effort in ("xhigh", "max"):
+                effort = "high"
             if effort is None and thinking_budget is not None:
                 effort = "high"
-            # opus-4.7's gateway only accepts "medium" today. Clamp anything
-            # else to medium so the request doesn't fail.
-            if bare_lower.startswith("claude-opus-4.7") and effort in (
-                "low",
-                "medium",
-                "high",
-            ):
-                effort = "medium"
             if effort in ("low", "medium", "high"):
                 payload["reasoning_effort"] = effort
     elif is_openai_reasoning:
         effort = reasoning_effort or budget_to_effort(thinking_budget)
         # Copilot's gpt-5* line natively accepts xhigh (verified against the
-        # gateway's supported_values list), so don't downgrade here.
+        # gateway's supported_values list). "max" is a Router-Maestro
+        # extension — clamp it to xhigh on the cold-start path.
+        if effort == "max":
+            effort = "xhigh"
         if effort in ("low", "medium", "high", "xhigh"):
             payload["reasoning_effort"] = effort
 
@@ -977,11 +985,12 @@ class CopilotProvider(BaseProvider):
                     upstream_effort = _pick_closest_effort(desired, catalog)
         else:
             upstream_effort = downgrade_for_upstream(request.reasoning_effort)
-            if request.reasoning_effort == "xhigh" and upstream_effort == "high":
+            if request.reasoning_effort in ("xhigh", "max") and upstream_effort == "high":
                 logger.warning(
                     "Copilot Responses catalog cold for %s; "
-                    "downgrading reasoning_effort=xhigh to high as a precaution",
+                    "downgrading reasoning_effort=%s to high as a precaution",
                     request.model,
+                    request.reasoning_effort,
                 )
         if upstream_effort is not None:
             # ``summary: auto`` opts in to reasoning_summary_text events so we

--- a/src/router_maestro/providers/openai_base.py
+++ b/src/router_maestro/providers/openai_base.py
@@ -64,15 +64,17 @@ class OpenAIChatProvider(BaseProvider, ABC):
             payload["tool_choice"] = request.tool_choice
 
         # Forward OpenAI-style reasoning_effort. Fall back to deriving it from
-        # thinking_budget when only the Anthropic-style budget is set. xhigh is
-        # downgraded to "high" since vanilla OpenAI/Copilot reject it.
+        # thinking_budget when only the Anthropic-style budget is set. xhigh /
+        # max are Router-Maestro extensions and get downgraded to "high" since
+        # vanilla OpenAI/Copilot reject them.
         effort = request.reasoning_effort or budget_to_effort(request.thinking_budget)
         upstream_effort = downgrade_for_upstream(effort)
         if upstream_effort is not None:
-            if effort == "xhigh":
+            if effort in ("xhigh", "max"):
                 self._logger.warning(
-                    "%s does not accept reasoning_effort=xhigh; downgrading to high",
+                    "%s does not accept reasoning_effort=%s; downgrading to high",
                     self._error_label(),
+                    effort,
                 )
             payload["reasoning_effort"] = upstream_effort
 

--- a/src/router_maestro/utils/reasoning.py
+++ b/src/router_maestro/utils/reasoning.py
@@ -5,8 +5,9 @@ Anthropic-style ``thinking.budget_tokens`` (integer) are normalised through
 this module so that every entry-route and every provider speaks the same
 language.
 
-``"xhigh"`` is a Router-Maestro extension above OpenAI's spec — when sent to
-an upstream that does not accept it, providers should downgrade to ``"high"``.
+``"xhigh"`` and ``"max"`` are Router-Maestro extensions above OpenAI's spec —
+when sent to an upstream that does not accept them, providers downgrade to
+the highest tier the upstream supports.
 """
 
 from __future__ import annotations
@@ -16,13 +17,14 @@ EFFORT_TO_BUDGET: dict[str, int] = {
     "medium": 4096,
     "high": 8192,
     "xhigh": 16384,
+    "max": 32768,
 }
 
-VALID_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+VALID_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 # Effort tiers eligible for transparent variant rewriting (e.g. claude-opus-4.7
 # → claude-opus-4.7-high). low/medium are passed through as reasoning_effort.
-VARIANT_EFFORTS: tuple[str, ...] = ("high", "xhigh")
+VARIANT_EFFORTS: tuple[str, ...] = ("high", "xhigh", "max")
 
 # Effort levels that vanilla OpenAI / Copilot upstreams accept directly.
 UPSTREAM_NATIVE_EFFORTS: tuple[str, ...] = ("low", "medium", "high")
@@ -51,11 +53,11 @@ def budget_to_effort(budget: int | None) -> str | None:
 
 
 def downgrade_for_upstream(effort: str | None) -> str | None:
-    """Map ``xhigh`` → ``high`` for upstreams that reject the extension."""
+    """Map ``xhigh``/``max`` → ``high`` for upstreams that reject extensions."""
     if effort is None:
         return None
     if effort in UPSTREAM_NATIVE_EFFORTS:
         return effort
-    if effort == "xhigh":
+    if effort in ("xhigh", "max"):
         return "high"
     return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,11 @@ from router_maestro.cli import config as cli_config
 from router_maestro.cli.config import (
     _OPUS_1M_NATIVE_KEY,
     _OPUS_1M_SOURCE_MODEL,
+    _OPUS_47_1M_NATIVE_KEY,
+    _OPUS_48_1M_NATIVE_KEY,
+    _SONNET_46_1M_NATIVE_KEY,
     _maybe_inject_opus_1m,
+    _prompt_auto_compact_window,
     _select_model,
 )
 from router_maestro.config.contexts import ContextConfig, ContextsConfig
@@ -214,6 +218,93 @@ class TestMaybeInjectOpus1M:
         """Guard against accidental changes to the source model constant."""
         assert _OPUS_1M_SOURCE_MODEL == "github-copilot/claude-opus-4.6-1m"
         assert _OPUS_1M_NATIVE_KEY == "claude-opus-4-6[1m]"
+
+    def test_injects_opus_48_and_sonnet_46_from_base_ids(self):
+        """4.8 and sonnet-4.6 have no dedicated -1m variant; the synthetic
+        entries map their [1m] native key straight to the base catalog id."""
+        models = [
+            {"provider": "github-copilot", "id": "claude-opus-4.8", "name": "Claude Opus 4.8"},
+            {
+                "provider": "github-copilot",
+                "id": "claude-sonnet-4.6",
+                "name": "Claude Sonnet 4.6",
+            },
+        ]
+
+        result = _maybe_inject_opus_1m(models)
+
+        # Two new synthetic entries appear before the originals.
+        assert len(result) == 4
+        custom_keys = {m.get("custom_key") for m in result if "custom_key" in m}
+        assert _OPUS_48_1M_NATIVE_KEY in custom_keys
+        assert _SONNET_46_1M_NATIVE_KEY in custom_keys
+        # The synthetic entries point at the base ids — there is no -1m suffix
+        # on the catalog side for these.
+        synthetic_by_key = {m["custom_key"]: m for m in result if "custom_key" in m}
+        assert synthetic_by_key[_OPUS_48_1M_NATIVE_KEY]["id"] == "claude-opus-4.8"
+        assert synthetic_by_key[_SONNET_46_1M_NATIVE_KEY]["id"] == "claude-sonnet-4.6"
+
+
+class TestPromptAutoCompactWindow:
+    """Tests for ``_prompt_auto_compact_window`` — the Claude Code auto-compact
+    env var selection. Native 1M model keys must offer 1M as the default; every
+    other model must fall back to the 200K default.
+    """
+
+    @staticmethod
+    def _synthetic(custom_key: str) -> dict:
+        """A model dict shaped like the synthetic entries _maybe_inject_opus_1m emits."""
+        return {
+            "provider": "github-copilot",
+            "id": "ignored-base-id",
+            "custom_key": custom_key,
+            "name": "test",
+        }
+
+    def test_returns_none_when_model_is_none(self):
+        assert _prompt_auto_compact_window(None) is None
+
+    def test_user_skip_returns_none(self, monkeypatch):
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: "n")
+        assert _prompt_auto_compact_window(self._synthetic(_OPUS_1M_NATIVE_KEY)) is None
+
+    def test_opus_48_native_key_defaults_to_1m(self, monkeypatch):
+        """4.8 has no -1m catalog variant, but its [1m] native key must still
+        unlock the 1M default in the auto-compact prompt."""
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: "d")
+        assert _prompt_auto_compact_window(self._synthetic(_OPUS_48_1M_NATIVE_KEY)) == 1_000_000
+
+    def test_sonnet_46_native_key_defaults_to_1m(self, monkeypatch):
+        """Same as 4.8 — sonnet-4.6 ships only the base id but [1m] gets 1M."""
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: "d")
+        assert _prompt_auto_compact_window(self._synthetic(_SONNET_46_1M_NATIVE_KEY)) == 1_000_000
+
+    def test_opus_46_and_47_native_keys_defaults_to_1m(self, monkeypatch):
+        """Regression guard: the pre-existing 4.6 / 4.7 native keys keep their
+        1M default after adding 4.8 / sonnet-4.6 to the set."""
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: "d")
+        assert _prompt_auto_compact_window(self._synthetic(_OPUS_1M_NATIVE_KEY)) == 1_000_000
+        assert _prompt_auto_compact_window(self._synthetic(_OPUS_47_1M_NATIVE_KEY)) == 1_000_000
+
+    def test_non_native_model_defaults_to_200k(self, monkeypatch):
+        """A plain catalog model (no [1m] native key) gets the 200K default."""
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: "d")
+        plain = {"provider": "github-copilot", "id": "claude-opus-4.8", "name": "Claude Opus 4.8"}
+        assert _prompt_auto_compact_window(plain) == 200_000
+
+    def test_native_1m_prompt_omits_upstream_choice(self, monkeypatch):
+        """For native 1M keys we must not offer ``y = upstream``; the Copilot
+        catalog's prompt cap (~936K) is below Claude Code's own 1M view, and
+        using it would arm auto-compact earlier than the user expects."""
+        captured = {}
+
+        def fake_ask(prompt_text, choices=None, default=None):
+            captured["choices"] = choices
+            return "d"
+
+        monkeypatch.setattr(cli_config.Prompt, "ask", fake_ask)
+        _prompt_auto_compact_window(self._synthetic(_SONNET_46_1M_NATIVE_KEY))
+        assert "y" not in captured["choices"]
 
 
 class _StubAdminClient:

--- a/tests/test_copilot_chat_reasoning.py
+++ b/tests/test_copilot_chat_reasoning.py
@@ -10,16 +10,26 @@ def _base_payload(extra: dict | None = None) -> dict:
     return payload
 
 
-def test_claude_47_clamped_to_medium():
-    """opus-4.7 gateway only accepts 'medium' — anything else gets clamped."""
-    for input_effort in ("low", "high", None):
+def test_claude_47_cold_start_uses_requested_effort():
+    """opus-4.7 cold-start (no catalog yet): pass through low/medium/high as-is.
+
+    Earlier the gateway clamped to ``medium``, but Copilot now advertises
+    low/medium/high/xhigh/max for opus-4.7 — we no longer artificially clamp.
+    """
+    for input_effort, expected in (("low", "low"), ("medium", "medium"), ("high", "high")):
         for budget in (1024, 16000, None):
-            if input_effort is None and budget is None:
-                continue
             p = _base_payload()
             apply_copilot_chat_reasoning(p, "claude-opus-4.7", budget, input_effort)
-            assert p.get("reasoning_effort") == "medium", (input_effort, budget)
+            assert p.get("reasoning_effort") == expected, (input_effort, budget)
             assert "thinking_budget" not in p
+
+
+def test_claude_47_cold_start_clamps_xhigh_and_max_to_high():
+    """Without the catalog we don't know xhigh/max are accepted — downgrade."""
+    for input_effort in ("xhigh", "max"):
+        p = _base_payload()
+        apply_copilot_chat_reasoning(p, "claude-opus-4.7", None, input_effort)
+        assert p.get("reasoning_effort") == "high", input_effort
 
 
 def test_claude_46_uses_reasoning_effort_not_thinking_budget():
@@ -78,8 +88,7 @@ def test_claude_47_dated_alias_still_supports_reasoning():
     support — it is *not* one of the tier-encoded variants."""
     p = _base_payload()
     apply_copilot_chat_reasoning(p, "claude-opus-4.7-20260101", 16000, "high")
-    # Subject to the existing 4.7 medium clamp, but reasoning_effort still set.
-    assert p.get("reasoning_effort") == "medium"
+    assert p.get("reasoning_effort") == "high"
 
 
 def test_claude_with_provider_prefix():
@@ -230,3 +239,71 @@ def test_catalog_thinking_budget_maps_through_normal_table():
     )
     # 8192 → "high" per EFFORT_TO_BUDGET threshold
     assert p.get("reasoning_effort") == "high"
+
+
+def test_catalog_passes_max_through_when_advertised():
+    """If the catalog advertises 'max', desired='max' should be sent as-is."""
+    p = _base_payload()
+    apply_copilot_chat_reasoning(
+        p,
+        "claude-opus-4.7",
+        None,
+        "max",
+        catalog_effort_values=["low", "medium", "high", "xhigh", "max"],
+    )
+    assert p.get("reasoning_effort") == "max"
+
+
+def test_catalog_promotes_xhigh_to_max_when_only_max_higher():
+    """opus-4.6 catalog is ['low','medium','high','max'] (no xhigh).
+    A request for 'xhigh' should promote up to 'max', not down to 'high'.
+    """
+    p = _base_payload()
+    apply_copilot_chat_reasoning(
+        p,
+        "claude-opus-4.6",
+        None,
+        "xhigh",
+        catalog_effort_values=["low", "medium", "high", "max"],
+    )
+    assert p.get("reasoning_effort") == "max"
+
+
+def test_catalog_thinking_only_aims_at_catalog_top_tier():
+    """When the client sends thinking_budget without an explicit effort, the
+    catalog-driven path should aim at the catalog's top tier (not hardcoded 'high').
+    """
+    p = _base_payload()
+    apply_copilot_chat_reasoning(
+        p,
+        "claude-opus-4.6",
+        4096,  # below "high" threshold but client opted into thinking
+        None,
+        catalog_effort_values=["low", "medium", "high", "max"],
+    )
+    # budget=4096 → desired derives to "medium", picked exactly: medium
+    assert p.get("reasoning_effort") == "medium"
+
+    p = _base_payload()
+    apply_copilot_chat_reasoning(
+        p,
+        "claude-opus-4.6",
+        None,
+        None,
+        catalog_effort_values=["low", "medium", "high", "max"],
+    )
+    # no budget, no effort → emit nothing
+    assert "reasoning_effort" not in p
+
+
+def test_catalog_thinking_budget_zero_picks_top_tier():
+    """budget=1 → no effort derived → catalog-top selected (max)."""
+    p = _base_payload()
+    apply_copilot_chat_reasoning(
+        p,
+        "claude-opus-4.8",
+        1,  # too small to map but client opted into thinking
+        None,
+        catalog_effort_values=["low", "medium", "high", "xhigh", "max"],
+    )
+    assert p.get("reasoning_effort") == "max"

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -46,7 +46,9 @@ class TestEffortMapping:
             ("medium", 4096),
             ("high", 8192),
             ("xhigh", 16384),
+            ("max", 32768),
             ("HIGH", 8192),
+            ("MAX", 32768),
             (None, None),
             ("bogus", None),
         ],
@@ -63,11 +65,14 @@ class TestEffortMapping:
         assert budget_to_effort(8192) == "high"
         assert budget_to_effort(16000) == "high"
         assert budget_to_effort(EFFORT_TO_BUDGET["xhigh"]) == "xhigh"
+        assert budget_to_effort(EFFORT_TO_BUDGET["max"]) == "max"
+        assert budget_to_effort(64000) == "max"
 
     def test_downgrade_for_upstream(self):
         assert downgrade_for_upstream(None) is None
         assert downgrade_for_upstream("low") == "low"
         assert downgrade_for_upstream("xhigh") == "high"
+        assert downgrade_for_upstream("max") == "high"
         assert downgrade_for_upstream("garbage") is None
 
 

--- a/tests/test_thinking_passthrough.py
+++ b/tests/test_thinking_passthrough.py
@@ -128,8 +128,9 @@ class TestCopilotPayloadThinking:
             await provider.chat_completion(request)
 
         assert "thinking_budget" not in captured_payload
-        # opus-4.7's gateway only accepts "medium" — anything else clamps.
-        assert captured_payload.get("reasoning_effort") == "medium"
+        # opus-4.7 now accepts high (Copilot opened the upper tiers via the
+        # model catalog). budget=16000 → desired "high" → passed through.
+        assert captured_payload.get("reasoning_effort") == "high"
 
     @pytest.mark.asyncio
     async def test_copilot_payload_omits_thinking_when_none(self):


### PR DESCRIPTION
## Summary

Two related Copilot-catalog updates bundled into one PR:

1. **`reasoning_effort=max` passthrough** for Opus 4.6 / 4.7 / 4.8 (commit `6b23232`).
   Copilot recently opened the `max` tier on the Opus catalog
   (`reasoning_effort_values: [...,"max"]` — also `xhigh` for 4.7 / 4.8).
   `_EFFORT_ORDER`, the cold-start path, the catalog-driven path, and
   `downgrade_for_upstream` all learned about `max`; the stale opus-4.7
   medium clamp is gone; the catalog-driven path now aims at the catalog's
   real top tier instead of hardcoded `high`.

2. **Native 1M keys for Opus 4.8 + Sonnet 4.6** (commit `68b820b`).
   Unlike 4.6 / 4.7, 4.8 and Sonnet 4.6 don't ship a dedicated `-1m`
   Copilot variant — their base catalog entry already advertises
   `max_context_window_tokens=1000000`. But Claude Code still clamps
   `CLAUDE_CODE_AUTO_COMPACT_WINDOW` at 200K unless the model key carries
   a `[1m]` suffix it recognizes. `config claude-code` now injects
   synthetic `claude-opus-4-8[1m]` / `claude-sonnet-4-6[1m]` entries that
   map straight to the base catalog id; the suffix exists only to raise
   the auto-compact threshold to 1M.

## Test plan

- [x] `uv run pytest tests/ -q` — 841 passed
- [x] `uv run ruff check src/` — clean
- [x] Live end-to-end smoke against Copilot for `reasoning_effort=max`
- [x] New `TestPromptAutoCompactWindow` covers all four native 1M keys,
      the 200K fallback for non-native models, and the `y = upstream`
      choice being suppressed for native 1M keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)