### PR TITLE
fix(anthropic-beta): strip unknown fields and retry on signature errors

### DIFF
--- a/integration_tests/test_live_anthropic_beta.py
+++ b/integration_tests/test_live_anthropic_beta.py
@@ -78,6 +78,20 @@ def test_beta_non_streaming_compat_fields(client: httpx.Client, chat_model: str)
     assert_anthropic_usage(data["usage"])
 
 
+def test_beta_strips_unknown_fields(client: httpx.Client, chat_model: str):
+    """Beta endpoint strips unknown fields (context_management, etc.) without error."""
+    payload = anthropic_payload(chat_model)
+    payload["context_management"] = {"enabled": True}
+    payload["output_config"] = {"format": "text"}
+    payload["service_tier"] = "standard"
+    response = client.post(BETA, json=payload)
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["type"] == "message"
+    assert_anthropic_usage(data["usage"])
+
+
 def test_beta_streaming(client: httpx.Client, chat_model: str):
     """Beta streaming emits standard Anthropic SSE event sequence."""
     with client.stream(
@@ -276,20 +290,28 @@ def test_beta_thinking_budget_matrix(
 
 
 def test_beta_thinking_replay(client: httpx.Client, chat_model: str):
-    """Multi-turn with prior thinking block — the native endpoint validates signatures.
+    """Multi-turn with prior thinking block triggers try-forward retry.
 
-    Unlike the standard path (which strips thinking during translation), the
-    native passthrough forwards the signature literally. Copilot's native
-    endpoint rejects invalid signatures, so we test with a simpler multi-turn
-    that doesn't include a fake thinking block.
+    The beta route first attempts to forward with the thinking block intact.
+    When Copilot rejects the invalid signature, it strips thinking blocks
+    and retries automatically — the client should see a successful response.
     """
     payload = {
         "model": chat_model,
         "max_tokens": 64,
-        "temperature": 0,
         "messages": [
             {"role": "user", "content": "What is 2 + 2? Reply with just the number."},
-            {"role": "assistant", "content": [{"type": "text", "text": "4"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Let me calculate: 2+2=4",
+                        "signature": "invalid-sig-from-old-route",
+                    },
+                    {"type": "text", "text": "4"},
+                ],
+            },
             {"role": "user", "content": "Now reply with exactly the word pong."},
         ],
     }
@@ -302,15 +324,24 @@ def test_beta_thinking_replay(client: httpx.Client, chat_model: str):
 
 
 def test_beta_thinking_replay_streaming(client: httpx.Client, chat_model: str):
-    """Streaming multi-turn conversation (without fake thinking signature)."""
+    """Streaming with invalid signature triggers try-forward retry."""
     payload = {
         "model": chat_model,
         "max_tokens": 64,
-        "temperature": 0,
         "stream": True,
         "messages": [
             {"role": "user", "content": "What is 2 + 2? Reply with just the number."},
-            {"role": "assistant", "content": [{"type": "text", "text": "4"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "2+2=4",
+                        "signature": "bad-sig",
+                    },
+                    {"type": "text", "text": "4"},
+                ],
+            },
             {"role": "user", "content": "Now reply with exactly the word pong."},
         ],
     }

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -37,6 +37,26 @@ COPILOT_COUNT_TOKENS_PATH = "/v1/messages/count_tokens"
 _STRIP_RESPONSE_KEYS = frozenset({"copilot_usage", "stop_details"})
 _STRIP_STREAM_MESSAGE_STOP_KEYS = frozenset({"copilot_usage", "amazon-bedrock-invocationMetrics"})
 
+# Fields the Copilot native Anthropic endpoint accepts. Anything not in this
+# set is stripped before forwarding — Copilot returns 400 on unknown fields.
+_COPILOT_ACCEPTED_FIELDS = frozenset(
+    {
+        "model",
+        "messages",
+        "max_tokens",
+        "stream",
+        "system",
+        "thinking",
+        "tools",
+        "tool_choice",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop_sequences",
+        "metadata",
+    }
+)
+
 
 def _is_native_eligible(provider_name: str, actual_model: str) -> bool:
     """Whether this model can use the native Copilot Anthropic endpoint."""
@@ -44,6 +64,33 @@ def _is_native_eligible(provider_name: str, actual_model: str) -> bool:
         return False
     bare = actual_model.split("/", 1)[-1].lower()
     return bare.startswith("claude-")
+
+
+def _strip_history_thinking_blocks(body: dict) -> None:
+    """Remove thinking blocks from assistant messages in conversation history.
+
+    Called as a retry fallback when Copilot rejects a signature it didn't
+    produce.  Stripping is safe — the model doesn't need prior thinking
+    to generate a new response.
+    """
+    messages = body.get("messages")
+    if not isinstance(messages, list):
+        return
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        filtered = [b for b in content if not (isinstance(b, dict) and b.get("type") == "thinking")]
+        if len(filtered) != len(content):
+            msg["content"] = filtered
+
+
+def _is_signature_error(response_text: str) -> bool:
+    """Check if an upstream 400 is a thinking signature validation error."""
+    lower = response_text.lower()
+    return "signature" in lower and "thinking" in lower
 
 
 def _strip_response(data: dict) -> dict:
@@ -149,6 +196,9 @@ async def beta_messages(raw_request: FastAPIRequest):
 
     stream = body.get("stream", False)
     thinking = body.get("thinking")
+
+    # Debug: log all top-level keys to identify fields Copilot might reject
+    logger.debug("Beta request body keys: %s", sorted(body.keys()))
     logger.info(
         "Received beta Anthropic request: model=%s, stream=%s, max_tokens=%s, thinking=%s",
         model,
@@ -191,6 +241,13 @@ async def beta_messages(raw_request: FastAPIRequest):
         logger.debug("Stripping top_p (temperature also present)")
         del body["top_p"]
 
+    # Strip fields the Copilot native endpoint doesn't accept.
+    unknown = set(body.keys()) - _COPILOT_ACCEPTED_FIELDS
+    if unknown:
+        logger.debug("Stripping unknown fields before passthrough: %s", unknown)
+        for key in unknown:
+            del body[key]
+
     # Ensure Copilot token is fresh
     await copilot_provider.ensure_token()
 
@@ -200,7 +257,7 @@ async def beta_messages(raw_request: FastAPIRequest):
             keepalive_frame=ANTHROPIC_PING_FRAME,
         )
 
-    # Non-streaming passthrough
+    # Non-streaming passthrough — try-forward with signature retry
     try:
         response = await copilot_provider._send_with_auth_retry(
             "POST",
@@ -210,6 +267,21 @@ async def beta_messages(raw_request: FastAPIRequest):
     except ProviderError as e:
         logger.error("Beta passthrough request failed: %s", e)
         raise HTTPException(status_code=e.status_code or 502, detail=str(e))
+
+    # If Copilot rejects a thinking signature, strip history thinking blocks
+    # and retry once — this handles the standard→beta route transition case.
+    if response.status_code == 400 and _is_signature_error(response.text):
+        logger.info("Signature rejected by upstream, stripping thinking blocks and retrying")
+        _strip_history_thinking_blocks(body)
+        try:
+            response = await copilot_provider._send_with_auth_retry(
+                "POST",
+                COPILOT_MESSAGES_PATH,
+                json=body,
+            )
+        except ProviderError as e:
+            logger.error("Beta passthrough retry failed: %s", e)
+            raise HTTPException(status_code=e.status_code or 502, detail=str(e))
 
     if response.status_code >= 400:
         logger.warning(
@@ -313,8 +385,40 @@ async def _stream_passthrough(
 
     Filters out copilot-internal events and strips internal metadata from
     ``message_stop`` events before yielding to the client.
+
+    On a signature validation error (400), strips history thinking blocks
+    and retries once before surfacing the error.
     """
     try:
+        async with provider._stream_with_auth_retry(
+            COPILOT_MESSAGES_PATH,
+            json=payload,
+            headers_kwargs={},
+        ) as response:
+            if response.status_code == 400:
+                error_text = (await response.aread()).decode()
+                if _is_signature_error(error_text):
+                    logger.info(
+                        "Stream: signature rejected, stripping thinking blocks and retrying"
+                    )
+                    _strip_history_thinking_blocks(payload)
+                    # Fall through to retry below
+                else:
+                    msg = f"Upstream error ({response.status_code}): {error_text[:200]}"
+                    yield _sse_error_event(msg)
+                    return
+            elif response.status_code >= 400:
+                error_text = (await response.aread()).decode()
+                msg = f"Upstream error ({response.status_code}): {error_text[:200]}"
+                yield _sse_error_event(msg)
+                return
+            else:
+                # Success — stream events
+                async for frame in _iter_sse_frames(response):
+                    yield frame
+                return
+
+        # Retry after stripping thinking blocks (only reached on signature error)
         async with provider._stream_with_auth_retry(
             COPILOT_MESSAGES_PATH,
             json=payload,
@@ -326,25 +430,8 @@ async def _stream_passthrough(
                 yield _sse_error_event(msg)
                 return
 
-            current_event: str | None = None
-            data_buffer: str = ""
-
-            async for line in response.aiter_lines():
-                if line.startswith("event: "):
-                    current_event = line[7:]
-                    # Don't yield event line yet — wait for data to decide
-                elif line.startswith("data: "):
-                    data_buffer = line[6:]
-                elif line == "":
-                    # End of SSE frame — process and yield
-                    if current_event and data_buffer:
-                        cleaned = _clean_stream_frame(current_event, data_buffer)
-                        if cleaned is not None:
-                            yield f"event: {current_event}\ndata: {cleaned}\n\n"
-                    elif current_event and not data_buffer:
-                        yield f"event: {current_event}\ndata: \n\n"
-                    current_event = None
-                    data_buffer = ""
+            async for frame in _iter_sse_frames(response):
+                yield frame
 
     except ProviderError as e:
         yield _sse_error_event(str(e))
@@ -354,6 +441,27 @@ async def _stream_passthrough(
     except Exception:
         logger.error("Unexpected error in beta anthropic stream", exc_info=True)
         yield _sse_error_event("Internal server error")
+
+
+async def _iter_sse_frames(response) -> AsyncGenerator[str, None]:
+    """Iterate SSE frames from a response, filtering copilot-internal events."""
+    current_event: str | None = None
+    data_buffer: str = ""
+
+    async for line in response.aiter_lines():
+        if line.startswith("event: "):
+            current_event = line[7:]
+        elif line.startswith("data: "):
+            data_buffer = line[6:]
+        elif line == "":
+            if current_event and data_buffer:
+                cleaned = _clean_stream_frame(current_event, data_buffer)
+                if cleaned is not None:
+                    yield f"event: {current_event}\ndata: {cleaned}\n\n"
+            elif current_event and not data_buffer:
+                yield f"event: {current_event}\ndata: \n\n"
+            current_event = None
+            data_buffer = ""
 
 
 def _clean_stream_frame(event_type: str, data_str: str) -> str | None:

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -13,6 +13,8 @@ from router_maestro.server.routes.anthropic_beta import (
     _apply_thinking_budget_native,
     _clean_stream_frame,
     _is_native_eligible,
+    _is_signature_error,
+    _strip_history_thinking_blocks,
     _strip_response,
     router,
 )
@@ -119,6 +121,83 @@ class TestCleanStreamFrame:
         data = '{"delta": {"type": "thinking_delta", "thinking": "hmm"}, "index": 0}'
         result = _clean_stream_frame("content_block_delta", data)
         assert result == data
+
+
+class TestIsSignatureError:
+    def test_detects_signature_in_thinking(self):
+        text = '{"message":"messages.3.content.0: Invalid `signature` in `thinking` block"}'
+        assert _is_signature_error(text) is True
+
+    def test_ignores_unrelated_400(self):
+        text = '{"message":"max_tokens: Field required"}'
+        assert _is_signature_error(text) is False
+
+    def test_ignores_signature_without_thinking(self):
+        text = '{"message":"Invalid signature format"}'
+        assert _is_signature_error(text) is False
+
+
+class TestStripHistoryThinkingBlocks:
+    def test_strips_thinking_from_assistant(self):
+        body = {
+            "messages": [
+                {"role": "user", "content": "Hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "...", "signature": "sig"},
+                        {"type": "text", "text": "Hello"},
+                    ],
+                },
+                {"role": "user", "content": "Bye"},
+            ]
+        }
+        _strip_history_thinking_blocks(body)
+        assistant_content = body["messages"][1]["content"]
+        assert len(assistant_content) == 1
+        assert assistant_content[0]["type"] == "text"
+
+    def test_preserves_user_messages(self):
+        body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Hi"}]},
+            ]
+        }
+        _strip_history_thinking_blocks(body)
+        assert len(body["messages"][0]["content"]) == 1
+
+    def test_preserves_tool_use_blocks(self):
+        body = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "x", "signature": "s"},
+                        {"type": "tool_use", "id": "t1", "name": "fn", "input": {}},
+                        {"type": "text", "text": "done"},
+                    ],
+                },
+            ]
+        }
+        _strip_history_thinking_blocks(body)
+        content = body["messages"][0]["content"]
+        assert len(content) == 2
+        assert content[0]["type"] == "tool_use"
+        assert content[1]["type"] == "text"
+
+    def test_no_op_when_no_thinking(self):
+        body = {
+            "messages": [
+                {"role": "assistant", "content": [{"type": "text", "text": "Hi"}]},
+            ]
+        }
+        _strip_history_thinking_blocks(body)
+        assert len(body["messages"][0]["content"]) == 1
+
+    def test_handles_string_content(self):
+        body = {"messages": [{"role": "assistant", "content": "plain text"}]}
+        _strip_history_thinking_blocks(body)
+        assert body["messages"][0]["content"] == "plain text"
 
 
 class TestApplyThinkingBudgetNative:
@@ -284,6 +363,143 @@ class TestBetaMessagesEndpoint:
 
         assert resp.status_code == 400
         assert resp.json()["error"]["message"] == "bad model"
+
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_signature_error_triggers_retry(self, mock_resolve, client):
+        """400 with signature error strips thinking and retries."""
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+
+        # First call returns signature error, second succeeds
+        error_response = MagicMock()
+        error_response.status_code = 400
+        error_response.text = (
+            '{"message":"messages.3.content.0: Invalid `signature` in `thinking` block"}'
+        )
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "id": "msg_bdrk_retry",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "retried ok"}],
+            "model": "claude-sonnet-4.5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+        mock_provider._send_with_auth_retry = AsyncMock(
+            side_effect=[error_response, success_response]
+        )
+        mock_resolve.return_value = ("github-copilot", "claude-sonnet-4.5", mock_provider)
+
+        with patch(
+            "router_maestro.server.routes.anthropic_beta._apply_thinking_budget_native",
+            side_effect=lambda body, _: body,
+        ):
+            resp = client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "claude-sonnet-4.5",
+                    "max_tokens": 100,
+                    "messages": [
+                        {"role": "user", "content": "Hi"},
+                        {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "thinking", "thinking": "x", "signature": "bad"},
+                                {"type": "text", "text": "Hello"},
+                            ],
+                        },
+                        {"role": "user", "content": "Bye"},
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["content"][0]["text"] == "retried ok"
+        # Should have been called twice (original + retry)
+        assert mock_provider._send_with_auth_retry.call_count == 2
+
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_non_signature_400_not_retried(self, mock_resolve, client):
+        """Non-signature 400 errors are NOT retried."""
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+
+        error_response = MagicMock()
+        error_response.status_code = 400
+        error_response.text = '{"message":"max_tokens: Field required"}'
+        error_response.json.return_value = {
+            "error": {"type": "invalid_request_error", "message": "max_tokens: Field required"}
+        }
+
+        mock_provider._send_with_auth_retry = AsyncMock(return_value=error_response)
+        mock_resolve.return_value = ("github-copilot", "claude-sonnet-4.5", mock_provider)
+
+        with patch(
+            "router_maestro.server.routes.anthropic_beta._apply_thinking_budget_native",
+            side_effect=lambda body, _: body,
+        ):
+            resp = client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "claude-sonnet-4.5",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert resp.status_code == 400
+        # Should only be called once — no retry
+        assert mock_provider._send_with_auth_retry.call_count == 1
+
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_unknown_fields_stripped(self, mock_resolve, client):
+        """Fields not in the accepted whitelist are stripped before forwarding."""
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "model": "claude-sonnet-4.5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        }
+        mock_provider._send_with_auth_retry = AsyncMock(return_value=mock_response)
+        mock_resolve.return_value = ("github-copilot", "claude-sonnet-4.5", mock_provider)
+
+        with patch(
+            "router_maestro.server.routes.anthropic_beta._apply_thinking_budget_native",
+            side_effect=lambda body, _: body,
+        ):
+            resp = client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "claude-sonnet-4.5",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "context_management": {"enabled": True},
+                    "output_config": {"format": "json"},
+                    "service_tier": "standard",
+                },
+            )
+
+        assert resp.status_code == 200
+        # Verify the forwarded payload doesn't contain unknown fields
+        forwarded_body = mock_provider._send_with_auth_retry.call_args.kwargs["json"]
+        assert "context_management" not in forwarded_body
+        assert "output_config" not in forwarded_body
+        assert "service_tier" not in forwarded_body
+        # Known fields should be preserved
+        assert forwarded_body["model"] == "claude-sonnet-4.5"
+        assert forwarded_body["max_tokens"] == 100
 
     def test_missing_model_returns_400(self, client):
         """Request without model field returns 400."""


### PR DESCRIPTION
## Summary

- Strip unknown request fields (e.g. `context_management`, `output_config`) via accepted-fields whitelist before forwarding to Copilot's native endpoint
- Try-forward with signature retry: attempt with thinking blocks intact, if Copilot returns 400 + signature error, strip history thinking blocks and retry once
- Handles both streaming and non-streaming paths

## Problem

Two issues discovered during live Claude Code testing:
1. Claude Code sends fields like `context_management` and `output_config` that Copilot's strict endpoint rejects with "Extra inputs are not permitted"
2. Mid-session route switch (standard → beta) carries thinking signatures that Copilot didn't produce, causing "Invalid signature in thinking block" errors

## Test plan

- [x] 33 unit tests pass (11 new: signature detection, thinking strip, field whitelist, retry behavior)
- [x] 15 live integration tests pass (including try-forward retry with invalid signatures)
- [x] 925 total unit tests pass — no regressions
- [x] Manually verified with Claude Code in a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)