### PR TITLE
chore: release 0.3.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.21"
+version = "0.3.22"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.21"
+__version__ = "0.3.22"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.21"
+version = "0.3.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Release 0.3.22.

### What's in this release

- **fix(anthropic): handle Claude Code 2.1 mid-conversation-system beta** (#95) — Claude Code 2.1.168 enables \`mid-conversation-system-2026-04-07\` by default for opus-4-8 and sends inline \`role:"system"\` entries in \`messages[]\`, which previously triggered 422. Now we either return a Claude-Code-recognised 400 (when the beta header is present) so the client falls back to \`<system-reminder>\` blocks and keeps the prompt cache warm, or silently hoist inline system to the top-level field for generic clients.

## Test plan

- [x] \`uv run pytest tests/ -q\` → 856 passed
- [ ] CI green
- [ ] GHA release workflow tags + publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)