### PR TITLE
chore: bump version to 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,44 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
-## Unreleased
+## v0.5.3 (2026-07-10)
+
+### Changes
+
+- **Responses bridge configuration in Docker Compose.** Pass
+  `ROUTER_MAESTRO_EXPERIMENTAL_RESPONSES_API` through the production Compose
+  service and document the opt-in environment variable in `.env.example`.
 
 ### Fixes
 
-- **Anthropic adaptive effort passthrough.** Preserve typed
+- **Anthropic adaptive effort passthrough (#120).** Preserve typed
   `output_config.effort` through standard and beta-native Anthropic routes and
   prefer it over conflicting client or server thinking budgets. Requests
   without effort retain the existing `budget_tokens` fallback. Copilot catalog
   parsing now also accepts the structured reasoning-effort capability shape so
   supported `xhigh`/`max` tiers are not unnecessarily downgraded.
+
+- **Cross-provider request fidelity (#119).** Convert OpenAI-style tools and
+  tool choices to Anthropic-native wire shapes, preserve Gemini `top_p` and
+  stop sequences, and return a non-retryable 501 when a provider does not
+  support the Responses API.
+
+- **Streaming choices, usage, and audit finalization (#119).** Process every
+  Copilot SSE choice so split text and tool-call deltas are retained, preserve
+  usage-only chunks from OpenAI-compatible providers, and finalize stream
+  audit state on both success and provider failure.
+
+- **Responses special tool calls (#119).** Preserve non-streaming Copilot
+  `custom_tool_call` and `tool_search_call` outputs in their native Responses
+  wire shapes instead of treating them as ordinary function calls.
+
+- **Admin configuration and Copilot OAuth login (#119).** Apply priority
+  updates immediately by refreshing router state and persist Copilot's
+  returned API endpoint during OAuth login.
+
+- **Sensitive config validation logs (#119).** Avoid logging validation input
+  values that may contain credentials while retaining the fallback to default
+  configuration.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.5.2"
+version = "0.5.3"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- bump Router-Maestro from 0.5.2 to 0.5.3 in `pyproject.toml`, package metadata, and `uv.lock`
- finalize the v0.5.3 changelog for all changes since v0.5.2, including PRs #119 and #120 plus Docker Compose Responses configuration

## Verification

- `uv lock --check`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/ -v` — 1028 passed
- `uv build` — built `router_maestro-0.5.3.tar.gz` and `router_maestro-0.5.3-py3-none-any.whl`
- verified wheel and sdist metadata report `Version: 0.5.3`
- independent release review: no Critical or Important findings
