### PR TITLE
chore(ci): bump softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ needs.prepare.outputs.version }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

Bumps `softprops/action-gh-release` from `v2` to `v3` in `.github/workflows/release.yml`.

v2 still runs on Node.js 20. GitHub Actions runners will force Node 20 actions off by default on **2026-06-16** and remove the Node 20 runtime entirely on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). [v3.0.0](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0) (released 2026-04-12) switched the action runtime to Node 24.

This is the only Node-20-affected action in the workflows — `actions/checkout@v6`, `astral-sh/setup-uv@v7`, and the `docker/*@v3` family are all already on Node 24.

The action only runs in the `create-release` job, which fires after a `v*.*.*` tag is pushed to master — no functional change otherwise.

## Test plan

- [x] No other workflow references `softprops/action-gh-release`
- [ ] Verified on the next release run (will surface as no Node-20 annotation under `Create GitHub Release`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)