### PR TITLE
fix(anthropic): handle Claude Code 2.1 mid-conversation-system beta

### DIFF
--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException
 from fastapi import Request as FastAPIRequest
+from fastapi.responses import JSONResponse
 
 from router_maestro.providers import AnthropicProvider, ChatRequest, ProviderError
 from router_maestro.routing import Router, get_router
@@ -191,6 +192,84 @@ def _has_extended_context_beta(raw_request: FastAPIRequest) -> bool:
     return "context-1m" in header.lower()
 
 
+# Anthropic beta header that lets clients append ``{"role": "system", ...}``
+# entries directly into ``messages[]`` mid-conversation, preserving prompt
+# cache locality instead of rebuilding the top-level ``system`` field.
+# Claude Code 2.1.x defaults this beta to ON for ``claude-opus-4-8``.
+_MID_CONV_SYSTEM_BETA = "mid-conversation-system-2026-04-07"
+
+
+def _has_mid_conv_system_beta(raw_request: FastAPIRequest) -> bool:
+    """Check if the request opts into the mid-conversation-system beta."""
+    header = raw_request.headers.get("anthropic-beta", "")
+    return _MID_CONV_SYSTEM_BETA in header.lower()
+
+
+async def _raw_body_has_inline_system(raw_request: FastAPIRequest) -> bool:
+    """Return True iff the original request body had ``role="system"`` in messages.
+
+    The Pydantic ``before`` validator hoists inline system messages out of the
+    array so the rest of the schema can validate, which means by the time the
+    route runs we've lost the original shape. Re-reading the raw body lets us
+    tell whether Claude Code actually sent the mid-conversation-system payload
+    so we can return the 400 it expects, vs. a non-Claude-Code client where
+    the silent hoist is the right behavior.
+
+    Body bytes are cached by Starlette, so this is a no-op second read.
+    """
+    try:
+        body = await raw_request.body()
+        if not body:
+            return False
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return False
+    return any(isinstance(m, dict) and m.get("role") == "system" for m in messages)
+
+
+def _mid_conv_system_rejection_response() -> JSONResponse:
+    """Return a 400 that triggers Claude Code's mid-conv-system fallback.
+
+    Claude Code's ``Mk8`` error classifier (Claude Code 2.1.x) accepts this
+    request as a beta-not-supported signal when the response message
+    contains both the beta header string and ``"anthropic-beta"``. Hitting
+    that path makes Claude Code:
+
+    1. Strip the ``mid-conversation-system-2026-04-07`` header for the rest
+       of the session (sticky until ``/clear`` or ``/compact``).
+    2. Rewrite the inline system messages into ``<system-reminder>`` blocks
+       inside ``user`` messages, preserving mid-conversation position so the
+       prompt cache stays warm.
+    3. Retry transparently — the user sees no error.
+
+    Returning the hoisted payload with a 200 instead would silently work but
+    waste cache: Claude Code would keep sending the beta every turn, and we
+    would keep flattening it into a top-level ``system`` rewrite that
+    invalidates the cache prefix on every message.
+    """
+    message = (
+        f"This model does not support the `anthropic-beta: {_MID_CONV_SYSTEM_BETA}` "
+        'header through Router-Maestro. Inline `role: "system"` messages were '
+        "rejected; the client should drop the beta header and fall back to "
+        "rebuilding the top-level system prompt or to <system-reminder> blocks."
+    )
+    return JSONResponse(
+        status_code=400,
+        content={
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": message,
+            },
+        },
+    )
+
+
 @router.post("/v1/messages")
 @router.post("/api/anthropic/v1/messages")
 async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIRequest):
@@ -209,6 +288,24 @@ async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIReques
                 keepalive_frame=ANTHROPIC_PING_FRAME,
             )
         return _create_test_response()
+
+    # Claude Code 2.1.x enables `mid-conversation-system-2026-04-07` by
+    # default for opus-4-8 and sends `role:"system"` blocks inline in
+    # `messages`. The schema validator silently hoists them so generic
+    # OpenAI-shaped clients (Cline, Aider, …) still work, but Claude Code
+    # itself has a richer fallback path that preserves prompt-cache
+    # locality. When we see the beta header AND the original payload had
+    # inline system messages, return a 400 that matches Claude Code's
+    # `Mk8` detector so it strips the beta and retries with
+    # <system-reminder> blocks. See binary analysis in PR description.
+    if _has_mid_conv_system_beta(raw_request) and await _raw_body_has_inline_system(raw_request):
+        logger.info(
+            "Rejecting mid-conversation-system beta for model=%s so the "
+            "client falls back to <system-reminder> blocks (preserves "
+            "prompt cache)",
+            request.model,
+        )
+        return _mid_conv_system_rejection_response()
 
     model_router = get_router()
 

--- a/src/router_maestro/server/schemas/anthropic.py
+++ b/src/router_maestro/server/schemas/anthropic.py
@@ -1,8 +1,8 @@
 """Anthropic API-compatible schemas."""
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Request types
 
@@ -147,6 +147,11 @@ class AnthropicMessagesRequest(BaseModel):
     thinking: AnthropicThinkingConfig | None = None
     service_tier: Literal["auto", "standard_only"] | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _hoist_inline_system_messages(cls, data: Any) -> Any:
+        return _hoist_inline_system_messages(data)
+
 
 class AnthropicCountTokensRequest(BaseModel):
     """Anthropic count_tokens API request (max_tokens not required)."""
@@ -155,6 +160,103 @@ class AnthropicCountTokensRequest(BaseModel):
     messages: list[AnthropicMessage]
     system: str | list[AnthropicTextBlock] | None = None
     tools: list[AnthropicTool] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _hoist_inline_system_messages(cls, data: Any) -> Any:
+        return _hoist_inline_system_messages(data)
+
+
+def _hoist_inline_system_messages(data: Any) -> Any:
+    """Move any ``role="system"`` entries out of ``messages`` and into ``system``.
+
+    The Anthropic Messages API only allows ``user`` and ``assistant`` roles in
+    the ``messages`` array — system prompts must be passed via the top-level
+    ``system`` field. Some clients (Cline, Aider, generic OpenAI-shaped tools
+    that get pointed at the Anthropic endpoint) still inline system messages
+    into the array, which would otherwise be rejected by Pydantic with a 422
+    before our routing code ever sees the request.
+
+    This is the **fallback** path of the dual-path mid-conversation-system
+    strategy: the Anthropic route also detects Claude Code's
+    ``mid-conversation-system-2026-04-07`` beta header and short-circuits
+    those requests with a 400 so Claude Code falls back to its own
+    ``<system-reminder>`` rewrite (which preserves prompt-cache locality).
+    Generic clients without that beta land here, where silent hoisting is
+    the most useful behavior because they don't know how to retry.
+
+    This validator runs in ``before`` mode and rewrites the payload so the
+    rest of the schema can validate normally. System content is concatenated
+    in original order and appended to any existing top-level ``system`` value.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    messages = data.get("messages")
+    if not isinstance(messages, list):
+        return data
+
+    kept: list = []
+    extracted: list[str] = []
+    found = False
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+        if role == "system":
+            found = True
+            content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
+            text = _coerce_system_content_to_text(content)
+            if text:
+                extracted.append(text)
+            continue
+        kept.append(msg)
+
+    if not found:
+        return data
+
+    data = dict(data)
+    data["messages"] = kept
+
+    if extracted:
+        merged = "\n\n".join(extracted)
+        existing = data.get("system")
+        if existing is None or (isinstance(existing, str) and not existing.strip()):
+            data["system"] = merged
+        elif isinstance(existing, str):
+            data["system"] = f"{existing}\n\n{merged}"
+        elif isinstance(existing, list):
+            data["system"] = list(existing) + [{"type": "text", "text": merged}]
+
+    return data
+
+
+def _coerce_system_content_to_text(content: Any) -> str:
+    """Flatten a system-message content payload to plain text.
+
+    Accepts a string or a list of text-shaped blocks (``{"type": "text",
+    "text": ...}``). Unknown block types are silently dropped — they would
+    not survive the strict ``AnthropicMessage`` union anyway, and we'd
+    rather hoist whatever text we can than fail the whole request.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+                continue
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                continue
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+        return "\n\n".join(p for p in parts if p)
+    return ""
 
 
 # Response types

--- a/tests/test_anthropic_inline_system.py
+++ b/tests/test_anthropic_inline_system.py
@@ -1,0 +1,153 @@
+"""Tests for hoisting inline ``role="system"`` messages into the top-level ``system`` field.
+
+The Anthropic Messages API only accepts ``user`` and ``assistant`` roles in
+``messages``. Some clients still inline a system message into the array; we
+silently hoist it so the request validates and routes normally instead of
+returning 422.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from router_maestro.server.schemas.anthropic import (
+    AnthropicCountTokensRequest,
+    AnthropicMessagesRequest,
+)
+
+
+class TestHoistInlineSystemMessages:
+    def test_inline_system_string_hoisted_when_no_top_level(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "Hi"},
+                    {"role": "system", "content": "You are concise."},
+                    {"role": "assistant", "content": "Hello."},
+                ],
+            }
+        )
+        assert req.system == "You are concise."
+        assert len(req.messages) == 2
+        assert req.messages[0].role == "user"
+        assert req.messages[1].role == "assistant"
+
+    def test_inline_system_block_list_hoisted(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": [
+                            {"type": "text", "text": "First rule."},
+                            {"type": "text", "text": "Second rule."},
+                        ],
+                    },
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        )
+        assert req.system == "First rule.\n\nSecond rule."
+        assert len(req.messages) == 1
+        assert req.messages[0].role == "user"
+
+    def test_inline_system_merges_with_existing_system_string(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "system": "Be helpful.",
+                "messages": [
+                    {"role": "system", "content": "Also be terse."},
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        )
+        assert req.system == "Be helpful.\n\nAlso be terse."
+
+    def test_inline_system_appends_to_existing_system_list(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "system": [{"type": "text", "text": "Be helpful."}],
+                "messages": [
+                    {"role": "system", "content": "Also be terse."},
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        )
+        assert isinstance(req.system, list)
+        assert len(req.system) == 2
+        assert req.system[0].text == "Be helpful."
+        assert req.system[1].text == "Also be terse."
+
+    def test_multiple_inline_system_messages_concatenated(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "system", "content": "Rule A."},
+                    {"role": "user", "content": "Hi"},
+                    {"role": "system", "content": "Rule B."},
+                    {"role": "assistant", "content": "Hello."},
+                ],
+            }
+        )
+        assert req.system == "Rule A.\n\nRule B."
+        assert [m.role for m in req.messages] == ["user", "assistant"]
+
+    def test_no_inline_system_leaves_request_unchanged(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "system": "Top-level only.",
+                "messages": [{"role": "user", "content": "Hi"}],
+            }
+        )
+        assert req.system == "Top-level only."
+        assert len(req.messages) == 1
+
+    def test_empty_inline_system_content_is_dropped_silently(self):
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "system", "content": ""},
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        )
+        assert req.system is None
+        assert len(req.messages) == 1
+
+    def test_count_tokens_request_also_hoists_inline_system(self):
+        req = AnthropicCountTokensRequest.model_validate(
+            {
+                "model": "claude-opus-4-8",
+                "messages": [
+                    {"role": "system", "content": "You are concise."},
+                    {"role": "user", "content": "Hi"},
+                ],
+            }
+        )
+        assert req.system == "You are concise."
+        assert len(req.messages) == 1
+
+    def test_unknown_role_still_rejected(self):
+        with pytest.raises(ValidationError):
+            AnthropicMessagesRequest.model_validate(
+                {
+                    "model": "claude-opus-4-8",
+                    "max_tokens": 1024,
+                    "messages": [
+                        {"role": "tool", "content": "nope"},
+                    ],
+                }
+            )

--- a/tests/test_anthropic_mid_conv_system_reject.py
+++ b/tests/test_anthropic_mid_conv_system_reject.py
@@ -1,0 +1,170 @@
+"""Tests for the mid-conversation-system beta rejection path.
+
+When Claude Code 2.1.x sends the ``mid-conversation-system-2026-04-07``
+beta header for ``claude-opus-4-8`` (and other models that default it on),
+inline ``role:"system"`` messages MUST be rejected with a 400 carrying the
+beta header string. Claude Code's ``Mk8`` error classifier reads that 400
+and falls back to ``<system-reminder>`` blocks while sticky-rejecting the
+beta for the rest of the session, which preserves prompt-cache locality.
+
+Generic OpenAI-shaped clients (Cline, Aider, etc.) that send inline
+``role:"system"`` WITHOUT the beta header still get the silent-hoist
+behavior — they have no fallback to negotiate with.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from router_maestro.providers.base import ChatResponse
+from router_maestro.server.routes.anthropic import (
+    _MID_CONV_SYSTEM_BETA,
+    router,
+)
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_router_success():
+    """A router that returns a trivial assistant response so non-rejected
+    requests can complete end-to-end through the route."""
+    response = ChatResponse(
+        content="ok",
+        model="claude-opus-4-8",
+        finish_reason="stop",
+        usage={"prompt_tokens": 1, "completion_tokens": 1},
+    )
+    mock = MagicMock()
+    mock.chat_completion = AsyncMock(return_value=(response, "anthropic"))
+    mock._resolve_provider = AsyncMock(return_value=("anthropic", "claude-opus-4-8", MagicMock()))
+    mock.get_model_info = AsyncMock(return_value=None)
+    mock.find_extended_context_model = AsyncMock(return_value=None)
+    mock.rewrite_to_reasoning_variant = AsyncMock(side_effect=lambda r: r)
+    return mock
+
+
+def _claude_code_payload(with_inline_system: bool) -> dict:
+    """Build a minimal AnthropicMessagesRequest payload."""
+    messages: list[dict] = [
+        {"role": "user", "content": "Hi"},
+    ]
+    if with_inline_system:
+        messages.append({"role": "system", "content": "Mid-conv reminder."})
+    messages.append({"role": "assistant", "content": "Hello."})
+    messages.append({"role": "user", "content": "Tell me more."})
+    return {
+        "model": "claude-opus-4-8",
+        "max_tokens": 16,
+        "messages": messages,
+    }
+
+
+class TestMidConvSystemRejection:
+    def test_inline_system_with_beta_header_returns_400(self, client, mock_router_success):
+        """With both inline system + beta header, return 400 in the shape
+        Claude Code's Mk8 detector recognises."""
+        with patch(
+            "router_maestro.server.routes.anthropic.get_router",
+            return_value=mock_router_success,
+        ):
+            response = client.post(
+                "/api/anthropic/v1/messages",
+                json=_claude_code_payload(with_inline_system=True),
+                headers={"anthropic-beta": _MID_CONV_SYSTEM_BETA},
+            )
+        assert response.status_code == 400
+        body = response.json()
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "invalid_request_error"
+        # Mk8 trigger: message must contain BOTH the beta header value
+        # and the literal string "anthropic-beta" so the client detects
+        # this as a beta-rejection and not a generic 400.
+        assert _MID_CONV_SYSTEM_BETA in body["error"]["message"]
+        assert "anthropic-beta" in body["error"]["message"]
+
+    def test_inline_system_with_multiple_betas_still_rejected(self, client, mock_router_success):
+        """Beta header can be comma-separated; mid-conv-system must still match."""
+        with patch(
+            "router_maestro.server.routes.anthropic.get_router",
+            return_value=mock_router_success,
+        ):
+            response = client.post(
+                "/api/anthropic/v1/messages",
+                json=_claude_code_payload(with_inline_system=True),
+                headers={
+                    "anthropic-beta": (
+                        f"context-1m-2024-08-07,{_MID_CONV_SYSTEM_BETA},prompt-caching"
+                    )
+                },
+            )
+        assert response.status_code == 400
+
+    def test_inline_system_without_beta_header_is_hoisted(self, client, mock_router_success):
+        """Non-Claude-Code clients (no beta header) get the silent hoist
+        path — should succeed, not 400, not 422."""
+        with patch(
+            "router_maestro.server.routes.anthropic.get_router",
+            return_value=mock_router_success,
+        ):
+            response = client.post(
+                "/api/anthropic/v1/messages",
+                json=_claude_code_payload(with_inline_system=True),
+            )
+        # Should not be a beta-rejection 400 nor a 422 schema error.
+        assert response.status_code == 200, response.text
+
+    def test_beta_header_without_inline_system_passes_through(self, client, mock_router_success):
+        """Claude Code may send the beta header speculatively even when
+        the conversation has no system message yet. Don't reject those."""
+        with patch(
+            "router_maestro.server.routes.anthropic.get_router",
+            return_value=mock_router_success,
+        ):
+            response = client.post(
+                "/api/anthropic/v1/messages",
+                json=_claude_code_payload(with_inline_system=False),
+                headers={"anthropic-beta": _MID_CONV_SYSTEM_BETA},
+            )
+        assert response.status_code == 200, response.text
+
+    def test_rejection_response_is_json_serialisable(self, client, mock_router_success):
+        """Body must parse cleanly so SDK error wrappers don't choke."""
+        with patch(
+            "router_maestro.server.routes.anthropic.get_router",
+            return_value=mock_router_success,
+        ):
+            response = client.post(
+                "/api/anthropic/v1/messages",
+                json=_claude_code_payload(with_inline_system=True),
+                headers={"anthropic-beta": _MID_CONV_SYSTEM_BETA},
+            )
+        # raises if not valid JSON
+        json.loads(response.content)
+        assert response.headers["content-type"].startswith("application/json")
+
+    def test_rejection_path_for_v1_alias(self, client, mock_router_success):
+        """The /v1/messages alias must reject identically to the namespaced path."""
+        with patch(
+            "router_maestro.server.routes.anthropic.get_router",
+            return_value=mock_router_success,
+        ):
+            response = client.post(
+                "/v1/messages",
+                json=_claude_code_payload(with_inline_system=True),
+                headers={"anthropic-beta": _MID_CONV_SYSTEM_BETA},
+            )
+        assert response.status_code == 400


### PR DESCRIPTION
## Summary

Claude Code 2.1.168 enabled the `mid-conversation-system-2026-04-07` beta by default for `claude-opus-4-8` and started shipping inline `role:"system"` entries directly in `messages[]`. Our strict Pydantic schema returned 422 before any router code ran, so users hit \`API Error: 422\` on the very first turn.

Binary analysis of \`/Users/likanwen/.local/share/claude/versions/2.1.168\` confirmed:
- \`x96(model)\` hard-codes \`return true\` for \`claude-opus-4-8\` (no env toggle to disable, short of HIPAA mode or \`CLAUDE_CODE_FORCE_MID_CONVERSATION_SYSTEM=0\`).
- \`Mk8(error)\` classifies a 400 as "drop the beta and retry" iff the message contains both the beta-header literal and the string \`anthropic-beta\`. On that path, Claude Code rewrites the inline system entries into \`<system-reminder>\` blocks at the same conversation position, sticky-rejects the beta for the session, and retries — prompt cache stays warm, user sees no error.

## Fix

Two complementary paths, dispatched by client capability:

1. **Route-level (Claude Code path)** — \`src/router_maestro/server/routes/anthropic.py\`: when the request carries the beta header AND the raw body has \`role:"system"\` in \`messages\`, short-circuit with a 400 in the exact shape \`Mk8\` recognises. Claude Code's own fallback chain takes over.
2. **Schema-level (generic clients)** — \`src/router_maestro/server/schemas/anthropic.py\`: a Pydantic \`model_validator(mode="before")\` silently hoists \`role:"system"\` entries into the top-level \`system\` field for clients like Cline/Aider that have no beta-rejection contract to negotiate with.

### Behaviour matrix

| Client signal | Behaviour |
|---|---|
| beta header + inline system | 400 → Claude Code falls back, cache OK |
| beta header only | 200 (passthrough) |
| inline system only | 200 (silently hoisted) |
| spec-compliant request | unchanged |

## Test plan

- [x] \`uv run pytest tests/ -q\` → 856 passed (15 new)
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run ruff format --check src/ tests/\` clean
- [ ] Manual smoke: \`claude\` 2.1.168 against local Router-Maestro with Opus 4.8 1M — no more 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)