### PR TITLE
fix(config): guard os.fchmod for Windows compatibility

### DIFF
--- a/src/router_maestro/config/settings.py
+++ b/src/router_maestro/config/settings.py
@@ -33,8 +33,11 @@ def write_json_owner_only(path: Path, data: Any) -> None:
     fdopen_took_fd = False
     try:
         # fchmod before fdopen takes ownership of fd; if it raises, fd is still
-        # ours to close (the except below handles it).
-        os.fchmod(fd, 0o600)
+        # ours to close (the except below handles it). os.fchmod is POSIX-only
+        # and absent on Windows, where mkstemp already restricts the file to the
+        # creating user and the POSIX permission bits do not apply.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             fdopen_took_fd = True
             json.dump(data, f, indent=2, ensure_ascii=False)

--- a/tests/test_auth_advanced.py
+++ b/tests/test_auth_advanced.py
@@ -1,5 +1,6 @@
 """Tests for auth storage module."""
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -284,6 +285,9 @@ class TestAuthStorage:
         finally:
             path.unlink(missing_ok=True)
 
+    @pytest.mark.skipif(
+        not hasattr(os, "fchmod"), reason="POSIX permission bits not applicable on this platform"
+    )
     def test_save_writes_owner_only_permissions(self, tmp_path):
         """auth.json contains tokens and API keys, so it must not be group/world-readable."""
         path = tmp_path / "auth.json"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,13 @@
 """Tests for configuration module."""
 
 import json
+import os
 import tempfile
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import tomlkit
 
 from router_maestro.cli import config as cli_config
@@ -91,6 +93,9 @@ class TestConfigIO:
             loaded = load_config(path, ProvidersConfig, ProvidersConfig.get_default)
             assert loaded.providers.keys() == original.providers.keys()
 
+    @pytest.mark.skipif(
+        not hasattr(os, "fchmod"), reason="POSIX permission bits not applicable on this platform"
+    )
     def test_save_config_writes_owner_only_permissions(self, tmp_path):
         """Config files may contain API keys and should be owner-readable only."""
         path = tmp_path / "contexts.json"


### PR DESCRIPTION
## Problem

On Windows, `router-maestro config` (and any config/auth write) crashes with:

```
Error: module 'os' has no attribute 'fchmod'
```

`os.fchmod` is POSIX-only. `write_json_owner_only()` in `config/settings.py` called it unconditionally, so the first config/auth save on Windows raises `AttributeError`.

## Fix

Guard the call with `hasattr(os, "fchmod")`:

- **POSIX (macOS/Linux):** unchanged — file is locked to `0o600`.
- **Windows:** skipped — POSIX permission bits don't apply, and `tempfile.mkstemp` already restricts the file to the creating user via the parent directory ACL (`C:\Users\<user>\...`).

The two `0o600` permission-assertion tests are skipped on platforms lacking `os.fchmod`.

## Test

51 tests pass on macOS; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)