### PR TITLE
feat(anthropic): add beta native passthrough to Copilot /v1/messages

### DIFF
--- a/integration_tests/test_live_anthropic_beta.py
+++ b/integration_tests/test_live_anthropic_beta.py
@@ -1,0 +1,464 @@
+"""Live integration tests for the Anthropic beta passthrough endpoint.
+
+Mirrors the coverage of ``test_live_anthropic_paths.py`` and
+``test_live_reasoning_matrix.py`` against the beta endpoint to ensure
+no feature gap between the standard (translation-based) and beta
+(native passthrough) paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from integration_tests.conftest import (
+    ANTHROPIC_THINKING_BUDGETS,
+    STREAM_MODES,
+    anthropic_compat_payload,
+    anthropic_count_tokens_payload,
+    anthropic_payload,
+    anthropic_reasoning_payload,
+    anthropic_tool_choice_any_payload,
+    anthropic_tool_payload,
+    assert_anthropic_has_tool_use,
+    assert_anthropic_usage,
+    assert_http_success,
+    assert_text_response,
+    bare_model,
+    event_payloads,
+    parse_sse_events,
+)
+
+BETA = "/api/anthropic/beta/v1/messages"
+BETA_COUNT = "/api/anthropic/beta/v1/messages/count_tokens"
+
+
+# ---------------------------------------------------------------------------
+# Basic messages — mirrors test_live_anthropic_paths.py
+# ---------------------------------------------------------------------------
+
+
+def test_beta_non_streaming(client: httpx.Client, chat_model: str):
+    """Beta endpoint returns a valid Anthropic response."""
+    response = client.post(BETA, json=anthropic_payload(chat_model))
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert data["model"]
+    assert data["stop_reason"] in {
+        "end_turn",
+        "max_tokens",
+        "stop_sequence",
+        "tool_use",
+        "pause_turn",
+        "refusal",
+    }
+    text_blocks = [b for b in data["content"] if b["type"] == "text"]
+    assert text_blocks, data
+    assert_text_response(text_blocks[0]["text"])
+    assert_anthropic_usage(data["usage"])
+    # Copilot-internal fields must be stripped
+    assert "copilot_usage" not in data
+    assert "stop_details" not in data
+
+
+def test_beta_non_streaming_compat_fields(client: httpx.Client, chat_model: str):
+    """Beta endpoint handles compat fields (system, top_p, stop_sequences, metadata)."""
+    response = client.post(BETA, json=anthropic_compat_payload(chat_model))
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    text_blocks = [b for b in data["content"] if b["type"] == "text"]
+    assert text_blocks, data
+    assert_anthropic_usage(data["usage"])
+
+
+def test_beta_streaming(client: httpx.Client, chat_model: str):
+    """Beta streaming emits standard Anthropic SSE event sequence."""
+    with client.stream(
+        "POST",
+        BETA,
+        json=anthropic_payload(chat_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    payloads = event_payloads(events)
+
+    assert "message_start" in event_names
+    assert "content_block_start" in event_names
+    assert "content_block_delta" in event_names
+    assert "message_delta" in event_names
+    assert "message_stop" in event_names
+    # copilot_usage event must be filtered
+    assert "copilot_usage" not in event_names
+    # Must have text_delta
+    assert any(
+        payload.get("delta", {}).get("type") == "text_delta"
+        for payload in payloads
+        if isinstance(payload, dict)
+    )
+    message_delta = next(payload for name, payload in events if name == "message_delta")
+    assert_anthropic_usage(message_delta["usage"])
+
+
+# ---------------------------------------------------------------------------
+# count_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_beta_count_tokens(client: httpx.Client, chat_model: str):
+    """Beta count_tokens returns positive input_tokens."""
+    response = client.post(
+        BETA_COUNT,
+        json=anthropic_count_tokens_payload(chat_model),
+    )
+    assert_http_success(response)
+    assert response.json()["input_tokens"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Tool use — mirrors test_live_anthropic_paths.py tool tests
+# ---------------------------------------------------------------------------
+
+
+def test_beta_forced_tool_call(client: httpx.Client, tool_model: str):
+    """Beta endpoint supports forced tool_use blocks."""
+    response = client.post(BETA, json=anthropic_tool_payload(tool_model))
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["stop_reason"] == "tool_use"
+    assert_anthropic_has_tool_use(data, "get_weather")
+    assert_anthropic_usage(data["usage"])
+
+
+def test_beta_forced_tool_call_streaming(client: httpx.Client, tool_model: str):
+    """Beta streaming supports tool_use block events."""
+    with client.stream(
+        "POST",
+        BETA,
+        json=anthropic_tool_payload(tool_model, stream=True),
+        timeout=180.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    tool_start = [
+        p
+        for p in payloads
+        if isinstance(p, dict)
+        and p.get("type") == "content_block_start"
+        and p.get("content_block", {}).get("type") == "tool_use"
+    ]
+    assert tool_start, payloads
+    assert any(
+        payload.get("delta", {}).get("type") == "input_json_delta"
+        for payload in payloads
+        if isinstance(payload, dict)
+    )
+    message_delta = next(payload for name, payload in events if name == "message_delta")
+    assert message_delta["delta"]["stop_reason"] == "tool_use"
+    assert_anthropic_usage(message_delta["usage"])
+
+
+def test_beta_tool_choice_any(client: httpx.Client, tool_model: str):
+    """Beta endpoint handles tool_choice type=any."""
+    response = client.post(BETA, json=anthropic_tool_choice_any_payload(tool_model))
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["stop_reason"] == "tool_use"
+    assert_anthropic_has_tool_use(data, "get_weather")
+
+
+# ---------------------------------------------------------------------------
+# Thinking / reasoning — mirrors test_live_reasoning_matrix.py
+# ---------------------------------------------------------------------------
+
+
+def test_beta_thinking_non_streaming(client: httpx.Client, chat_model: str):
+    """Beta endpoint supports extended thinking natively."""
+    payload = {
+        "model": chat_model,
+        "messages": [{"role": "user", "content": "What is 7*8?"}],
+        "max_tokens": 8000,
+        "thinking": {"type": "enabled", "budget_tokens": 4000},
+    }
+    response = client.post(BETA, json=payload, timeout=60)
+    assert_http_success(response)
+    data = response.json()
+
+    thinking_blocks = [b for b in data["content"] if b["type"] == "thinking"]
+    text_blocks = [b for b in data["content"] if b["type"] == "text"]
+    assert thinking_blocks, f"Expected thinking block, got: {data['content']}"
+    assert thinking_blocks[0].get("signature"), "Thinking block should have signature"
+    assert text_blocks
+    assert_anthropic_usage(data["usage"])
+
+
+def test_beta_thinking_streaming(client: httpx.Client, chat_model: str):
+    """Beta streaming surfaces thinking_delta and signature_delta events."""
+    payload = {
+        "model": chat_model,
+        "messages": [{"role": "user", "content": "What is 3+5?"}],
+        "max_tokens": 8000,
+        "stream": True,
+        "thinking": {"type": "enabled", "budget_tokens": 4000},
+    }
+    with client.stream("POST", BETA, json=payload, timeout=120.0) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    payloads = event_payloads(events)
+
+    assert "message_start" in event_names
+    assert "message_stop" in event_names
+    assert "copilot_usage" not in event_names
+
+    # Must have a thinking content_block_start
+    thinking_start = [
+        p
+        for p in payloads
+        if isinstance(p, dict)
+        and p.get("type") == "content_block_start"
+        and p.get("content_block", {}).get("type") == "thinking"
+    ]
+    assert thinking_start, "Expected thinking block start in stream"
+
+    # Must have thinking_delta events
+    thinking_deltas = [
+        p
+        for p in payloads
+        if isinstance(p, dict) and p.get("delta", {}).get("type") == "thinking_delta"
+    ]
+    assert thinking_deltas, "Expected thinking_delta events"
+
+    # Must have signature_delta
+    sig_deltas = [
+        p
+        for p in payloads
+        if isinstance(p, dict) and p.get("delta", {}).get("type") == "signature_delta"
+    ]
+    assert sig_deltas, "Expected signature_delta events"
+
+
+def test_beta_thinking_budget_matrix(
+    client: httpx.Client,
+    anthropic_thinking_models: list[str],
+):
+    """Beta endpoint handles thinking budget × stream mode matrix."""
+    failures: list[str] = []
+
+    for model in anthropic_thinking_models:
+        for budget in ANTHROPIC_THINKING_BUDGETS:
+            for stream in STREAM_MODES:
+                cell = f"{bare_model(model)}|budget={budget}|stream={stream}"
+                try:
+                    if stream:
+                        data = _post_beta_stream(client, model, budget)
+                    else:
+                        data = _post_beta_non_stream(client, model, budget)
+                    _assert_thinking_result(data, budget)
+                except AssertionError as exc:
+                    failures.append(f"{cell}: {exc}")
+
+    assert not failures, "\n".join(failures)
+
+
+def test_beta_thinking_replay(client: httpx.Client, chat_model: str):
+    """Multi-turn with prior thinking block — the native endpoint validates signatures.
+
+    Unlike the standard path (which strips thinking during translation), the
+    native passthrough forwards the signature literally. Copilot's native
+    endpoint rejects invalid signatures, so we test with a simpler multi-turn
+    that doesn't include a fake thinking block.
+    """
+    payload = {
+        "model": chat_model,
+        "max_tokens": 64,
+        "temperature": 0,
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2? Reply with just the number."},
+            {"role": "assistant", "content": [{"type": "text", "text": "4"}]},
+            {"role": "user", "content": "Now reply with exactly the word pong."},
+        ],
+    }
+    response = client.post(BETA, json=payload, timeout=60)
+    assert_http_success(response)
+    data = response.json()
+
+    text_blocks = [b for b in data["content"] if b.get("type") == "text"]
+    assert text_blocks, data
+
+
+def test_beta_thinking_replay_streaming(client: httpx.Client, chat_model: str):
+    """Streaming multi-turn conversation (without fake thinking signature)."""
+    payload = {
+        "model": chat_model,
+        "max_tokens": 64,
+        "temperature": 0,
+        "stream": True,
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2? Reply with just the number."},
+            {"role": "assistant", "content": [{"type": "text", "text": "4"}]},
+            {"role": "user", "content": "Now reply with exactly the word pong."},
+        ],
+    }
+    with client.stream("POST", BETA, json=payload, timeout=120.0) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    assert "message_start" in event_names
+    assert "message_stop" in event_names
+
+
+# ---------------------------------------------------------------------------
+# Fallback path (non-Claude models)
+# ---------------------------------------------------------------------------
+
+
+def test_beta_fallback_non_claude_model(client: httpx.Client, copilot_models: list[str]):
+    """Non-Claude model on beta endpoint falls back to standard translation."""
+    chat_capable = [
+        m
+        for m in copilot_models
+        if "claude" not in m.lower()
+        and ("gpt-5-mini" in m.lower() or "gpt-5.4" == m.split("/")[-1].lower())
+    ]
+    if not chat_capable:
+        import pytest
+
+        pytest.skip("No chat-capable non-Claude models available")
+
+    model = chat_capable[0]
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Say OK."}],
+        "max_tokens": 16,
+    }
+    response = client.post(BETA, json=payload, timeout=60)
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["type"] == "message"
+    assert data["role"] == "assistant"
+    assert_anthropic_usage(data["usage"])
+
+
+def test_beta_fallback_non_claude_streaming(client: httpx.Client, copilot_models: list[str]):
+    """Non-Claude streaming on beta endpoint falls back and produces valid SSE."""
+    chat_capable = [
+        m
+        for m in copilot_models
+        if "claude" not in m.lower()
+        and ("gpt-5-mini" in m.lower() or "gpt-5.4" == m.split("/")[-1].lower())
+    ]
+    if not chat_capable:
+        import pytest
+
+        pytest.skip("No chat-capable non-Claude models available")
+
+    model = chat_capable[0]
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Say OK."}],
+        "max_tokens": 16,
+        "stream": True,
+    }
+    with client.stream("POST", BETA, json=payload, timeout=180.0) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    event_names = [name for name, _payload in events]
+    assert "message_start" in event_names
+    assert "message_stop" in event_names
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _post_beta_non_stream(
+    client: httpx.Client,
+    model: str,
+    budget: int | None,
+) -> dict[str, Any]:
+    response = client.post(
+        BETA,
+        json=anthropic_reasoning_payload(model, budget=budget),
+        timeout=240.0,
+    )
+    assert_http_success(response)
+    return response.json()
+
+
+def _post_beta_stream(
+    client: httpx.Client,
+    model: str,
+    budget: int | None,
+) -> dict[str, Any]:
+    with client.stream(
+        "POST",
+        BETA,
+        json=anthropic_reasoning_payload(model, budget=budget, stream=True),
+        timeout=240.0,
+    ) as response:
+        assert_http_success(response)
+        events = parse_sse_events(response)
+
+    payloads = event_payloads(events)
+    errors = [payload for payload in payloads if payload.get("type") == "error"]
+    assert not errors, errors
+    assert "message_stop" in [name for name, _payload in events]
+
+    blocks = [
+        payload.get("content_block", {})
+        for payload in payloads
+        if payload.get("type") == "content_block_start"
+    ]
+    text = "".join(
+        payload.get("delta", {}).get("text", "")
+        for payload in payloads
+        if payload.get("delta", {}).get("type") == "text_delta"
+    )
+    thinking = "".join(
+        payload.get("delta", {}).get("thinking", "")
+        for payload in payloads
+        if payload.get("delta", {}).get("type") == "thinking_delta"
+    )
+    message_delta = next(payload for name, payload in events if name == "message_delta")
+    return {
+        "content": [
+            {"type": block.get("type"), "text": text, "thinking": thinking} for block in blocks
+        ],
+        "usage": message_delta["usage"],
+        "stop_reason": message_delta["delta"].get("stop_reason"),
+    }
+
+
+def _assert_thinking_result(data: dict[str, Any], budget: int | None) -> None:
+    """Assert thinking/reasoning result from the beta endpoint."""
+    assert_anthropic_usage(data["usage"])
+
+    # With thinking enabled, content must have at least one block
+    assert data["content"], f"Empty content: {data}"
+
+    if budget is not None:
+        thinking_blocks = [b for b in data["content"] if b.get("type") == "thinking"]
+        assert thinking_blocks, f"Expected thinking with budget={budget}: {data['content']}"
+    else:
+        # Without thinking budget, must have text
+        text_blocks = [b for b in data["content"] if b.get("type") == "text"]
+        assert text_blocks, f"No text block without thinking: {data['content']}"

--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -253,6 +253,26 @@ _CLAUDE_CODE_NATIVE_1M_KEYS: frozenset[str] = frozenset(
 _CLAUDE_CODE_DEFAULT_AUTO_COMPACT_WINDOW = 200_000
 
 
+def _prompt_endpoint_mode(model: dict | None) -> bool:
+    """Prompt whether to use the beta native passthrough endpoint.
+
+    Only offered when the selected model is a Claude model on GitHub Copilot.
+    Returns True to use the beta endpoint, False for standard.
+    """
+    if model is None:
+        return False
+    provider = model.get("provider", "")
+    model_id = model.get("id", "")
+    if provider != "github-copilot" or not model_id.lower().startswith("claude-"):
+        return False
+
+    console.print("\n[bold]Endpoint mode[/bold]")
+    console.print("  1. Standard (translation-based, battle-tested)")
+    console.print("  2. Beta (native Copilot Anthropic passthrough — full thinking/cache fidelity)")
+    choice = Prompt.ask("Select", choices=["1", "2"], default="2")
+    return choice == "2"
+
+
 def _prompt_auto_compact_window(model: dict | None) -> int | None:
     """Prompt the user whether to set CLAUDE_CODE_AUTO_COMPACT_WINDOW.
 
@@ -411,13 +431,17 @@ def claude_code_config() -> None:
     # Step 4b: Optional auto-compact window override (Claude Code only)
     auto_compact_window = _prompt_auto_compact_window(main_model_dict)
 
+    # Step 4c: Endpoint mode — offer beta passthrough for Claude models on Copilot
+    use_beta_endpoint = _prompt_endpoint_mode(main_model_dict)
+
     # Step 5: Generate config
     auth_token = get_current_context_api_key() or "router-maestro"
     client = get_admin_client()
     base_url = (
         client.endpoint.rstrip("/") if hasattr(client, "endpoint") else "http://localhost:8080"
     )
-    anthropic_url = f"{base_url}/api/anthropic"
+    anthropic_path = "/api/anthropic/beta" if use_beta_endpoint else "/api/anthropic"
+    anthropic_url = f"{base_url}{anthropic_path}"
 
     env_config = {
         "ANTHROPIC_BASE_URL": anthropic_url,

--- a/src/router_maestro/server/app.py
+++ b/src/router_maestro/server/app.py
@@ -21,6 +21,7 @@ from router_maestro.server.observability import (
 )
 from router_maestro.server.routes import (
     admin_router,
+    anthropic_beta_router,
     anthropic_router,
     chat_router,
     gemini_router,
@@ -128,6 +129,7 @@ def create_app() -> FastAPI:
     app.include_router(models_router, dependencies=[Depends(verify_api_key)])
     app.include_router(responses_router, dependencies=[Depends(verify_api_key)])
     app.include_router(anthropic_router, dependencies=[Depends(verify_api_key)])
+    app.include_router(anthropic_beta_router, dependencies=[Depends(verify_api_key)])
     app.include_router(gemini_router, dependencies=[Depends(verify_api_key)])
     app.include_router(admin_router, dependencies=[Depends(verify_api_key)])
 

--- a/src/router_maestro/server/routes/__init__.py
+++ b/src/router_maestro/server/routes/__init__.py
@@ -2,6 +2,7 @@
 
 from router_maestro.server.routes.admin import router as admin_router
 from router_maestro.server.routes.anthropic import router as anthropic_router
+from router_maestro.server.routes.anthropic_beta import router as anthropic_beta_router
 from router_maestro.server.routes.chat import router as chat_router
 from router_maestro.server.routes.gemini import router as gemini_router
 from router_maestro.server.routes.models import router as models_router
@@ -9,6 +10,7 @@ from router_maestro.server.routes.responses import router as responses_router
 
 __all__ = [
     "admin_router",
+    "anthropic_beta_router",
     "anthropic_router",
     "chat_router",
     "gemini_router",

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -1,0 +1,349 @@
+"""Anthropic Messages API beta route — native passthrough to Copilot.
+
+For Claude models routed via GitHub Copilot, forwards requests directly to
+Copilot's native ``/v1/messages`` endpoint without Anthropic→OpenAI→Anthropic
+translation.  Non-Claude or non-Copilot models fall back to the standard
+translation-based handler transparently.
+"""
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, HTTPException
+from fastapi import Request as FastAPIRequest
+from fastapi.responses import JSONResponse
+
+from router_maestro.providers import ProviderError
+from router_maestro.providers.copilot import CopilotProvider
+from router_maestro.routing import get_router
+from router_maestro.server.routes.anthropic import (
+    ANTHROPIC_PING_FRAME,
+)
+from router_maestro.server.routes.anthropic import (
+    messages as standard_messages,
+)
+from router_maestro.server.streaming import sse_streaming_response
+from router_maestro.utils import get_logger
+from router_maestro.utils.context_window import resolve_thinking_budget
+
+logger = get_logger("server.routes.anthropic_beta")
+
+router = APIRouter()
+
+COPILOT_MESSAGES_PATH = "/v1/messages"
+COPILOT_COUNT_TOKENS_PATH = "/v1/messages/count_tokens"
+
+_STRIP_RESPONSE_KEYS = frozenset({"copilot_usage", "stop_details"})
+_STRIP_STREAM_MESSAGE_STOP_KEYS = frozenset({"copilot_usage", "amazon-bedrock-invocationMetrics"})
+
+
+def _is_native_eligible(provider_name: str, actual_model: str) -> bool:
+    """Whether this model can use the native Copilot Anthropic endpoint."""
+    if provider_name != "github-copilot":
+        return False
+    bare = actual_model.split("/", 1)[-1].lower()
+    return bare.startswith("claude-")
+
+
+def _strip_response(data: dict) -> dict:
+    """Remove Copilot-internal fields from a non-streaming response."""
+    for key in _STRIP_RESPONSE_KEYS:
+        data.pop(key, None)
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        for key in _STRIP_RESPONSE_KEYS:
+            msg.pop(key, None)
+    return data
+
+
+def _apply_thinking_budget_native(body: dict, actual_model: str) -> dict:
+    """Apply server-side thinking budget config to the raw Anthropic body.
+
+    Modifies ``body["thinking"]`` in-place if the server config specifies a
+    budget and the client hasn't already set one.
+    """
+    from router_maestro.config import load_priorities_config
+
+    priorities = load_priorities_config()
+    thinking_config = priorities.thinking
+
+    client_thinking = body.get("thinking")
+    client_budget = None
+    client_type = None
+    if isinstance(client_thinking, dict):
+        client_budget = client_thinking.get("budget_tokens")
+        client_type = client_thinking.get("type")
+
+    model_router = get_router()
+    model_info = None
+    if hasattr(model_router, "_models_cache"):
+        cache_entry = model_router._models_cache.get(actual_model)
+        if cache_entry:
+            _, model_info = cache_entry
+
+    supports_thinking = model_info.supports_thinking if model_info else True
+    max_output = (model_info.max_output_tokens or 16384) if model_info else 16384
+
+    budget, thinking_type = resolve_thinking_budget(
+        client_budget=client_budget,
+        client_thinking_type=client_type,
+        model_id=actual_model,
+        max_output_tokens=max_output,
+        thinking_config=thinking_config,
+        supports_thinking=supports_thinking,
+    )
+
+    if budget != client_budget or thinking_type != client_type:
+        if budget is not None and thinking_type in ("enabled", "adaptive"):
+            body["thinking"] = {"type": thinking_type, "budget_tokens": budget}
+        elif thinking_type == "disabled" or budget is None:
+            body.pop("thinking", None)
+
+    return body
+
+
+async def _resolve_model(model: str) -> tuple[str, str, CopilotProvider | None]:
+    """Resolve model to (provider_name, actual_model_id, provider_if_copilot).
+
+    Returns (provider_name, actual_model, None) for non-Copilot providers.
+    Raises HTTPException(404) if the model can't be resolved at all.
+    """
+    model_router = get_router()
+    try:
+        provider_name, actual_model, provider = await model_router._resolve_provider(model)
+    except ProviderError as e:
+        raise HTTPException(status_code=e.status_code or 404, detail=str(e))
+    if isinstance(provider, CopilotProvider):
+        return provider_name, actual_model, provider
+    return provider_name, actual_model, None
+
+
+@router.post("/api/anthropic/beta/v1/messages")
+async def beta_messages(raw_request: FastAPIRequest):
+    """Handle Anthropic Messages API requests via native passthrough or fallback."""
+    body_bytes = await raw_request.body()
+    try:
+        body = json.loads(body_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    model = body.get("model")
+    if not model:
+        raise HTTPException(status_code=400, detail="'model' field is required")
+
+    stream = body.get("stream", False)
+
+    # Resolve provider and check native eligibility
+    provider_name, actual_model, copilot_provider = await _resolve_model(model)
+
+    if not _is_native_eligible(provider_name, actual_model) or copilot_provider is None:
+        logger.info(
+            "Beta route falling back to standard path: model=%s, provider=%s",
+            model,
+            provider_name,
+        )
+        # Delegate to the standard translation-based handler
+        return await standard_messages(
+            request=await _parse_as_anthropic_request(body_bytes),
+            raw_request=raw_request,
+        )
+
+    logger.info(
+        "Beta route using native passthrough: model=%s -> %s, stream=%s",
+        model,
+        actual_model,
+        stream,
+    )
+
+    # Apply server-side thinking budget
+    body = _apply_thinking_budget_native(body, actual_model)
+
+    # Replace model with the resolved catalog name
+    body["model"] = actual_model
+
+    # Copilot's native endpoint rejects temperature + top_p together;
+    # drop top_p when both are present (temperature takes priority).
+    if "temperature" in body and "top_p" in body:
+        del body["top_p"]
+
+    # Ensure Copilot token is fresh
+    await copilot_provider.ensure_token()
+
+    if stream:
+        return sse_streaming_response(
+            _stream_passthrough(copilot_provider, body),
+            keepalive_frame=ANTHROPIC_PING_FRAME,
+        )
+
+    # Non-streaming passthrough
+    try:
+        response = await copilot_provider._send_with_auth_retry(
+            "POST",
+            COPILOT_MESSAGES_PATH,
+            json=body,
+        )
+    except ProviderError as e:
+        raise HTTPException(status_code=e.status_code or 502, detail=str(e))
+
+    if response.status_code >= 400:
+        # Forward upstream error verbatim (already Anthropic format)
+        try:
+            error_body = response.json()
+        except Exception:
+            error_body = {"error": {"type": "api_error", "message": response.text}}
+        return JSONResponse(content=error_body, status_code=response.status_code)
+
+    data = response.json()
+    _strip_response(data)
+    return JSONResponse(content=data)
+
+
+@router.post("/api/anthropic/beta/v1/messages/count_tokens")
+async def beta_count_tokens(raw_request: FastAPIRequest):
+    """Count tokens via native passthrough or fallback."""
+    body_bytes = await raw_request.body()
+    try:
+        body = json.loads(body_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    model = body.get("model")
+    if not model:
+        raise HTTPException(status_code=400, detail="'model' field is required")
+
+    provider_name, actual_model, copilot_provider = await _resolve_model(model)
+
+    if not _is_native_eligible(provider_name, actual_model) or copilot_provider is None:
+        # Fallback to standard count_tokens handler
+        from router_maestro.server.routes.anthropic import count_tokens
+        from router_maestro.server.schemas.anthropic import AnthropicCountTokensRequest
+
+        request = AnthropicCountTokensRequest.model_validate(body)
+        return await count_tokens(request)
+
+    body["model"] = actual_model
+    await copilot_provider.ensure_token()
+
+    try:
+        response = await copilot_provider._send_with_auth_retry(
+            "POST",
+            COPILOT_COUNT_TOKENS_PATH,
+            json=body,
+        )
+    except ProviderError as e:
+        raise HTTPException(status_code=e.status_code or 502, detail=str(e))
+
+    if response.status_code >= 400:
+        try:
+            error_body = response.json()
+        except Exception:
+            error_body = {"error": {"type": "api_error", "message": response.text}}
+        return JSONResponse(content=error_body, status_code=response.status_code)
+
+    return JSONResponse(content=response.json())
+
+
+async def _stream_passthrough(
+    provider: CopilotProvider,
+    payload: dict,
+) -> AsyncGenerator[str, None]:
+    """Stream SSE events from Copilot's native Anthropic endpoint.
+
+    Filters out copilot-internal events and strips internal metadata from
+    ``message_stop`` events before yielding to the client.
+    """
+    try:
+        async with provider._stream_with_auth_retry(
+            COPILOT_MESSAGES_PATH,
+            json=payload,
+            headers_kwargs={},
+        ) as response:
+            if response.status_code >= 400:
+                error_text = (await response.aread()).decode()
+                msg = f"Upstream error ({response.status_code}): {error_text[:200]}"
+                yield _sse_error_event(msg)
+                return
+
+            current_event: str | None = None
+            data_buffer: str = ""
+
+            async for line in response.aiter_lines():
+                if line.startswith("event: "):
+                    current_event = line[7:]
+                    # Don't yield event line yet — wait for data to decide
+                elif line.startswith("data: "):
+                    data_buffer = line[6:]
+                elif line == "":
+                    # End of SSE frame — process and yield
+                    if current_event and data_buffer:
+                        cleaned = _clean_stream_frame(current_event, data_buffer)
+                        if cleaned is not None:
+                            yield f"event: {current_event}\ndata: {cleaned}\n\n"
+                    elif current_event and not data_buffer:
+                        yield f"event: {current_event}\ndata: \n\n"
+                    current_event = None
+                    data_buffer = ""
+
+    except ProviderError as e:
+        yield _sse_error_event(str(e))
+    except asyncio.CancelledError:
+        logger.info("Beta anthropic stream cancelled by client")
+        raise
+    except Exception:
+        logger.error("Unexpected error in beta anthropic stream", exc_info=True)
+        yield _sse_error_event("Internal server error")
+
+
+def _clean_stream_frame(event_type: str, data_str: str) -> str | None:
+    """Clean a single SSE frame's data payload.
+
+    Returns the cleaned data string, or None to suppress the event entirely.
+    """
+    # Filter out copilot-internal events
+    if event_type == "copilot_usage":
+        return None
+
+    # For message_start, strip copilot fields from nested message
+    if event_type == "message_start":
+        try:
+            data = json.loads(data_str)
+            msg = data.get("message")
+            if isinstance(msg, dict):
+                for key in _STRIP_RESPONSE_KEYS:
+                    msg.pop(key, None)
+            return json.dumps(data)
+        except (json.JSONDecodeError, TypeError):
+            return data_str
+
+    # For message_stop, strip bedrock metrics
+    if event_type == "message_stop":
+        try:
+            data = json.loads(data_str)
+            for key in _STRIP_STREAM_MESSAGE_STOP_KEYS:
+                data.pop(key, None)
+            return json.dumps(data)
+        except (json.JSONDecodeError, TypeError):
+            return data_str
+
+    return data_str
+
+
+def _sse_error_event(message: str) -> str:
+    """Format an Anthropic SSE error event."""
+    error_event = {
+        "type": "error",
+        "error": {
+            "type": "api_error",
+            "message": message,
+        },
+    }
+    return f"event: error\ndata: {json.dumps(error_event)}\n\n"
+
+
+async def _parse_as_anthropic_request(body_bytes: bytes):
+    """Parse raw body bytes into an AnthropicMessagesRequest for fallback."""
+    from router_maestro.server.schemas.anthropic import AnthropicMessagesRequest
+
+    body = json.loads(body_bytes)
+    return AnthropicMessagesRequest.model_validate(body)

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -1,0 +1,329 @@
+"""Tests for the Anthropic beta passthrough route."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from router_maestro.providers.copilot import CopilotProvider
+from router_maestro.server.routes.anthropic_beta import (
+    _apply_thinking_budget_native,
+    _clean_stream_frame,
+    _is_native_eligible,
+    _strip_response,
+    router,
+)
+
+# --- Unit tests for helper functions ---
+
+
+class TestIsNativeEligible:
+    def test_copilot_claude_model(self):
+        assert _is_native_eligible("github-copilot", "claude-sonnet-4.5") is True
+
+    def test_copilot_claude_with_prefix(self):
+        assert _is_native_eligible("github-copilot", "github-copilot/claude-opus-4.6") is True
+
+    def test_copilot_non_claude(self):
+        assert _is_native_eligible("github-copilot", "gpt-5.4") is False
+
+    def test_non_copilot_claude(self):
+        assert _is_native_eligible("anthropic", "claude-sonnet-4.5") is False
+
+    def test_non_copilot_non_claude(self):
+        assert _is_native_eligible("openai", "gpt-4o") is False
+
+
+class TestStripResponse:
+    def test_strips_copilot_usage(self):
+        data = {
+            "id": "msg_123",
+            "content": [{"type": "text", "text": "hi"}],
+            "copilot_usage": {"token_details": []},
+            "stop_details": {"reason": "end"},
+            "model": "claude-sonnet-4.5",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        result = _strip_response(data)
+        assert "copilot_usage" not in result
+        assert "stop_details" not in result
+        assert result["id"] == "msg_123"
+        assert result["usage"] == {"input_tokens": 10, "output_tokens": 5}
+
+    def test_preserves_standard_fields(self):
+        data = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+            "model": "claude-sonnet-4.5",
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        result = _strip_response(data)
+        assert result == data
+
+    def test_handles_no_copilot_fields(self):
+        data = {"id": "msg_123", "content": []}
+        result = _strip_response(data)
+        assert result == {"id": "msg_123", "content": []}
+
+
+class TestCleanStreamFrame:
+    def test_filters_copilot_usage_event(self):
+        assert _clean_stream_frame("copilot_usage", '{"some": "data"}') is None
+
+    def test_strips_message_start_copilot_fields(self):
+        data = json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_123",
+                    "model": "claude-sonnet-4.5",
+                    "copilot_usage": {"x": 1},
+                    "stop_details": {"y": 2},
+                    "usage": {"input_tokens": 10},
+                },
+            }
+        )
+        result = _clean_stream_frame("message_start", data)
+        parsed = json.loads(result)
+        assert "copilot_usage" not in parsed["message"]
+        assert "stop_details" not in parsed["message"]
+        assert parsed["message"]["usage"] == {"input_tokens": 10}
+
+    def test_strips_message_stop_bedrock_metrics(self):
+        data = json.dumps(
+            {
+                "type": "message_stop",
+                "amazon-bedrock-invocationMetrics": {"latency": 1000},
+                "copilot_usage": {"x": 1},
+            }
+        )
+        result = _clean_stream_frame("message_stop", data)
+        parsed = json.loads(result)
+        assert "amazon-bedrock-invocationMetrics" not in parsed
+        assert "copilot_usage" not in parsed
+        assert parsed["type"] == "message_stop"
+
+    def test_passes_through_content_block_delta(self):
+        data = '{"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hi"}}'
+        result = _clean_stream_frame("content_block_delta", data)
+        assert result == data
+
+    def test_passes_through_thinking_delta(self):
+        data = '{"delta": {"type": "thinking_delta", "thinking": "hmm"}, "index": 0}'
+        result = _clean_stream_frame("content_block_delta", data)
+        assert result == data
+
+
+class TestApplyThinkingBudgetNative:
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_no_change_when_client_sets_budget(self, mock_resolve_tb, mock_config, mock_router):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        mock_resolve_tb.return_value = (5000, "enabled")
+
+        body = {"thinking": {"type": "enabled", "budget_tokens": 5000}}
+        result = _apply_thinking_budget_native(body, "claude-sonnet-4.5")
+        assert result["thinking"]["budget_tokens"] == 5000
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_removes_thinking_when_server_disables(self, mock_resolve_tb, mock_config, mock_router):
+        """Server config forces thinking off when client requested it."""
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        # Client asked for thinking, but server resolves to disabled
+        mock_resolve_tb.return_value = (None, "disabled")
+
+        body = {"thinking": {"type": "enabled", "budget_tokens": 5000}}
+        result = _apply_thinking_budget_native(body, "claude-sonnet-4.5")
+        assert "thinking" not in result
+
+
+# --- Integration tests with TestClient ---
+
+
+@pytest.fixture
+def app():
+    """Create a test FastAPI app with only the beta router."""
+    test_app = FastAPI()
+    test_app.include_router(router)
+    return test_app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+class TestBetaMessagesEndpoint:
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_native_passthrough_non_streaming(self, mock_resolve, client):
+        """Claude model on Copilot uses native passthrough."""
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "msg_bdrk_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+            "model": "claude-sonnet-4-5-20250929",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "copilot_usage": {"token_details": []},
+            "stop_details": {"type": "end_turn"},
+        }
+        mock_provider._send_with_auth_retry = AsyncMock(return_value=mock_response)
+        mock_resolve.return_value = ("github-copilot", "claude-sonnet-4.5", mock_provider)
+
+        with patch(
+            "router_maestro.server.routes.anthropic_beta._apply_thinking_budget_native",
+            side_effect=lambda body, _: body,
+        ):
+            resp = client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "claude-sonnet-4",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["content"] == [{"type": "text", "text": "hello"}]
+        assert "copilot_usage" not in data
+        assert "stop_details" not in data
+
+    @patch("router_maestro.server.routes.anthropic_beta._parse_as_anthropic_request")
+    @patch("router_maestro.server.routes.anthropic_beta.standard_messages")
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_fallback_for_non_claude_model(self, mock_resolve, mock_standard, mock_parse, client):
+        """Non-Claude model falls back to the standard translation path."""
+        mock_resolve.return_value = ("github-copilot", "gpt-5.4", None)
+        mock_parse.return_value = MagicMock()
+        mock_standard.return_value = JSONResponse(
+            content={"id": "msg_fake", "content": [{"type": "text", "text": "from standard"}]},
+        )
+
+        client.post(
+            "/api/anthropic/beta/v1/messages",
+            json={
+                "model": "gpt-5.4",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hi"}],
+            },
+        )
+
+        mock_standard.assert_called_once()
+
+    @patch("router_maestro.server.routes.anthropic_beta._parse_as_anthropic_request")
+    @patch("router_maestro.server.routes.anthropic_beta.standard_messages")
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_fallback_for_non_copilot_provider(
+        self, mock_resolve, mock_standard, mock_parse, client
+    ):
+        """Claude model on native Anthropic provider falls back."""
+        mock_resolve.return_value = ("anthropic", "claude-sonnet-4.5", None)
+        mock_parse.return_value = MagicMock()
+        mock_standard.return_value = JSONResponse(content={})
+
+        client.post(
+            "/api/anthropic/beta/v1/messages",
+            json={
+                "model": "claude-sonnet-4.5",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hi"}],
+            },
+        )
+
+        mock_standard.assert_called_once()
+
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_upstream_error_forwarded(self, mock_resolve, client):
+        """Upstream 4xx errors are forwarded verbatim."""
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {
+            "error": {"type": "invalid_request_error", "message": "bad model"}
+        }
+        mock_provider._send_with_auth_retry = AsyncMock(return_value=mock_response)
+        mock_resolve.return_value = ("github-copilot", "claude-sonnet-4.5", mock_provider)
+
+        with patch(
+            "router_maestro.server.routes.anthropic_beta._apply_thinking_budget_native",
+            side_effect=lambda body, _: body,
+        ):
+            resp = client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "claude-sonnet-4.5",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"]["message"] == "bad model"
+
+    def test_missing_model_returns_400(self, client):
+        """Request without model field returns 400."""
+        resp = client.post(
+            "/api/anthropic/beta/v1/messages",
+            json={"max_tokens": 100, "messages": [{"role": "user", "content": "Hi"}]},
+        )
+        assert resp.status_code == 400
+        assert "model" in resp.json()["detail"]
+
+    def test_invalid_json_returns_400(self, client):
+        """Malformed JSON body returns 400."""
+        resp = client.post(
+            "/api/anthropic/beta/v1/messages",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+
+
+class TestBetaCountTokensEndpoint:
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_passthrough_count_tokens(self, mock_resolve, client):
+        """Claude model count_tokens goes through native endpoint."""
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"input_tokens": 42}
+        mock_provider._send_with_auth_retry = AsyncMock(return_value=mock_response)
+        mock_resolve.return_value = ("github-copilot", "claude-sonnet-4.5", mock_provider)
+
+        resp = client.post(
+            "/api/anthropic/beta/v1/messages/count_tokens",
+            json={
+                "model": "claude-sonnet-4.5",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"input_tokens": 42}


### PR DESCRIPTION
## Summary

- Add `/api/anthropic/beta/v1/messages` endpoint that forwards Claude model requests directly to GitHub Copilot's native Anthropic Messages API — no Anthropic→OpenAI→Anthropic translation
- Non-Claude models automatically fall back to the existing translation-based handler
- CLI `router-maestro config claude-code` now offers Standard vs Beta endpoint choice for Claude-on-Copilot models

## What this enables

- **Full fidelity**: thinking signatures, cache usage breakdown (`cache_creation`, `output_tokens_details.thinking_tokens`), native tool_use blocks — all preserved without translation loss
- **Simpler path**: bypasses multi-choice tool_call merging, XML recovery, stop reason mapping, and reasoning_effort translation for Claude models
- **Drop-in replacement**: users can point `ANTHROPIC_BASE_URL` to `/api/anthropic/beta` and everything works — Claude gets the native path, non-Claude models transparently fall back

## Key behaviors

- Strips Copilot-internal fields (`copilot_usage`, `stop_details`, `amazon-bedrock-invocationMetrics`)
- Handles `temperature + top_p` conflict (Copilot native endpoint rejects both; auto-strips `top_p`)
- Applies server-side thinking budget config in native Anthropic format
- Streaming: filters `copilot_usage` SSE events, keeps standard Anthropic protocol events
- Model name resolution via existing fuzzy match (`claude-sonnet-4` → `claude-sonnet-4.5`)

## Test plan

- [x] 22 unit tests (helpers, response stripping, streaming filtering, fallback delegation)
- [x] 14 live integration tests (non-streaming, streaming, tools, thinking budget matrix, multi-turn, count_tokens, fallback)
- [x] Full model matrix run: 14/14 beta tests pass, no regressions in standard path
- [x] 914 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)