### PR TITLE
fix(copilot): retry on 401/403 + accept multi-header auth

### DIFF
--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -5,13 +5,16 @@ import contextlib
 import json
 import time
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, NoReturn
 from uuid import uuid4
 
 import httpx
 
 from router_maestro.auth import AuthManager, AuthType
-from router_maestro.auth.github_oauth import get_copilot_token
+from router_maestro.auth.github_oauth import (
+    GitHubOAuthError,
+    get_copilot_token,
+)
 from router_maestro.auth.storage import OAuthCredential
 from router_maestro.providers.base import (
     TIMEOUT_NON_STREAMING,
@@ -205,6 +208,9 @@ def apply_copilot_chat_reasoning(
 # Model cache TTL in seconds (5 minutes)
 MODELS_CACHE_TTL = 300
 
+# HTTP statuses that may indicate a stale/invalid Copilot token.
+_AUTH_RETRY_STATUSES = frozenset({401, 403})
+
 
 def _thinking_requested(request: ChatRequest) -> bool:
     """Whether the client opted into reasoning passthrough.
@@ -274,8 +280,14 @@ class CopilotProvider(BaseProvider):
         cred = self.auth_manager.get_credential("github-copilot")
         return cred is not None and cred.type == AuthType.OAUTH
 
-    async def ensure_token(self) -> None:
-        """Ensure we have a valid Copilot token, refreshing if needed."""
+    async def ensure_token(self, force: bool = False) -> None:
+        """Ensure we have a valid Copilot token, refreshing if needed.
+
+        Args:
+            force: Re-mint the Copilot token even if the locally-cached one
+                looks unexpired. Used by the 401/403 retry path when the
+                upstream rejects a token our clock still considers valid.
+        """
         cred = self.auth_manager.get_credential("github-copilot")
         if not cred or not isinstance(cred, OAuthCredential):
             logger.error("Not authenticated with GitHub Copilot")
@@ -287,14 +299,30 @@ class CopilotProvider(BaseProvider):
         current_time = int(time.time())
 
         # Check if we need to refresh (token expired or will expire soon)
-        if self._cached_token and self._token_expires > current_time + 60:
+        if not force and self._cached_token and self._token_expires > current_time + 60:
             return  # Token still valid
+
+        # Snapshot the token we're trying to replace so that, after we win the
+        # lock, we can tell whether another coroutine already re-minted it.
+        token_before_lock = self._cached_token
 
         async with self._token_refresh_lock:
             # Double-checked: another coroutine may have refreshed while we waited.
             current_time = int(time.time())
-            if self._cached_token and self._token_expires > current_time + 60:
+            if not force and self._cached_token and self._token_expires > current_time + 60:
                 return
+            # Force path: if another coroutine already swapped in a fresh token
+            # while we waited for the lock, reuse it instead of re-minting. This
+            # collapses an N-request 401 storm into a single mint.
+            if force and self._cached_token and self._cached_token != token_before_lock:
+                return
+
+            # Re-read the credential under the lock: another coroutine may have
+            # persisted a fresh Copilot token while we waited; use the latest.
+            cred = self.auth_manager.get_credential("github-copilot")
+            if not cred or not isinstance(cred, OAuthCredential):
+                logger.error("Not authenticated with GitHub Copilot")
+                raise ProviderError("Not authenticated with GitHub Copilot", status_code=401)
 
             logger.debug("Refreshing Copilot token")
             # Use a fresh short-lived client for token refresh to avoid blocking
@@ -302,7 +330,23 @@ class CopilotProvider(BaseProvider):
             try:
                 async with httpx.AsyncClient(timeout=TIMEOUT_NON_STREAMING) as client:
                     copilot_token = await get_copilot_token(client, cred.refresh)
-            except httpx.HTTPError as e:
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code in (401, 403):
+                    logger.error(
+                        "GitHub Copilot authentication failed (%s)", e.response.status_code
+                    )
+                    # Keep retryable=True so the router can still fall back to
+                    # other configured providers; the message tells the user how
+                    # to recover if Copilot is their only provider.
+                    raise ProviderError(
+                        "GitHub Copilot authentication expired. If Copilot is your only "
+                        "provider, re-authenticate: `router-maestro auth login github-copilot`.",
+                        status_code=401,
+                        retryable=True,
+                    )
+                logger.error("Failed to refresh Copilot token: %s", e)
+                raise ProviderError(f"Failed to refresh Copilot token: {e}", retryable=True)
+            except (httpx.HTTPError, GitHubOAuthError) as e:
                 logger.error("Failed to refresh Copilot token: %s", e)
                 raise ProviderError(f"Failed to refresh Copilot token: {e}", retryable=True)
 
@@ -310,16 +354,139 @@ class CopilotProvider(BaseProvider):
             self._token_expires = copilot_token.expires_at
             self._api_base = copilot_token.api_endpoint or self._api_base or COPILOT_BASE_URL
 
-            # Update stored credential with new access token (immutable pattern)
-            updated_cred = OAuthCredential(
-                refresh=cred.refresh,
-                access=copilot_token.token,
-                expires=copilot_token.expires_at,
-                api_endpoint=copilot_token.api_endpoint or cred.api_endpoint,
+            # Update stored credential with the new access token (immutable pattern).
+            await self._persist_credential(
+                OAuthCredential(
+                    refresh=cred.refresh,
+                    access=copilot_token.token,
+                    expires=copilot_token.expires_at,
+                    api_endpoint=copilot_token.api_endpoint or cred.api_endpoint,
+                )
             )
-            self.auth_manager.storage.set("github-copilot", updated_cred)
-            await asyncio.to_thread(self.auth_manager.save)
             logger.debug("Copilot token refreshed, expires at %d", copilot_token.expires_at)
+
+    async def _persist_credential(self, cred: OAuthCredential) -> None:
+        """Store and flush a credential to auth.json off the event loop."""
+        self.auth_manager.storage.set("github-copilot", cred)
+        await asyncio.to_thread(self.auth_manager.save)
+
+    async def _refresh_for_auth_status(self, path: str, status_code: int) -> bool:
+        """Decide whether an auth-status response warrants a forced re-mint.
+
+        Shared by every Copilot call site (chat, responses, models — streaming
+        and not) so the retry policy lives in exactly one place. Only 401/403
+        trigger a refresh; 429/5xx pass through to the caller. A 403 we can't
+        heal (policy/entitlement/quota) just costs one wasted re-mint+retry,
+        which is cheaper than a token-age heuristic that would blind us to a
+        genuinely revoked token in its first seconds. Returns True iff a forced
+        refresh was performed and the caller should retry once.
+        """
+        if status_code not in _AUTH_RETRY_STATUSES:
+            return False
+        logger.info(
+            "Copilot %s returned %d; forcing token refresh and retrying",
+            path,
+            status_code,
+        )
+        await self.ensure_token(force=True)
+        return True
+
+    def _raise_auth_failure(self, path: str, status_code: int) -> NoReturn:
+        """Raise a retryable auth error for a 401/403 that survived the retry.
+
+        Centralizes the policy so every call site (chat, responses, models —
+        streaming and not) treats a post-retry auth rejection identically:
+        retryable so the router can fall back to other configured providers,
+        with a message that tells the user how to recover if Copilot is their
+        only provider.
+        """
+        logger.error("Copilot %s still returned %d after token refresh", path, status_code)
+        raise ProviderError(
+            f"Copilot authentication rejected ({status_code}) after refresh. If Copilot is "
+            "your only provider, re-authenticate: `router-maestro auth login github-copilot`.",
+            status_code=status_code,
+            retryable=True,
+        )
+
+    async def _send_with_auth_retry(
+        self,
+        method: str,
+        path: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+        json: dict | None = None,
+        headers_kwargs: dict | None = None,
+        timeout: Any = TIMEOUT_NON_STREAMING,
+    ) -> httpx.Response:
+        """Send a non-streaming Copilot request, force-refreshing once on 401/403.
+
+        Shared by chat/responses (POST, shared pool) and models (GET, fresh
+        short-lived ``client``). Auth rejections on a token our clock still
+        considers valid self-heal by re-minting and retrying once; a 401/403
+        that survives the retry raises a retryable auth error so the router can
+        fall back. 429/5xx pass through unchanged for the caller to handle.
+        """
+        client = client or self._get_client()
+        headers_kwargs = headers_kwargs or {}
+        for attempt in range(2):
+            if method == "GET":
+                response = await client.get(
+                    self._url(path),
+                    headers=self._get_headers(**headers_kwargs),
+                    timeout=timeout,
+                )
+            else:
+                response = await client.post(
+                    self._url(path),
+                    json=json,
+                    headers=self._get_headers(**headers_kwargs),
+                    timeout=timeout,
+                )
+            if attempt == 0 and await self._refresh_for_auth_status(path, response.status_code):
+                continue
+            if response.status_code in _AUTH_RETRY_STATUSES:
+                self._raise_auth_failure(path, response.status_code)
+            return response
+        # Unreachable: attempt 1 always returns or raises above.
+        return response
+
+    @contextlib.asynccontextmanager
+    async def _stream_with_auth_retry(
+        self, path: str, *, json: dict, headers_kwargs: dict
+    ) -> "AsyncIterator[httpx.Response]":
+        """Open a Copilot stream, force-refreshing and retrying once on 401/403.
+
+        Mirrors ``_send_with_auth_retry`` for streaming. The 401/403 is detected
+        from the response status *before* any chunk is yielded, so the retry
+        never replays partial output. A 401/403 that survives the retry raises a
+        retryable auth error (consistent with the non-streaming path); other
+        statuses are yielded for the caller to pre-read and raise on.
+        """
+        client = self._get_client()
+        for attempt in range(2):
+            cm = client.stream(
+                "POST", self._url(path), json=json, headers=self._get_headers(**headers_kwargs)
+            )
+            response = await cm.__aenter__()
+            if attempt == 0 and response.status_code in _AUTH_RETRY_STATUSES:
+                with contextlib.suppress(Exception):
+                    await response.aread()
+                await cm.__aexit__(None, None, None)
+                if await self._refresh_for_auth_status(path, response.status_code):
+                    continue
+            # A 401/403 surviving the retry is an unrecoverable auth failure —
+            # raise the shared retryable error rather than yielding a dead
+            # response for the caller to re-read.
+            if response.status_code in _AUTH_RETRY_STATUSES:
+                with contextlib.suppress(Exception):
+                    await response.aread()
+                await cm.__aexit__(None, None, None)
+                self._raise_auth_failure(path, response.status_code)
+            try:
+                yield response
+            finally:
+                await cm.__aexit__(None, None, None)
+            return
 
     def _url(self, path: str) -> str:
         """Build a Copilot API URL from the token-advertised API base."""
@@ -545,13 +712,12 @@ class CopilotProvider(BaseProvider):
             payload.get("thinking_budget"),
             payload.get("reasoning_effort"),
         )
-        client = self._get_client()
         try:
-            response = await client.post(
-                self._url(COPILOT_CHAT_PATH),
+            response = await self._send_with_auth_retry(
+                "POST",
+                COPILOT_CHAT_PATH,
                 json=payload,
-                headers=self._get_headers(vision_request=has_images, messages=request.messages),
-                timeout=TIMEOUT_NON_STREAMING,
+                headers_kwargs={"vision_request": has_images, "messages": request.messages},
             )
             response.raise_for_status()
             data = response.json()
@@ -710,13 +876,11 @@ class CopilotProvider(BaseProvider):
             payload.get("thinking_budget"),
             payload.get("reasoning_effort"),
         )
-        client = self._get_client()
         try:
-            async with client.stream(
-                "POST",
-                self._url(COPILOT_CHAT_PATH),
+            async with self._stream_with_auth_retry(
+                COPILOT_CHAT_PATH,
                 json=payload,
-                headers=self._get_headers(vision_request=has_images, messages=request.messages),
+                headers_kwargs={"vision_request": has_images, "messages": request.messages},
             ) as response:
                 # Streamed responses defer body reads; if the upstream returns
                 # an error status, pull the body *inside* the stream context
@@ -830,16 +994,16 @@ class CopilotProvider(BaseProvider):
                 logger.debug("Using cached Copilot models (%d models)", len(cached))
                 return cached
 
-        await self.ensure_token()
-
         logger.debug("Fetching Copilot models from API")
         # Use a fresh short-lived client to avoid blocking on the shared
         # streaming HTTP/2 connection pool
         try:
+            # Mint inside the try so a dead-token failure degrades to the stale
+            # cache (below) instead of hard-failing the models endpoint.
+            await self.ensure_token()
             async with httpx.AsyncClient(timeout=TIMEOUT_NON_STREAMING) as client:
-                response = await client.get(
-                    self._url(COPILOT_MODELS_PATH),
-                    headers=self._get_headers(),
+                response = await self._send_with_auth_retry(
+                    "GET", COPILOT_MODELS_PATH, client=client
                 )
                 response.raise_for_status()
                 data = response.json()
@@ -883,13 +1047,18 @@ class CopilotProvider(BaseProvider):
 
             logger.info("Fetched %d Copilot models", len(models))
             return models
-        except httpx.HTTPError as e:
-            # If cache exists, return stale cache on error
+        except (httpx.HTTPError, ProviderError) as e:
+            # If cache exists, return stale cache on error — including the case
+            # where the in-loop forced refresh raised a ProviderError because the
+            # token is unrecoverable. Serving the last known catalog is better
+            # than hard-failing the models endpoint.
             stale = self._models_ttl_cache._value
             if stale is not None:
                 logger.warning("Failed to refresh Copilot models, using stale cache: %s", e)
                 return stale
             logger.error("Failed to list Copilot models: %s", e)
+            if isinstance(e, ProviderError):
+                raise
             raise ProviderError(f"Failed to list models: {e}", retryable=True)
 
     # Tools that are not supported by Copilot Responses API.
@@ -1079,18 +1248,17 @@ class CopilotProvider(BaseProvider):
         payload = self._build_responses_payload(request)
 
         logger.debug("Copilot responses completion: model=%s", request.model)
-        client = self._get_client()
         try:
-            response = await client.post(
-                self._url(COPILOT_RESPONSES_PATH),
+            response = await self._send_with_auth_retry(
+                "POST",
+                COPILOT_RESPONSES_PATH,
                 json=payload,
-                headers=self._get_headers(
-                    vision_request=self._responses_input_has_vision(request.input),
-                    response_input=(
+                headers_kwargs={
+                    "vision_request": self._responses_input_has_vision(request.input),
+                    "response_input": (
                         request.input if isinstance(request.input, (str, list)) else None
                     ),
-                ),
-                timeout=TIMEOUT_NON_STREAMING,
+                },
             )
             response.raise_for_status()
             data = response.json()
@@ -1152,18 +1320,16 @@ class CopilotProvider(BaseProvider):
 
         logger.debug("Copilot streaming responses: model=%s", request.model)
         logger.debug("Copilot responses payload: %s", payload)
-        client = self._get_client()
         try:
-            async with client.stream(
-                "POST",
-                self._url(COPILOT_RESPONSES_PATH),
+            async with self._stream_with_auth_retry(
+                COPILOT_RESPONSES_PATH,
                 json=payload,
-                headers=self._get_headers(
-                    vision_request=self._responses_input_has_vision(request.input),
-                    response_input=(
+                headers_kwargs={
+                    "vision_request": self._responses_input_has_vision(request.input),
+                    "response_input": (
                         request.input if isinstance(request.input, (str, list)) else None
                     ),
-                ),
+                },
             ) as response:
                 # Check for errors before processing stream
                 if response.status_code >= 400:
@@ -1175,6 +1341,9 @@ class CopilotProvider(BaseProvider):
                         response.status_code,
                         error_text,
                     )
+                    # 401/403 are handled by _stream_with_auth_retry (refresh +
+                    # retry, then a retryable auth error), so they never reach
+                    # here; only transient 429/5xx are retryable at this point.
                     retryable = response.status_code in (429, 500, 502, 503, 504)
                     raise ProviderError(
                         f"Copilot API error: {response.status_code} - {error_text}",

--- a/src/router_maestro/server/middleware/auth.py
+++ b/src/router_maestro/server/middleware/auth.py
@@ -36,29 +36,30 @@ async def verify_api_key(
             detail="Server API key is not configured",
         )
 
-    # Get API key from header
-    api_key: str | None = None
+    # Collect every candidate key. Clients like Claude Code may send several
+    # credential headers at once (e.g. an OAuth Authorization bearer alongside
+    # the configured x-api-key); accept the request if ANY candidate matches so
+    # the correct key is not ignored just because another header is present.
+    candidates: list[str] = []
 
     if credentials:
-        api_key = credentials.credentials
+        candidates.append(credentials.credentials)
     else:
         # Try to get from Authorization header directly (without Bearer prefix)
         auth_header = request.headers.get("Authorization")
         if auth_header:
             if auth_header.startswith("Bearer "):
-                api_key = auth_header[7:]
+                candidates.append(auth_header[7:])
             else:
-                api_key = auth_header
+                candidates.append(auth_header)
 
-    # Also check x-api-key header for Anthropic API compatibility
-    if not api_key:
-        api_key = request.headers.get("x-api-key")
+    # x-api-key (Anthropic) and x-goog-api-key (Gemini CLI) compatibility headers.
+    for header_name in ("x-api-key", "x-goog-api-key"):
+        value = request.headers.get(header_name)
+        if value:
+            candidates.append(value)
 
-    # Also check x-goog-api-key header for Gemini CLI compatibility
-    if not api_key:
-        api_key = request.headers.get("x-goog-api-key")
-
-    if not api_key:
+    if not candidates:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing API key. Use 'Authorization: Bearer <api_key>' header.",
@@ -67,7 +68,10 @@ async def verify_api_key(
 
     # Compare on UTF-8 bytes: hmac.compare_digest raises TypeError on non-ASCII
     # str inputs, so a non-ASCII bearer token would otherwise 500 instead of 401.
-    if not hmac.compare_digest(api_key.encode("utf-8"), server_api_key.encode("utf-8")):
+    server_key_bytes = server_api_key.encode("utf-8")
+    if not any(
+        hmac.compare_digest(candidate.encode("utf-8"), server_key_bytes) for candidate in candidates
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -14,12 +14,15 @@ from starlette.requests import Request
 from router_maestro.server.middleware.auth import verify_api_key
 
 
-def _make_request(path: str = "/api/openai/v1/chat/completions") -> Request:
+def _make_request(
+    path: str = "/api/openai/v1/chat/completions",
+    headers: dict[str, str] | None = None,
+) -> Request:
     scope = {
         "type": "http",
         "method": "POST",
         "path": path,
-        "headers": Headers({}).raw,
+        "headers": Headers(headers or {}).raw,
     }
     return Request(scope)
 
@@ -57,3 +60,26 @@ async def test_health_endpoint_skips_auth(monkeypatch):
     monkeypatch.setenv("ROUTER_MAESTRO_API_KEY", "sk-correct")
     # No credentials, but /health is exempt — must not raise.
     await verify_api_key(_make_request("/health"), None)
+
+
+@pytest.mark.asyncio
+async def test_x_api_key_passes_despite_wrong_authorization(monkeypatch):
+    """Claude Code sends an OAuth Authorization bearer plus the correct x-api-key.
+
+    The correct x-api-key must be honored even when another credential header is
+    present, otherwise the request 401s and the proxy cannot route.
+    """
+    monkeypatch.setenv("ROUTER_MAESTRO_API_KEY", "sk-correct")
+    req = _make_request(
+        path="/api/anthropic/v1/messages",
+        headers={"x-api-key": "sk-correct"},
+    )
+    # Authorization bearer carries an unrelated/wrong OAuth token.
+    await verify_api_key(req, _creds("sk-wrong-oauth"))
+
+
+@pytest.mark.asyncio
+async def test_x_goog_api_key_passes_despite_wrong_authorization(monkeypatch):
+    monkeypatch.setenv("ROUTER_MAESTRO_API_KEY", "sk-correct")
+    req = _make_request(headers={"x-goog-api-key": "sk-correct"})
+    await verify_api_key(req, _creds("sk-wrong"))

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -12,9 +12,12 @@ from router_maestro.providers import (
     ChatRequest,
     CopilotProvider,
     Message,
+    ModelInfo,
     OpenAICompatibleProvider,
     OpenAIProvider,
+    ResponsesRequest,
 )
+from router_maestro.providers.base import ProviderError
 
 
 class TestProviderBase:
@@ -327,3 +330,271 @@ class TestAnthropicMessageConversion:
                 ],
             }
         ]
+
+
+def _copilot_with_cred(**cred_kwargs):
+    """Build a CopilotProvider with an in-memory stored credential and saved-no-op."""
+    provider = CopilotProvider()
+    provider.auth_manager.storage = AuthStorage()
+    defaults = {"refresh": "ghu_user", "access": "copilot-token", "expires": 0}
+    defaults.update(cred_kwargs)
+    provider.auth_manager.storage.set("github-copilot", OAuthCredential(**defaults))
+    provider.auth_manager.save = Mock()  # type: ignore[method-assign]
+    return provider
+
+
+class TestCopilotTokenRefresh:
+    """Tests for automatic Copilot token refresh + 401/403 retry."""
+
+    @pytest.mark.asyncio
+    async def test_ensure_token_dead_token_raises_reauth_error(self):
+        """No refresh token + a 403 mint surfaces a clear re-auth error.
+
+        It stays retryable=True so the router can still fall back to other
+        configured providers; the message tells the user how to recover when
+        Copilot is their only provider.
+        """
+        provider = _copilot_with_cred()  # mint will be rejected
+
+        reject = httpx.HTTPStatusError(
+            "forbidden",
+            request=httpx.Request("GET", "https://api.github.com"),
+            response=httpx.Response(403),
+        )
+        with patch(
+            "router_maestro.providers.copilot.get_copilot_token",
+            new=AsyncMock(side_effect=reject),
+        ):
+            with pytest.raises(ProviderError) as exc:
+                await provider.ensure_token()
+
+        assert exc.value.status_code == 401
+        assert exc.value.retryable is True
+        assert "auth login github-copilot" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_retries_once_on_403(self):
+        """A 403 from the chat API forces a token refresh and retries the call once."""
+        provider = _copilot_with_cred()
+        provider._cached_token = "stale-token"
+        provider._token_expires = 2**31  # clock thinks it's valid
+
+        calls = {"n": 0}
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(403, json={"detail": "forbidden"})
+            return httpx.Response(
+                200,
+                json={
+                    "model": "gpt-4o",
+                    "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+                    "usage": {"completion_tokens": 1},
+                },
+            )
+
+        provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(provider, "ensure_token", new=AsyncMock()) as mock_ensure:
+            response = await provider.chat_completion(
+                ChatRequest(
+                    model="github-copilot/gpt-4o", messages=[Message(role="user", content="hey")]
+                )
+            )
+
+        assert calls["n"] == 2  # original + retry
+        # ensure_token called once at entry, once forced after the 403.
+        assert mock_ensure.await_count == 2
+        assert mock_ensure.await_args.kwargs.get("force") is True
+        assert response.content == "hi"
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_retries_once_on_403(self):
+        """A 403 opening the chat stream forces a refresh and retries before yielding."""
+        provider = _copilot_with_cred()
+        provider._cached_token = "stale-token"
+        provider._token_expires = 2**31
+
+        calls = {"n": 0}
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(403, json={"detail": "forbidden"})
+            body = (
+                'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n'
+                "data: [DONE]\n\n"
+            )
+            return httpx.Response(200, text=body)
+
+        provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(provider, "ensure_token", new=AsyncMock()) as mock_ensure:
+            chunks = [
+                c
+                async for c in provider.chat_completion_stream(
+                    ChatRequest(
+                        model="github-copilot/gpt-4o",
+                        messages=[Message(role="user", content="hey")],
+                    )
+                )
+            ]
+
+        assert calls["n"] == 2
+        assert mock_ensure.await_count == 2
+        assert "".join(c.content for c in chunks if c.content) == "hi"
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_skips_when_token_changed_under_lock(self):
+        """force=True early-returns if another coro re-minted while we waited (#1/#3)."""
+        provider = _copilot_with_cred()
+        provider._cached_token = "token-A"
+        provider._token_expires = 0
+
+        # Acquire the refresh lock so our ensure_token(force=True) blocks on it,
+        # then swap the cached token (as a winning coroutine would) before release.
+        await provider._token_refresh_lock.acquire()
+
+        async def swap_then_release():
+            provider._cached_token = "token-B"  # another coro minted a fresh token
+            provider._token_refresh_lock.release()
+
+        mint = AsyncMock()
+        with patch("router_maestro.providers.copilot.get_copilot_token", new=mint):
+            import asyncio
+
+            waiter = asyncio.create_task(provider.ensure_token(force=True))
+            await asyncio.sleep(0)  # let the waiter block on the lock
+            await swap_then_release()
+            await waiter
+
+        # The waiter saw token-B (!= token-A snapshot) and skipped the mint.
+        mint.assert_not_awaited()
+        assert provider._cached_token == "token-B"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_force_refresh_mints_once(self):
+        """N concurrent 401-driven force refreshes collapse to a single mint (#3)."""
+        import asyncio
+
+        provider = _copilot_with_cred()
+        provider._cached_token = "stale"
+        provider._token_expires = 0
+
+        mint_calls = {"n": 0}
+
+        async def slow_mint(_client, _gh_token):
+            mint_calls["n"] += 1
+            await asyncio.sleep(0.05)  # hold the lock so others queue behind us
+            return CopilotTokenResponse(
+                token=f"fresh-{mint_calls['n']}", expires_at=2**31, refresh_in=1000
+            )
+
+        with patch("router_maestro.providers.copilot.get_copilot_token", new=slow_mint):
+            await asyncio.gather(*(provider.ensure_token(force=True) for _ in range(5)))
+
+        # The first waiter mints; the rest see the freshly-swapped token and skip.
+        assert mint_calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_mint_persists_auth_json_once(self):
+        """A successful mint persists the new Copilot token exactly once."""
+        provider = _copilot_with_cred()
+
+        with patch(
+            "router_maestro.providers.copilot.get_copilot_token",
+            new=AsyncMock(
+                return_value=CopilotTokenResponse(
+                    token="new-copilot", expires_at=2**31, refresh_in=1000
+                )
+            ),
+        ):
+            await provider.ensure_token()
+
+        assert provider.auth_manager.save.call_count == 1
+        stored = provider.auth_manager.storage.get("github-copilot")
+        assert stored.access == "new-copilot"
+        assert provider._cached_token == "new-copilot"
+
+    @pytest.mark.asyncio
+    async def test_chat_403_retries_once_then_raises_retryable(self):
+        """A persistent 403 on chat refreshes once, retries once, then raises retryable.
+
+        retryable=True is load-bearing: it lets the router fall back to other
+        providers. This must match the /responses behavior (no stream-vs-chat
+        divergence).
+        """
+        provider = _copilot_with_cred()
+        provider._cached_token = "tok"
+        provider._token_expires = 2**31
+
+        calls = {"n": 0}
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(403, json={"detail": "policy"})
+
+        provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(provider, "ensure_token", new=AsyncMock()) as mock_ensure:
+            with pytest.raises(ProviderError) as exc:
+                await provider.chat_completion(
+                    ChatRequest(
+                        model="github-copilot/gpt-4o",
+                        messages=[Message(role="user", content="hey")],
+                    )
+                )
+
+        assert calls["n"] == 2  # exactly one retry, never an unbounded storm
+        assert mock_ensure.await_count == 2  # entry + one forced refresh
+        assert exc.value.status_code == 403
+        assert exc.value.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_list_models_serves_stale_cache_on_dead_token(self):
+        """An unrecoverable token serves the stale model cache instead of hard-failing (#4)."""
+        provider = _copilot_with_cred()
+        provider._cached_token = "stale"
+        provider._token_expires = 2**31
+        # Seed a stale cache.
+        cached = [
+            ModelInfo(id="gpt-4o", name="GPT-4o", provider="github-copilot"),
+        ]
+        provider._models_ttl_cache.set(cached)
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, json={"detail": "forbidden"})
+
+        # Entry ensure_token() succeeds; the in-loop force=True refresh raises
+        # (token unrecoverable) — that ProviderError must degrade to stale cache.
+        async def maybe_dead(force: bool = False):
+            if force:
+                raise ProviderError("auth login github-copilot", status_code=401, retryable=True)
+
+        with patch(
+            "httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        ):
+            with patch.object(provider, "ensure_token", new=AsyncMock(side_effect=maybe_dead)):
+                models = await provider.list_models(force_refresh=True)
+
+        assert [m.id for m in models] == ["gpt-4o"]
+
+    @pytest.mark.asyncio
+    async def test_responses_stream_403_is_retryable_for_fallback(self):
+        """A surviving 403 on /responses stream is retryable so the router can fall back (#3)."""
+        provider = _copilot_with_cred()
+        provider._cached_token = "tok"
+        provider._token_expires = 2**31
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, json={"detail": "forbidden"})
+
+        provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(provider, "ensure_token", new=AsyncMock()):
+            with pytest.raises(ProviderError) as exc:
+                async for _ in provider.responses_completion_stream(
+                    ResponsesRequest(model="github-copilot/gpt-5", input="hi", stream=True)
+                ):
+                    pass
+
+        assert exc.value.status_code == 403
+        assert exc.value.retryable is True


### PR DESCRIPTION
## Problem

Two failures observed on real deployments (two machines), reconciled against on-disk `auth.json` + logs:

- A transient upstream **403** (entitlement/quota) on the Copilot token mint or `chat/completions` propagated as a hard failure. Real incident: a 403 burst hitting `/models` mint and `/chat/completions` together, self-healed only by restarts.
- **Claude Code 401s**: it sends an OAuth `Authorization` bearer alongside the correct `x-api-key`; the middleware only honored `Authorization` and discarded the matching key.

The data did **not** support the original "expiring `ghu_` → auto-renew via `ghr_`" framing — neither machine's OAuth app issues `ghr_` refresh tokens. That speculative layer has been removed; this PR is scoped to what the real failures need.

## Changes

**Copilot 401/403 self-heal** (`providers/copilot.py`)
- `ensure_token(force=True)` re-mints on demand; every call site (chat / responses / models, streaming and not) routes through shared auth-retry wrappers that refresh once on 401/403 and retry.
- A 401/403 that survives the retry raises a single shared **retryable** error, so the router falls back to other providers **consistently** (no chat-vs-responses divergence).
- Concurrent force-refreshes dedupe to a single mint (no 401-storm stampede).
- `list_models` degrades to its stale cache when the token is unrecoverable.

**Multi-header auth** (`server/middleware/auth.py`)
- Accept any of `Authorization` / `x-api-key` / `x-goog-api-key` (constant-time compare).

## Verify
- 888 passing; the 2 `TestCodexConfig` failures are pre-existing and unrelated.
- Rebuilt the container from this branch; end-to-end 200 (stream + non-stream) once the runtime key matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
