### PR TITLE
chore: bump version to 0.3.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.25"
+version = "0.3.26"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.25"
+__version__ = "0.3.26"

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.25"
+version = "0.3.26"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps version to 0.3.26 for release.

Includes #105 (thinking-budget model-name normalization + 32768 max-budget ceiling).

- `pyproject.toml`, `src/router_maestro/__init__.py`, `uv.lock` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)