### PR TITLE
fix(dev): bind published port to 127.0.0.1 to avoid orphaned WSL IPv6 relay

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,14 @@ services:
     container_name: router-maestro
     restart: unless-stopped
     ports:
-      - "${ROUTER_MAESTRO_PORT:-8080}:8080"
+      # Bind to IPv4 loopback only. A bare "8080:8080" publishes dual-stack
+      # (0.0.0.0 + [::]), which makes WSL2/Docker Desktop spin up an IPv6
+      # `wslrelay` on [::1]:8080. After a host sleep/restart that relay can be
+      # orphaned — it accepts connections but never responds, so clients that
+      # resolve `localhost` to ::1 first (e.g. Node) hang for ~6s. Pinning the
+      # host side to 127.0.0.1 means no IPv6 relay is ever created, and stray
+      # ::1 attempts get an instant connection-refused + IPv4 fallback.
+      - "127.0.0.1:${ROUTER_MAESTRO_PORT:-8080}:8080"
     environment:
       - ROUTER_MAESTRO_API_KEY=${ROUTER_MAESTRO_API_KEY:-}
       - ROUTER_MAESTRO_LOG_LEVEL=${ROUTER_MAESTRO_LOG_LEVEL:-INFO}


### PR DESCRIPTION
## Summary

A bare `8080:8080` in `docker-compose.dev.yml` publishes dual-stack (`0.0.0.0` + `[::]`), which makes Docker Desktop on WSL2 create an IPv6 `wslrelay` on `[::1]:8080`. After a host sleep/restart that relay can be orphaned: it accepts the TCP connection but never responds, so clients that resolve `localhost` to `::1` first (e.g. Node-based clients like Claude Code) hang ~6s until timeout. This surfaced as router-maestro appearing to "stop" while the container was actually healthy.

## Fix

Pin the host side to `127.0.0.1` so no IPv6 publish exists — WSL never creates a relay to orphan. Stray `::1` attempts get a fast connection-refused and fall back to IPv4 in milliseconds. Also tightens exposure from LAN-wide to loopback-only, which is all the dev container needs.

## Scope

- Only `docker-compose.dev.yml` is changed.
- Production `docker-compose.yml` is unaffected (it does not publish 8080 to the host; Traefik reaches the container over the internal network).