### PR TITLE
chore: bump version to 0.3.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
-## Unreleased
+## v0.3.27 (2026-06-23)
 
 ### Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.3.26"
+version = "0.3.27"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.3.26"
+__version__ = "0.3.27"

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.3.26"
+version = "0.3.27"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bump version `0.3.26` → `0.3.27` to release the HTTP observability foundation (#101).

## Changes
- `pyproject.toml`, `src/router_maestro/__init__.py`: version → 0.3.27
- `uv.lock`: relock
- `CHANGELOG.md`: promote the Unreleased observability entry to v0.3.27 (2026-06-23)

After merge, tag `v0.3.27` on master to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)