### PR TITLE
chore: release 0.3.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.22"
+version = "0.3.23"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.22"
+__version__ = "0.3.23"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.22"
+version = "0.3.23"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump 0.3.22 → 0.3.23.

Releases the codebase review batch merged in #97 (correctness, security and streaming fixes across providers, routing, translation, server routes, config and auth).

After merge, tag `v0.3.23` is pushed to trigger the release workflow (PyPI + Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)