### PR TITLE
chore: release 0.3.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.20"
+version = "0.3.21"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.20"
+__version__ = "0.3.21"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.20"
+version = "0.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Release v0.3.21 — bundles two Copilot-catalog updates merged in #92:

- **`reasoning_effort=max` passthrough** for Opus 4.6 / 4.7 / 4.8 (Copilot opened the `max` tier on the Opus catalog; `xhigh` also for 4.7 / 4.8). Removes the stale opus-4.7 medium clamp and makes the catalog-driven path aim at the catalog's real top tier instead of hardcoded `high`.
- **Native 1M context keys for Opus 4.8 + Sonnet 4.6**: `config claude-code` now injects synthetic `claude-opus-4-8[1m]` / `claude-sonnet-4-6[1m]` entries that raise `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to 1M without rewriting the model id (4.8 / sonnet-4.6 don't ship dedicated `-1m` Copilot variants — their base catalog already advertises 1M).

## Test plan

- [x] `uv run pytest tests/ -v` — 841 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv lock` refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)