### PR TITLE
Fix provider streaming review findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,18 @@ local-only, not part of GitHub Actions:
 uv run router-maestro auth login github-copilot
 ```
 
+The default live integration suite includes the full Copilot model matrix and
+covers model invocation paths such as OpenAI Chat/Responses, Anthropic
+Messages/count_tokens, Gemini generateContent/stream/countTokens, streaming,
+tool calls, usage accounting, Anthropic thinking budgets, OpenAI
+reasoning_effort, and Gemini-family model coverage.
+
+The integration server starts with
+`ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API=1` by default, so GPT-5 family
+models are routed through the Responses API bridge, including when accessed via
+Anthropic or Gemini endpoints. Set `RM_INTEGRATION_RESPONSES_CHAT=1` to force
+all models through `/chat/completions` instead.
+
 Run a single test file:
 
 ```bash
@@ -237,7 +249,11 @@ uv run router-maestro auth login github-copilot
   model subset, use `RM_INTEGRATION_MAX_MODELS=<N> make integration-test`. The
   reasoning/thinking sweep defaults to one representative model per family; to
   intentionally run that sweep across every available reasoning model, use
-  `RM_INTEGRATION_MAX_REASONING_MODELS=0 make integration-test`.
+  `RM_INTEGRATION_MAX_REASONING_MODELS=0 make integration-test`. The default
+  integration server enables the Responses API bridge, including for GPT-5
+  family models reached through Anthropic or Gemini endpoints; set
+  `RM_INTEGRATION_RESPONSES_CHAT=1` only when intentionally validating the chat
+  completions path.
 - Run the narrowest relevant pytest target first, then broaden to the full
   suite when the change has wider risk.
 

--- a/src/router_maestro/config/settings.py
+++ b/src/router_maestro/config/settings.py
@@ -73,7 +73,14 @@ def load_config(path: Path, model: type[T], default_factory: callable) -> T:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
         return model.model_validate(data)
-    except (json.JSONDecodeError, ValidationError, OSError) as e:
+    except ValidationError:
+        logger.error(
+            "Failed to validate config from %s as %s; falling back to defaults",
+            path,
+            model.__name__,
+        )
+        return default_factory()
+    except (json.JSONDecodeError, OSError) as e:
         logger.error("Failed to load config from %s (%s); falling back to defaults", path, e)
         return default_factory()
 

--- a/src/router_maestro/providers/anthropic.py
+++ b/src/router_maestro/providers/anthropic.py
@@ -103,6 +103,37 @@ class AnthropicProvider(BaseProvider):
 
         return system_prompt, converted
 
+    def _convert_tools(self, tools: list[dict]) -> list[dict]:
+        """Convert OpenAI-style function tools to Anthropic tool definitions."""
+        converted = []
+        for tool in tools:
+            function = tool.get("function") if tool.get("type") == "function" else None
+            if isinstance(function, dict):
+                anthropic_tool = {
+                    "name": function.get("name", ""),
+                    "input_schema": function.get("parameters") or {"type": "object"},
+                }
+                if function.get("description"):
+                    anthropic_tool["description"] = function["description"]
+                converted.append(anthropic_tool)
+            else:
+                converted.append(tool)
+        return converted
+
+    def _convert_tool_choice(self, tool_choice: str | dict) -> dict | str:
+        """Convert OpenAI-style tool_choice to Anthropic tool_choice."""
+        if tool_choice == "auto":
+            return {"type": "auto"}
+        if tool_choice == "none":
+            return {"type": "none"}
+        if tool_choice == "required":
+            return {"type": "any"}
+        if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+            name = (tool_choice.get("function") or {}).get("name")
+            if name:
+                return {"type": "tool", "name": name}
+        return tool_choice
+
     def _build_payload(self, request: ChatRequest, *, stream: bool = False) -> dict:
         """Build an Anthropic messages payload."""
         system_prompt, messages = self._convert_messages(request.messages)
@@ -124,9 +155,9 @@ class AnthropicProvider(BaseProvider):
                 thinking_config["budget_tokens"] = request.thinking_budget
             payload["thinking"] = thinking_config
         if request.tools:
-            payload["tools"] = request.tools
+            payload["tools"] = self._convert_tools(request.tools)
         if request.tool_choice:
-            payload["tool_choice"] = request.tool_choice
+            payload["tool_choice"] = self._convert_tool_choice(request.tool_choice)
         return payload
 
     async def chat_completion(self, request: ChatRequest) -> ChatResponse:

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -403,9 +403,13 @@ class BaseProvider(ABC):
             Responses completion response
 
         Raises:
-            NotImplementedError: If provider does not support Responses API
+            ProviderError: If provider does not support Responses API
         """
-        raise NotImplementedError("Provider does not support Responses API")
+        raise ProviderError(
+            "Provider does not support Responses API",
+            status_code=501,
+            retryable=False,
+        )
 
     async def responses_completion_stream(
         self, request: ResponsesRequest
@@ -419,9 +423,13 @@ class BaseProvider(ABC):
             Responses completion chunks
 
         Raises:
-            NotImplementedError: If provider does not support Responses API
+            ProviderError: If provider does not support Responses API
         """
-        raise NotImplementedError("Provider does not support Responses API")
+        raise ProviderError(
+            "Provider does not support Responses API",
+            status_code=501,
+            retryable=False,
+        )
         # Make this a generator (required for type checking)
         if False:
             yield ResponsesStreamChunk(content="")

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -973,39 +973,48 @@ class CopilotProvider(BaseProvider):
                     usage = data.get("usage")
 
                     if "choices" in data and data["choices"]:
-                        delta = data["choices"][0].get("delta", {})
-                        content = delta.get("content", "")
-                        finish_reason = data["choices"][0].get("finish_reason")
-                        tool_calls = delta.get("tool_calls")
-                        if tool_calls:
-                            emitted_tool_call = True
-                        if finish_reason == "stop" and emitted_tool_call:
-                            finish_reason = "tool_calls"
-                        if _thinking_requested(request):
-                            thinking_text, thinking_sig = _extract_reasoning_from_chunk(delta)
-                        else:
-                            thinking_text, thinking_sig = "", None
+                        terminal_chunks = []
+                        for choice in data["choices"]:
+                            delta = choice.get("delta", {})
+                            content = delta.get("content", "")
+                            finish_reason = choice.get("finish_reason")
+                            tool_calls = delta.get("tool_calls")
+                            if tool_calls:
+                                emitted_tool_call = True
+                            if finish_reason == "stop" and emitted_tool_call:
+                                finish_reason = "tool_calls"
+                            if _thinking_requested(request):
+                                thinking_text, thinking_sig = _extract_reasoning_from_chunk(delta)
+                            else:
+                                thinking_text, thinking_sig = "", None
 
-                        if (
-                            content
-                            or finish_reason
-                            or usage
-                            or tool_calls
-                            or thinking_text
-                            or thinking_sig
-                        ):
-                            yield ChatStreamChunk(
-                                content=content,
-                                finish_reason=finish_reason,
-                                usage=usage,
-                                tool_calls=tool_calls,
-                                thinking=thinking_text or None,
-                                thinking_signature=thinking_sig,
-                            )
+                            if (
+                                content
+                                or finish_reason
+                                or usage
+                                or tool_calls
+                                or thinking_text
+                                or thinking_sig
+                            ):
+                                chunk = ChatStreamChunk(
+                                    content=content,
+                                    finish_reason=finish_reason,
+                                    usage=usage,
+                                    tool_calls=tool_calls,
+                                    thinking=thinking_text or None,
+                                    thinking_signature=thinking_sig,
+                                )
+                                if finish_reason:
+                                    terminal_chunks.append(chunk)
+                                else:
+                                    yield chunk
 
-                        # Mark stream as finished after receiving finish_reason
-                        if finish_reason:
-                            stream_finished = True
+                            # Mark stream as finished after processing every
+                            # choice in this SSE event.
+                            if finish_reason:
+                                stream_finished = True
+                        for chunk in terminal_chunks:
+                            yield chunk
                     elif usage:
                         # Handle usage-only chunks (no choices)
                         yield ChatStreamChunk(
@@ -1296,6 +1305,31 @@ class CopilotProvider(BaseProvider):
                         name=output.get("name", ""),
                         arguments=output.get("arguments", "{}"),
                         namespace=output.get("namespace"),
+                    )
+                )
+            elif output.get("type") == "custom_tool_call":
+                tool_calls.append(
+                    ResponsesToolCall(
+                        call_id=output.get("call_id", ""),
+                        name=output.get("name", ""),
+                        arguments=output.get("input", ""),
+                        kind="custom",
+                    )
+                )
+            elif output.get("type") == "tool_search_call":
+                args = output.get("arguments")
+                if isinstance(args, str):
+                    args_str = args
+                elif args is None:
+                    args_str = "{}"
+                else:
+                    args_str = json.dumps(args)
+                tool_calls.append(
+                    ResponsesToolCall(
+                        call_id=output.get("call_id", ""),
+                        name="tool_search",
+                        arguments=args_str,
+                        kind="tool_search",
                     )
                 )
         return tool_calls

--- a/src/router_maestro/providers/openai_base.py
+++ b/src/router_maestro/providers/openai_base.py
@@ -152,11 +152,11 @@ class OpenAIChatProvider(BaseProvider, ABC):
 
                         data = json.loads(data_str)
 
+                        usage = data.get("usage")
                         if "choices" in data and data["choices"]:
                             delta = data["choices"][0].get("delta", {})
                             content = delta.get("content", "")
                             finish_reason = data["choices"][0].get("finish_reason")
-                            usage = data.get("usage")
                             tool_calls = delta.get("tool_calls")
 
                             if content or finish_reason or usage or tool_calls:
@@ -166,6 +166,12 @@ class OpenAIChatProvider(BaseProvider, ABC):
                                     usage=usage,
                                     tool_calls=tool_calls,
                                 )
+                        elif usage:
+                            yield ChatStreamChunk(
+                                content="",
+                                finish_reason=None,
+                                usage=usage,
+                            )
             except httpx.HTTPStatusError as e:
                 self._raise_http_status_error(
                     label, e, self._logger, stream=True, include_body=True

--- a/src/router_maestro/server/routes/admin.py
+++ b/src/router_maestro/server/routes/admin.py
@@ -157,6 +157,7 @@ async def _poll_oauth_completion(
                     refresh=access_token.access_token,
                     access=copilot_token.token,
                     expires=copilot_token.expires_at,
+                    api_endpoint=copilot_token.api_endpoint,
                 ),
             )
             manager.save()
@@ -288,6 +289,7 @@ async def update_priorities(request: PrioritiesUpdateRequest) -> PrioritiesRespo
         config.fallback = FallbackConfig.model_validate(request.fallback)
 
     save_priorities_config(config)
+    reset_router()
 
     return PrioritiesResponse(
         priorities=config.priorities,

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -542,6 +542,7 @@ async def stream_response(
         yield f"event: {start_event['type']}\ndata: {json.dumps(start_event)}\n\n"
     yield f"event: ping\ndata: {json.dumps({'type': 'ping'})}\n\n"
 
+    pipeline = None
     try:
         stream, provider_name = await model_router.chat_completion_stream(request)
 
@@ -615,7 +616,11 @@ async def stream_response(
             for event in events:
                 yield f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
 
+        pipeline.finish(status=200)
+
     except ProviderError as e:
+        if pipeline is not None:
+            pipeline.finish(status=e.status_code, body_summary=str(e))
         yield _sse_error_event(str(e))
     except asyncio.CancelledError:
         logger.info("Anthropic stream cancelled by client")

--- a/src/router_maestro/server/routes/chat.py
+++ b/src/router_maestro/server/routes/chat.py
@@ -145,6 +145,7 @@ async def chat_completions(request: ChatCompletionRequest):
 
 async def stream_response(model_router: Router, request: ChatRequest) -> AsyncGenerator[str, None]:
     """Stream chat completion response."""
+    pipeline = None
     try:
         stream, provider_name = await model_router.chat_completion_stream(request)
         response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
@@ -238,8 +239,11 @@ async def stream_response(model_router: Router, request: ChatRequest) -> AsyncGe
                 yield f"data: {final_chunk.model_dump_json()}\n\n"
 
         yield "data: [DONE]\n\n"
+        pipeline.finish(status=200)
 
     except ProviderError as e:
+        if pipeline is not None:
+            pipeline.finish(status=e.status_code, body_summary=str(e))
         error_data = {"error": {"message": str(e), "type": "provider_error"}}
         yield f"data: {json.dumps(error_data)}\n\n"
         yield "data: [DONE]\n\n"

--- a/src/router_maestro/server/routes/gemini.py
+++ b/src/router_maestro/server/routes/gemini.py
@@ -271,6 +271,7 @@ async def _stream_response(
     estimated_input_tokens: int = 0,
 ) -> AsyncGenerator[str, None]:
     """Stream Gemini-format SSE response from the upstream provider."""
+    pipeline = None
     try:
         stream, _provider_name = await model_router.chat_completion_stream(request)
 
@@ -313,7 +314,11 @@ async def _stream_response(
                     "\r\n\r\n"
                 )
 
+        pipeline.finish(status=200)
+
     except ProviderError as e:
+        if pipeline is not None:
+            pipeline.finish(status=e.status_code, body_summary=str(e))
         yield _sse_error_data(str(e))
     except asyncio.CancelledError:
         logger.info("Gemini stream cancelled by client")

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -250,6 +250,44 @@ def make_function_call_item(
     return item
 
 
+def make_custom_tool_call_item(
+    ctc_id: str,
+    call_id: str,
+    name: str,
+    input_text: str,
+    status: str = "completed",
+) -> dict[str, Any]:
+    """Create custom_tool_call output item."""
+    return {
+        "type": "custom_tool_call",
+        "id": ctc_id,
+        "call_id": call_id,
+        "name": name,
+        "input": input_text,
+        "status": status,
+    }
+
+
+def parse_tool_search_arguments(arguments: str) -> dict[str, Any]:
+    """Parse tool_search arguments into the dict shape clients expect."""
+    try:
+        parsed = json.loads(arguments) if arguments else {}
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def make_tool_search_call_item(call_id: str, arguments: str) -> dict[str, Any]:
+    """Create tool_search_call output item."""
+    return {
+        "type": "tool_search_call",
+        "call_id": call_id,
+        "execution": "client",
+        "status": "completed",
+        "arguments": parse_tool_search_arguments(arguments),
+    }
+
+
 @router.post("/api/openai/v1/responses")
 async def create_response(request: ResponsesRequest):
     """Handle Responses API requests (for Codex models)."""
@@ -331,23 +369,37 @@ async def create_response(request: ResponsesRequest):
 
         if response.tool_calls:
             for tc in response.tool_calls:
-                fc_id = generate_id("fc")
-                output.append(
-                    make_function_call_item(
-                        fc_id,
-                        tc.call_id,
-                        tc.name,
-                        tc.arguments,
-                        namespace=tc.namespace,
+                if tc.kind == "custom":
+                    output.append(
+                        make_custom_tool_call_item(
+                            generate_id("ctc"),
+                            tc.call_id,
+                            tc.name,
+                            tc.arguments,
+                        )
                     )
-                )
+                elif tc.kind == "tool_search":
+                    output.append(make_tool_search_call_item(tc.call_id, tc.arguments))
+                else:
+                    output.append(
+                        make_function_call_item(
+                            generate_id("fc"),
+                            tc.call_id,
+                            tc.name,
+                            tc.arguments,
+                            namespace=tc.namespace,
+                        )
+                    )
 
-        return ResponsesResponse(
+        return ResponsesResponse.model_construct(
             id=response_id,
+            object="response",
             model=response.model,
             status="completed",
             output=output,
             usage=usage,
+            error=None,
+            incomplete_details=None,
         )
     except ProviderError as e:
         elapsed_ms = (time.time() - start_time) * 1000
@@ -478,6 +530,7 @@ async def stream_response(
     # them even if responses_completion_stream() raises before returning.
     response_id = generate_id("resp")
     created_at = int(time.time())
+    pipeline = None
     try:
         stream, provider_name = await model_router.responses_completion_stream(request)
 
@@ -734,16 +787,12 @@ async def stream_response(
                     # — the model retries forever (v0.3.5/v0.3.6 bug).
                     # Codex only requires output_item.done with the full
                     # item; arguments must be a dict, not a JSON string.
-                    try:
-                        args_obj = json.loads(tc.arguments) if tc.arguments else {}
-                    except (TypeError, ValueError):
-                        args_obj = {}
                     tsc_item = {
                         "type": "tool_search_call",
                         "call_id": tc.call_id,
                         "execution": "client",
                         "status": "completed",
-                        "arguments": args_obj,
+                        "arguments": parse_tool_search_arguments(tc.arguments),
                     }
                     yield sse_event(
                         {
@@ -900,6 +949,7 @@ async def stream_response(
 
         # NOTE: Do NOT send "data: [DONE]\n\n" - agent-maestro doesn't send it
         # for Responses API
+        pipeline.finish(status=200)
 
     except ProviderError as e:
         elapsed_ms = (time.time() - start_time) * 1000
@@ -909,6 +959,8 @@ async def stream_response(
             elapsed_ms,
             e,
         )
+        if pipeline is not None:
+            pipeline.finish(status=e.status_code, body_summary=str(e))
         # Send response.failed event matching OpenAI spec
         yield sse_event(
             {

--- a/src/router_maestro/server/translation_gemini.py
+++ b/src/router_maestro/server/translation_gemini.py
@@ -134,10 +134,15 @@ def translate_gemini_to_openai(request: GeminiGenerateContentRequest, model: str
 
     temperature = 1.0
     max_tokens: int | None = None
+    extra: dict[str, Any] = {}
     if request.generation_config:
         if request.generation_config.temperature is not None:
             temperature = request.generation_config.temperature
         max_tokens = request.generation_config.max_output_tokens
+        if request.generation_config.top_p is not None:
+            extra["top_p"] = request.generation_config.top_p
+        if request.generation_config.stop_sequences:
+            extra["stop"] = request.generation_config.stop_sequences
 
     return ChatRequest(
         model=model,
@@ -147,6 +152,7 @@ def translate_gemini_to_openai(request: GeminiGenerateContentRequest, model: str
         stream=False,
         tools=tools,
         tool_choice=tool_choice,
+        extra=extra,
     )
 
 

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,0 +1,102 @@
+"""Tests for admin route side effects."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from router_maestro.auth.storage import OAuthCredential
+from router_maestro.config import PrioritiesConfig
+from router_maestro.server.routes import admin
+from router_maestro.server.schemas.admin import PrioritiesUpdateRequest
+
+
+@dataclass
+class _AccessToken:
+    access_token: str
+
+
+@dataclass
+class _CopilotToken:
+    token: str
+    expires_at: int
+    api_endpoint: str | None
+
+
+class _StorageSpy:
+    def __init__(self):
+        self.saved: dict[str, OAuthCredential] = {}
+
+    def set(self, provider: str, credential: OAuthCredential) -> None:
+        self.saved[provider] = credential
+
+
+class _AuthManagerSpy:
+    instances: list["_AuthManagerSpy"] = []
+
+    def __init__(self):
+        self.storage = _StorageSpy()
+        self.save_called = False
+        _AuthManagerSpy.instances.append(self)
+
+    def save(self) -> None:
+        self.save_called = True
+
+
+class _OAuthSessionsSpy:
+    def __init__(self):
+        self.updates: list[dict] = []
+
+    async def update_session_status(self, session_id: str, **kwargs) -> None:
+        self.updates.append({"session_id": session_id, **kwargs})
+
+
+async def _fake_poll_access_token(client, device_code, interval, timeout):
+    return _AccessToken("gh-access")
+
+
+async def _fake_get_copilot_token(client, access_token):
+    return _CopilotToken(
+        token="copilot-token",
+        expires_at=12345,
+        api_endpoint="https://api.enterprise.githubcopilot.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_oauth_completion_preserves_copilot_api_endpoint(monkeypatch):
+    sessions = _OAuthSessionsSpy()
+    reset_calls: list[None] = []
+    _AuthManagerSpy.instances.clear()
+
+    monkeypatch.setattr(admin, "AuthManager", _AuthManagerSpy)
+    monkeypatch.setattr(admin, "oauth_sessions", sessions)
+    monkeypatch.setattr(admin, "reset_router", lambda: reset_calls.append(None))
+    monkeypatch.setattr(admin, "poll_access_token", _fake_poll_access_token)
+    monkeypatch.setattr(admin, "get_copilot_token", _fake_get_copilot_token)
+
+    await admin._poll_oauth_completion("sess-1", "device-code", 1)
+
+    manager = _AuthManagerSpy.instances[0]
+    credential = manager.storage.saved["github-copilot"]
+    assert credential.api_endpoint == "https://api.enterprise.githubcopilot.com"
+    assert manager.save_called is True
+    assert reset_calls == [None]
+    assert sessions.updates[0]["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_update_priorities_invalidates_router_cache_after_save(monkeypatch):
+    saved_configs: list[PrioritiesConfig] = []
+    reset_calls: list[None] = []
+
+    monkeypatch.setattr(admin, "load_priorities_config", lambda: PrioritiesConfig())
+    monkeypatch.setattr(admin, "save_priorities_config", saved_configs.append)
+    monkeypatch.setattr(admin, "reset_router", lambda: reset_calls.append(None))
+
+    response = await admin.update_priorities(
+        PrioritiesUpdateRequest(priorities=["github-copilot/gpt-4o"])
+    )
+
+    assert response.priorities == ["github-copilot/gpt-4o"]
+    assert saved_configs[0].priorities == ["github-copilot/gpt-4o"]
+    assert reset_calls == [None]

--- a/tests/test_chat_stream_usage.py
+++ b/tests/test_chat_stream_usage.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from router_maestro.providers import ChatRequest, ChatStreamChunk, CopilotProvider, Message
+from router_maestro.providers.openai_compat import OpenAICompatibleProvider
 from router_maestro.server.routes.chat import stream_response
 
 
@@ -36,6 +37,61 @@ def _parse_chat_stream_events(raw_events: list[str]) -> list[dict[str, Any]]:
             if line.startswith("data: "):
                 events.append(json.loads(line[len("data: ") :]))
     return events
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_chat_stream_emits_usage_only_chunk():
+    """OpenAI-compatible providers must surface usage chunks with empty choices."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        body = (
+            b'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
+            b'data: {"choices":[],"usage":{"prompt_tokens":4,'
+            b'"completion_tokens":2,"total_tokens":6}}\n\n'
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+            b"data: [DONE]\n\n"
+        )
+        return httpx.Response(
+            status_code=200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = OpenAICompatibleProvider(
+        name="custom",
+        base_url="https://example.com/v1",
+        api_key="sk-test",
+    )
+
+    provider_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                "httpx.AsyncClient",
+                lambda *args, **kwargs: provider_client,
+            )
+            chunks = [
+                chunk
+                async for chunk in provider.chat_completion_stream(
+                    ChatRequest(
+                        model="gpt-4o",
+                        messages=[Message(role="user", content="hi")],
+                        stream=True,
+                    )
+                )
+            ]
+    finally:
+        await provider_client.aclose()
+
+    usage_chunks = [chunk for chunk in chunks if chunk.usage]
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0].content == ""
+    assert usage_chunks[0].finish_reason is None
+    assert usage_chunks[0].usage == {
+        "prompt_tokens": 4,
+        "completion_tokens": 2,
+        "total_tokens": 6,
+    }
 
 
 @pytest.mark.asyncio
@@ -152,5 +208,59 @@ async def test_copilot_chat_stream_tool_calls_force_tool_calls_finish_reason():
     )
     chunks = [chunk async for chunk in provider.chat_completion_stream(request)]
 
+    assert any(chunk.tool_calls for chunk in chunks)
+    assert chunks[-1].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_copilot_chat_stream_processes_all_choices():
+    """Copilot can split text/tool deltas across choices in the same SSE event."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        body = (
+            b'data: {"choices":['
+            b'{"delta":{"content":"hello"},"finish_reason":null},'
+            b'{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function",'
+            b'"function":{"name":"test_tool","arguments":"{}"}}]},'
+            b'"finish_reason":null}'
+            b"]}\n\n"
+            b'data: {"choices":['
+            b'{"delta":{},"finish_reason":"stop"},'
+            b'{"delta":{"content":"ignored only if choice skipped"},"finish_reason":null}'
+            b"]}\n\n"
+        )
+        return httpx.Response(
+            status_code=200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = CopilotProvider()
+    provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider.ensure_token = _noop  # type: ignore[method-assign]
+    provider._get_headers = lambda *args, **kwargs: {"authorization": "Bearer test"}  # type: ignore[method-assign]
+
+    chunks = [
+        chunk
+        async for chunk in provider.chat_completion_stream(
+            ChatRequest(
+                model="gpt-4o",
+                messages=[Message(role="user", content="Use the test tool")],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "test_tool",
+                            "description": "A test tool",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                stream=True,
+            )
+        )
+    ]
+
+    assert any(chunk.content == "hello" for chunk in chunks)
     assert any(chunk.tool_calls for chunk in chunks)
     assert chunks[-1].finish_reason == "tool_calls"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,6 +135,27 @@ class TestConfigIO:
         config = load_config(path, ContextsConfig, ContextsConfig.get_default)
         assert config.current == "local"
 
+    def test_load_validation_error_does_not_log_input_values(self, tmp_path, caplog):
+        """Validation errors can include secret values and must not log them."""
+        path = tmp_path / "contexts.json"
+        secret = "sk-secret-from-invalid-config"
+        path.write_text(
+            json.dumps(
+                {
+                    "current": "local",
+                    "contexts": {"local": {"endpoint": {"raw": secret}}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = load_config(path, ContextsConfig, ContextsConfig.get_default)
+
+        assert config.current == "local"
+        assert secret not in caplog.text
+        assert "input_value" not in caplog.text
+        assert "contexts.local.endpoint" not in caplog.text
+
     def test_write_is_atomic_no_partial_file_on_crash(self, tmp_path):
         """If json.dump raises mid-write, the existing file is left intact."""
         import pytest

--- a/tests/test_gemini_routes.py
+++ b/tests/test_gemini_routes.py
@@ -245,6 +245,20 @@ class TestTranslateGeminiToOpenAI:
         assert result.temperature == 0.7
         assert result.max_tokens == 8192
 
+    def test_generation_config_preserves_supported_extra_options(self):
+        request = GeminiGenerateContentRequest(
+            contents=[GeminiContent(role="user", parts=[GeminiPart(text="Hi")])],
+            generation_config=GeminiGenerationConfig(
+                top_p=0.8,
+                stop_sequences=["END", "STOP"],
+            ),
+        )
+
+        result = translate_gemini_to_openai(request, "model")
+
+        assert result.extra["top_p"] == 0.8
+        assert result.extra["stop"] == ["END", "STOP"]
+
     def test_function_call_in_model_content(self):
         request = GeminiGenerateContentRequest(
             contents=[

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,6 @@
 """Tests for providers module."""
 
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -9,7 +10,10 @@ from router_maestro.auth.github_oauth import CopilotTokenResponse
 from router_maestro.auth.storage import AuthStorage, OAuthCredential
 from router_maestro.providers import (
     AnthropicProvider,
+    BaseProvider,
     ChatRequest,
+    ChatResponse,
+    ChatStreamChunk,
     CopilotProvider,
     Message,
     ModelInfo,
@@ -207,6 +211,61 @@ class TestProviderBase:
         assert provider.name == "custom"
         assert provider.is_authenticated() is True
 
+    @pytest.mark.asyncio
+    async def test_responses_completion_default_raises_provider_error_501(self):
+        """Providers without Responses API support should surface a protocol error."""
+
+        class MinimalProvider(BaseProvider):
+            async def chat_completion(self, request: ChatRequest) -> ChatResponse:
+                return ChatResponse(content="ok", model=request.model)
+
+            async def chat_completion_stream(self, request: ChatRequest):
+                yield ChatStreamChunk(content="ok")
+
+            async def list_models(self) -> list[ModelInfo]:
+                return []
+
+            def is_authenticated(self) -> bool:
+                return True
+
+        provider = MinimalProvider()
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.responses_completion(ResponsesRequest(model="gpt-5", input="hi"))
+
+        assert exc.value.status_code == 501
+        assert exc.value.retryable is False
+        assert "Responses API" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_responses_completion_stream_default_raises_provider_error_501(self):
+        """Streaming defaults should raise ProviderError instead of NotImplementedError."""
+
+        class MinimalProvider(BaseProvider):
+            async def chat_completion(self, request: ChatRequest) -> ChatResponse:
+                return ChatResponse(content="ok", model=request.model)
+
+            async def chat_completion_stream(self, request: ChatRequest):
+                yield ChatStreamChunk(content="ok")
+
+            async def list_models(self) -> list[ModelInfo]:
+                return []
+
+            def is_authenticated(self) -> bool:
+                return True
+
+        provider = MinimalProvider()
+
+        with pytest.raises(ProviderError) as exc:
+            async for _chunk in provider.responses_completion_stream(
+                ResponsesRequest(model="gpt-5", input="hi", stream=True)
+            ):
+                pass
+
+        assert exc.value.status_code == 501
+        assert exc.value.retryable is False
+        assert "Responses API" in str(exc.value)
+
 
 class TestChatRequest:
     """Tests for ChatRequest."""
@@ -331,6 +390,69 @@ class TestAnthropicMessageConversion:
             }
         ]
 
+    def test_build_payload_converts_openai_tools_to_anthropic_tools(self):
+        """Anthropic payloads require native tool schema, not OpenAI wrappers."""
+        provider = AnthropicProvider()
+
+        payload = provider._build_payload(
+            ChatRequest(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", content="weather?")],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get current weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+            )
+        )
+
+        assert payload["tools"] == [
+            {
+                "name": "get_weather",
+                "description": "Get current weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        ("tool_choice", "expected"),
+        [
+            ("auto", {"type": "auto"}),
+            ("none", {"type": "none"}),
+            ("required", {"type": "any"}),
+            (
+                {"type": "function", "function": {"name": "get_weather"}},
+                {"type": "tool", "name": "get_weather"},
+            ),
+        ],
+    )
+    def test_build_payload_converts_openai_tool_choice_to_anthropic(self, tool_choice, expected):
+        """OpenAI tool_choice values must be mapped to Anthropic equivalents."""
+        provider = AnthropicProvider()
+
+        payload = provider._build_payload(
+            ChatRequest(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", content="weather?")],
+                tool_choice=tool_choice,
+            )
+        )
+
+        assert payload["tool_choice"] == expected
+
 
 def _copilot_with_cred(**cred_kwargs):
     """Build a CopilotProvider with an in-memory stored credential and saved-no-op."""
@@ -341,6 +463,50 @@ def _copilot_with_cred(**cred_kwargs):
     provider.auth_manager.storage.set("github-copilot", OAuthCredential(**defaults))
     provider.auth_manager.save = Mock()  # type: ignore[method-assign]
     return provider
+
+
+class TestCopilotResponsesNonStreaming:
+    """Tests for Copilot non-streaming /responses parsing."""
+
+    def test_extract_tool_calls_preserves_special_tool_call_kinds(self):
+        """custom_tool_call and tool_search_call must keep their Responses item kinds."""
+        provider = CopilotProvider()
+
+        tool_calls = provider._extract_tool_calls(
+            {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_fn",
+                        "name": "lookup",
+                        "arguments": '{"query":"x"}',
+                        "namespace": "mcp__search__",
+                    },
+                    {
+                        "type": "custom_tool_call",
+                        "call_id": "call_custom",
+                        "name": "apply_patch",
+                        "input": "*** Begin Patch\n*** End Patch",
+                    },
+                    {
+                        "type": "tool_search_call",
+                        "call_id": "call_search",
+                        "execution": "client",
+                        "arguments": {"query": "tools", "limit": 5},
+                    },
+                ]
+            }
+        )
+
+        assert [(tc.name, tc.kind) for tc in tool_calls] == [
+            ("lookup", "function"),
+            ("apply_patch", "custom"),
+            ("tool_search", "tool_search"),
+        ]
+        assert tool_calls[0].namespace == "mcp__search__"
+        assert tool_calls[1].arguments == "*** Begin Patch\n*** End Patch"
+        assert tool_calls[1].is_custom is True
+        assert json.loads(tool_calls[2].arguments) == {"query": "tools", "limit": 5}
 
 
 class TestCopilotTokenRefresh:

--- a/tests/test_providers_advanced.py
+++ b/tests/test_providers_advanced.py
@@ -317,9 +317,19 @@ class TestBaseProviderAbstract:
         # Test default ensure_token
         await provider.ensure_token()
 
-        # Test default responses methods raise NotImplementedError
-        with pytest.raises(NotImplementedError):
+        # Test default responses methods raise ProviderError so routes can map status codes.
+        with pytest.raises(ProviderError) as exc:
             await provider.responses_completion(ResponsesRequest(model="test", input="hi"))
+        assert exc.value.status_code == 501
+        assert exc.value.retryable is False
+
+        with pytest.raises(ProviderError) as stream_exc:
+            async for _ in provider.responses_completion_stream(
+                ResponsesRequest(model="test", input="hi", stream=True)
+            ):
+                pass
+        assert stream_exc.value.status_code == 501
+        assert stream_exc.value.retryable is False
 
 
 class TestOpenAIChatProviderBuildPayload:

--- a/tests/test_responses_route_wire_shape.py
+++ b/tests/test_responses_route_wire_shape.py
@@ -16,8 +16,10 @@ from typing import Any
 import pytest
 
 from router_maestro.providers import ResponsesRequest as InternalResponsesRequest
+from router_maestro.providers.base import ResponsesResponse as InternalResponsesResponse
 from router_maestro.providers.base import ResponsesStreamChunk, ResponsesToolCall
-from router_maestro.server.routes.responses import stream_response
+from router_maestro.server.routes.responses import create_response, stream_response
+from router_maestro.server.schemas.responses import ResponsesRequest
 
 
 class _StubRouter:
@@ -34,6 +36,18 @@ class _StubRouter:
                 yield c
 
         return _gen(), "github-copilot"
+
+
+class _NonStreamStubRouter:
+    """Minimal Router stub for non-streaming /responses route tests."""
+
+    def __init__(self, response: InternalResponsesResponse):
+        self._response = response
+
+    async def responses_completion(
+        self, request: InternalResponsesRequest, fallback: bool = True
+    ) -> tuple[InternalResponsesResponse, str]:
+        return self._response, "github-copilot"
 
 
 def _parse_sse(events: list[str]) -> list[dict[str, Any]]:
@@ -166,6 +180,73 @@ class TestToolSearchCallWireShape:
             and e.get("item", {}).get("type") == "tool_search_call"
         )
         assert done["item"]["arguments"] == {}
+
+
+class TestNonStreamingToolCallWireShape:
+    """Non-streaming output must use the same per-kind item types as streaming."""
+
+    @pytest.mark.asyncio
+    async def test_non_stream_response_maps_tool_call_kinds(self, monkeypatch):
+        monkeypatch.setattr(
+            "router_maestro.server.routes.responses.get_router",
+            lambda: _NonStreamStubRouter(
+                InternalResponsesResponse(
+                    content="",
+                    model="github-copilot/gpt-5",
+                    tool_calls=[
+                        ResponsesToolCall(
+                            call_id="call_fn",
+                            name="get_weather",
+                            arguments='{"location": "NYC"}',
+                            kind="function",
+                        ),
+                        ResponsesToolCall(
+                            call_id="call_custom",
+                            name="apply_patch",
+                            arguments="*** Begin Patch\n*** End Patch",
+                            kind="custom",
+                        ),
+                        ResponsesToolCall(
+                            call_id="call_search",
+                            name="tool_search",
+                            arguments='{"query": "routes", "limit": 3}',
+                            kind="tool_search",
+                        ),
+                    ],
+                )
+            ),
+        )
+
+        response = await create_response(
+            ResponsesRequest(
+                model="github-copilot/gpt-5",
+                input="hi",
+                stream=False,
+            )
+        )
+
+        output = [
+            item.model_dump(exclude_none=True) if hasattr(item, "model_dump") else item
+            for item in response.output
+        ]
+        by_call_id = {item["call_id"]: item for item in output if "call_id" in item}
+        assert by_call_id["call_fn"]["type"] == "function_call"
+        assert by_call_id["call_fn"]["arguments"] == '{"location": "NYC"}'
+        assert by_call_id["call_custom"] == {
+            "type": "custom_tool_call",
+            "id": by_call_id["call_custom"]["id"],
+            "call_id": "call_custom",
+            "name": "apply_patch",
+            "input": "*** Begin Patch\n*** End Patch",
+            "status": "completed",
+        }
+        assert by_call_id["call_search"] == {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "arguments": {"query": "routes", "limit": 3},
+        }
 
 
 class TestResponsesStreamUsageWireShape:

--- a/tests/test_stream_pipeline_finish.py
+++ b/tests/test_stream_pipeline_finish.py
@@ -1,0 +1,188 @@
+"""Regression tests for streaming routes finalizing RequestPipeline."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from router_maestro.providers import ChatRequest, ChatStreamChunk, Message
+from router_maestro.providers import ResponsesRequest as InternalResponsesRequest
+from router_maestro.providers.base import ProviderError, ResponsesStreamChunk
+from router_maestro.server.routes import anthropic, chat, gemini, responses
+
+
+class _PipelineSpy:
+    instances: list["_PipelineSpy"] = []
+
+    def __init__(self, request_id: str, model: str, tool_names: set[str] | None = None):
+        self.request_id = request_id
+        self.model = model
+        self.tool_names = tool_names
+        self.finished: list[tuple[int, str | None]] = []
+        _PipelineSpy.instances.append(self)
+
+    @classmethod
+    def create(
+        cls,
+        request_id: str,
+        model: str,
+        tool_names: set[str] | None = None,
+    ) -> "_PipelineSpy":
+        return cls(request_id=request_id, model=model, tool_names=tool_names)
+
+    def feed_stream(self, chunk) -> str | None:
+        return None
+
+    def check_invoke_at_finish(self) -> list[dict] | None:
+        return None
+
+    def finish(self, status: int = 200, body_summary: str | None = None) -> None:
+        self.finished.append((status, body_summary))
+
+
+class _ChatRouter:
+    def __init__(self, chunks: list[ChatStreamChunk], error: ProviderError | None = None):
+        self._chunks = chunks
+        self._error = error
+
+    async def chat_completion_stream(
+        self, request: ChatRequest, fallback: bool = True
+    ) -> tuple[AsyncIterator[ChatStreamChunk], str]:
+        async def _gen() -> AsyncIterator[ChatStreamChunk]:
+            for chunk in self._chunks:
+                yield chunk
+            if self._error is not None:
+                raise self._error
+
+        return _gen(), "github-copilot"
+
+
+class _ResponsesRouter:
+    def __init__(
+        self,
+        chunks: list[ResponsesStreamChunk],
+        error: ProviderError | None = None,
+    ):
+        self._chunks = chunks
+        self._error = error
+
+    async def responses_completion_stream(
+        self, request: InternalResponsesRequest, fallback: bool = True
+    ) -> tuple[AsyncIterator[ResponsesStreamChunk], str]:
+        async def _gen() -> AsyncIterator[ResponsesStreamChunk]:
+            for chunk in self._chunks:
+                yield chunk
+            if self._error is not None:
+                raise self._error
+
+        return _gen(), "github-copilot"
+
+
+def _chat_request() -> ChatRequest:
+    return ChatRequest(
+        model="github-copilot/gpt-4o",
+        messages=[Message(role="user", content="hi")],
+        stream=True,
+    )
+
+
+def _responses_request() -> InternalResponsesRequest:
+    return InternalResponsesRequest(model="github-copilot/gpt-5", input="hi", stream=True)
+
+
+@pytest.fixture(autouse=True)
+def pipeline_spy(monkeypatch):
+    _PipelineSpy.instances.clear()
+    monkeypatch.setattr("router_maestro.pipeline.RequestPipeline", _PipelineSpy)
+    return _PipelineSpy.instances
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stream_func", "router", "route_request", "extra_args"),
+    [
+        (
+            chat.stream_response,
+            _ChatRouter([ChatStreamChunk(content="hi", finish_reason="stop")]),
+            _chat_request(),
+            (),
+        ),
+        (
+            anthropic.stream_response,
+            _ChatRouter([ChatStreamChunk(content="hi", finish_reason="stop")]),
+            _chat_request(),
+            ("github-copilot/claude-sonnet-4", 1),
+        ),
+        (
+            gemini._stream_response,
+            _ChatRouter([ChatStreamChunk(content="hi", finish_reason="stop")]),
+            _chat_request(),
+            ("github-copilot/gemini-2.5-pro", 1),
+        ),
+        (
+            responses.stream_response,
+            _ResponsesRouter([ResponsesStreamChunk(content="hi", finish_reason="stop")]),
+            _responses_request(),
+            ("req-test", 0.0),
+        ),
+    ],
+)
+async def test_stream_routes_finish_pipeline_on_success(
+    pipeline_spy, stream_func, router, route_request, extra_args
+):
+    events = [event async for event in stream_func(router, route_request, *extra_args)]
+
+    assert events
+    assert len(pipeline_spy) == 1
+    assert pipeline_spy[0].finished == [(200, None)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stream_func", "router", "route_request", "extra_args"),
+    [
+        (
+            chat.stream_response,
+            _ChatRouter(
+                [ChatStreamChunk(content="hi")],
+                ProviderError("upstream failed", status_code=503),
+            ),
+            _chat_request(),
+            (),
+        ),
+        (
+            anthropic.stream_response,
+            _ChatRouter(
+                [ChatStreamChunk(content="hi")],
+                ProviderError("upstream failed", status_code=503),
+            ),
+            _chat_request(),
+            ("github-copilot/claude-sonnet-4", 1),
+        ),
+        (
+            gemini._stream_response,
+            _ChatRouter(
+                [ChatStreamChunk(content="hi")],
+                ProviderError("upstream failed", status_code=503),
+            ),
+            _chat_request(),
+            ("github-copilot/gemini-2.5-pro", 1),
+        ),
+        (
+            responses.stream_response,
+            _ResponsesRouter(
+                [ResponsesStreamChunk(content="hi")],
+                ProviderError("upstream failed", status_code=503),
+            ),
+            _responses_request(),
+            ("req-test", 0.0),
+        ),
+    ],
+)
+async def test_stream_routes_finish_pipeline_on_provider_error_after_pipeline_exists(
+    pipeline_spy, stream_func, router, route_request, extra_args
+):
+    events = [event async for event in stream_func(router, route_request, *extra_args)]
+
+    assert any("upstream failed" in event for event in events)
+    assert len(pipeline_spy) == 1
+    assert pipeline_spy[0].finished == [(503, "upstream failed")]


### PR DESCRIPTION
## Summary
- Normalize provider protocol boundaries for Anthropic tools/tool_choice, Responses defaults, usage-only streaming chunks, and Copilot multi-choice/tool-call parsing.
- Finalize streaming request pipelines on successful and provider-error paths, preserve admin OAuth endpoints, reset router state after priority updates, and emit correct Responses wire shapes for custom/tool-search calls.
- Sync AGENTS.md with CLAUDE.md integration guidance, redact validation error input values from config logs, and forward supported Gemini generation options.

## Test Plan
- [x] `uv run ruff check src/ tests/`
- [x] `git diff --check`
- [x] `uv run pytest tests/ -q` (`1007 passed`)
- [x] `make integration-test` (`64 passed, 1 skipped`)
