### PR TITLE
fix(anthropic): preserve enabled thinking budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,19 @@ All notable changes to Router-Maestro are documented here.
 
 ### Fixes
 
+- **Anthropic manual thinking with effort.** Preserve `thinking.budget_tokens`
+  when `thinking.type="enabled"` and `output_config.effort` are both present,
+  avoiding invalid enabled-thinking payloads in standard and beta-native routes.
+  The Copilot beta-native path also maps effort to the closest tier advertised
+  by the model catalog, preventing unsupported values such as Opus 4.6 `xhigh`.
+
 - **Anthropic adaptive effort passthrough (#120).** Preserve typed
   `output_config.effort` through standard and beta-native Anthropic routes and
-  prefer it over conflicting client or server thinking budgets. Requests
-  without effort retain the existing `budget_tokens` fallback. Copilot catalog
-  parsing now also accepts the structured reasoning-effort capability shape so
-  supported `xhigh`/`max` tiers are not unnecessarily downgraded.
+  prefer it over conflicting adaptive thinking budgets. Manual enabled thinking
+  retains its required normalized budget. Requests without effort retain the
+  existing `budget_tokens` fallback. Copilot catalog parsing now also accepts the
+  structured reasoning-effort capability shape so supported `xhigh`/`max` tiers
+  are not unnecessarily downgraded.
 
 - **Cross-provider request fidelity (#119).** Convert OpenAI-style tools and
   tool choices to Anthropic-native wire shapes, preserve Gemini `top_p` and

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Router-Maestro acts as a proxy that gives you access to models from multiple pro
 - **1M context support**: Activate Opus 4.6, Opus 4.7, Opus 4.8, *or* Sonnet 4.6 with a 1M context window via GitHub Copilot — just select `claude-opus-4-6[1m]`, `claude-opus-4-7[1m]`, `claude-opus-4-8[1m]`, or `claude-sonnet-4-6[1m]` during `config claude-code` setup. For 4.6 / 4.7 the `[1m]` beta header is auto-mapped to a dedicated Copilot variant (`claude-opus-4.6-1m` / `claude-opus-4.7-1m-internal`); for 4.8 and Sonnet 4.6 the base catalog entry already advertises 1M, so the synthetic `[1m]` key just raises Claude Code's auto-compact threshold (`CLAUDE_CODE_AUTO_COMPACT_WINDOW`) to 1M.
 - **Transparent reasoning-tier routing**: Requests for `claude-opus-4.7` with `reasoning_effort: "high"` or `"xhigh"` (or an Anthropic-style `thinking.budget_tokens` ≥ 8192) are auto-rewritten to the dedicated Copilot variants `claude-opus-4.7-high` / `claude-opus-4.7-xhigh` — no client changes needed. The newly-opened `reasoning_effort: "max"` tier (Opus 4.6 / 4.7 / 4.8 on Copilot) is also passed through verbatim when the model catalog advertises it.
 - **Anthropic adaptive effort passthrough**: `output_config.effort` is preserved
-  across standard and beta-native Anthropic routes. Explicit effort takes
-  precedence over `thinking.budget_tokens`; budgets remain the fallback when
-  effort is absent.
+  across standard and beta-native Anthropic routes. Explicit effort replaces
+  an adaptive thinking budget, while manual `thinking.type="enabled"` retains
+  its protocol-required `budget_tokens`. Copilot-native requests map effort to
+  the closest tier advertised by each model's live catalog.
 
 ## Table of Contents
 

--- a/docs/api-translation.md
+++ b/docs/api-translation.md
@@ -29,12 +29,16 @@ OpenAI Request ──────────────── (passthrough) �
 | `tool_choice` | `tool_choice` | `auto`→`"auto"`, `any`→`"required"`, `tool`→`{"type":"function",...}` |
 | `thinking.type` | `thinking_type` | Extracted directly |
 | `thinking.budget_tokens` | `thinking_budget` | Extracted directly |
-| `output_config.effort` | `reasoning_effort` | Extracted directly; takes precedence over thinking budgets |
+| `output_config.effort` | `reasoning_effort` | Extracted directly; replaces adaptive budgets only |
 
-When `output_config.effort` is present, Router-Maestro clears the internal
-`thinking_budget` before provider routing. Without effort, the existing budget
-fallback remains: client `budget_tokens`, per-model server budget, then the
-server default for an explicit thinking request.
+When `output_config.effort` is present with adaptive thinking, Router-Maestro
+clears the internal `thinking_budget` before provider routing. Manual
+`thinking.type="enabled"` retains its required `budget_tokens` alongside effort.
+Without effort, the existing budget fallback remains: client `budget_tokens`,
+per-model server budget, then the server default for an explicit thinking request.
+Adaptive budgets may be used internally for provider effort mapping, but
+Anthropic-native payloads always serialize adaptive thinking as
+`{"type":"adaptive"}` without `budget_tokens`.
 
 #### Message Translation Details
 
@@ -161,14 +165,18 @@ apply_copilot_chat_reasoning(
 - Converts OpenAI-format messages back to Anthropic format
 - Extracts system message → `system` parameter
 - Adds `thinking` config if `thinking_type` is enabled/adaptive
-- Sends `output_config.effort` when explicit effort is present and omits a
-  conflicting `thinking.budget_tokens`
+- Sends `output_config.effort` when explicit effort is present, omitting an
+  adaptive budget while retaining the budget required by manual enabled thinking
 - Otherwise uses the budget fallback format:
   `{"type":"enabled","budget_tokens":16000}`
 
 The beta native Copilot route preserves only a valid `output_config.effort`
 member and strips unsupported siblings such as `output_config.format`. Explicit
-effort also removes a conflicting `thinking.budget_tokens` before forwarding.
+effort removes only an adaptive `thinking.budget_tokens`; manual enabled thinking
+keeps its required budget before forwarding. When the Copilot model catalog
+advertises an effort allowlist, the requested value is mapped to the closest
+supported tier using the same higher-first policy as the Copilot chat and
+Responses paths.
 
 #### OpenAI / OpenAI-Compatible (`providers/openai_base.py`)
 - Direct passthrough of OpenAI format

--- a/docs/token-calculation.md
+++ b/docs/token-calculation.md
@@ -124,9 +124,12 @@ Both preserve the protocol rule that `budget_tokens < max_tokens`. Router-Maestr
 default ceiling is slightly higher so high client budgets can map to the local
 `max` reasoning tier before provider-specific catalog clamping.
 
-These budget calculations are used only when the request does not contain an
-explicit Anthropic `output_config.effort`. Effort is a tiered behavioral control,
-not an exact token budget, and takes precedence when both fields are present.
+These budget calculations are bypassed for adaptive thinking when the request
+contains an explicit Anthropic `output_config.effort`. Effort is a tiered
+behavioral control, not an exact token budget. Manual `thinking.type="enabled"`
+still keeps its protocol-required budget alongside effort. An adaptive budget
+may remain as an internal routing signal when effort is absent, but it is never
+serialized into an Anthropic-native adaptive thinking object.
 
 ---
 

--- a/src/router_maestro/providers/anthropic.py
+++ b/src/router_maestro/providers/anthropic.py
@@ -17,6 +17,7 @@ from router_maestro.providers.base import (
     ProviderError,
 )
 from router_maestro.utils import get_logger
+from router_maestro.utils.context_window import normalize_thinking_budget
 
 logger = get_logger("providers.anthropic")
 
@@ -149,11 +150,15 @@ class AnthropicProvider(BaseProvider):
             payload["system"] = system_prompt
         if request.temperature != 1.0:
             payload["temperature"] = request.temperature
-        if request.thinking_type and request.thinking_type != "disabled":
-            thinking_config: dict = {"type": request.thinking_type}
-            if request.thinking_budget is not None and request.reasoning_effort is None:
-                thinking_config["budget_tokens"] = request.thinking_budget
-            payload["thinking"] = thinking_config
+        if request.thinking_type == "adaptive":
+            payload["thinking"] = {"type": "adaptive"}
+        elif request.thinking_type == "enabled" and request.thinking_budget is not None:
+            budget = normalize_thinking_budget(request.thinking_budget, payload["max_tokens"])
+            if budget is not None:
+                payload["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": budget,
+                }
 
         if request.reasoning_effort is not None:
             payload["output_config"] = {"effort": request.reasoning_effort}

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -33,7 +33,11 @@ from router_maestro.providers.base import (
 from router_maestro.providers.tool_parsing import recover_tool_calls_from_content
 from router_maestro.utils import get_logger
 from router_maestro.utils.cache import TTLCache
-from router_maestro.utils.reasoning import budget_to_effort, downgrade_for_upstream
+from router_maestro.utils.reasoning import (
+    budget_to_effort,
+    downgrade_for_upstream,
+    pick_closest_effort,
+)
 
 logger = get_logger("providers.copilot")
 
@@ -77,43 +81,6 @@ def _claude_supports_reasoning(bare_lower: str) -> bool:
         or bare_lower.startswith("claude-opus-4.6")
         or bare_lower.startswith("claude-sonnet-4.6")
     )
-
-
-_EFFORT_ORDER = ("low", "medium", "high", "xhigh", "max")
-
-
-def _pick_closest_effort(desired: str, allowed: list[str]) -> str | None:
-    """Pick the value from ``allowed`` closest to ``desired`` on the L/M/H/XH/MAX ladder.
-
-    Strategy when an exact match is unavailable: prefer the next *higher* tier
-    (the user asked for thinking — give them more, not less), and fall back to
-    the next lower tier if no higher tier is offered. Returns ``None`` only if
-    ``allowed`` is empty.
-    """
-    if not allowed:
-        return None
-    if desired in allowed:
-        return desired
-    try:
-        target = _EFFORT_ORDER.index(desired)
-    except ValueError:
-        # Unknown tier — give them whatever the catalog ranks highest.
-        return max(allowed, key=lambda v: _EFFORT_ORDER.index(v) if v in _EFFORT_ORDER else -1)
-    higher = [v for v in allowed if v in _EFFORT_ORDER and _EFFORT_ORDER.index(v) > target]
-    if higher:
-        return min(higher, key=lambda v: _EFFORT_ORDER.index(v))
-    lower = [v for v in allowed if v in _EFFORT_ORDER and _EFFORT_ORDER.index(v) < target]
-    if lower:
-        return max(lower, key=lambda v: _EFFORT_ORDER.index(v))
-    return allowed[0]
-
-
-def _catalog_top_effort(allowed: list[str]) -> str | None:
-    """Return the highest tier from ``allowed`` per the L/M/H/XH/MAX ladder."""
-    ranked = [v for v in allowed if v in _EFFORT_ORDER]
-    if not ranked:
-        return allowed[0] if allowed else None
-    return max(ranked, key=lambda v: _EFFORT_ORDER.index(v))
 
 
 def apply_copilot_chat_reasoning(
@@ -166,9 +133,9 @@ def apply_copilot_chat_reasoning(
                 # Client asked for thinking without a clear effort — aim for
                 # the top tier the catalog actually advertises (e.g. "max" on
                 # opus-4.6+, "xhigh" on gpt-5.x).
-                desired = _catalog_top_effort(catalog_effort_values)
+                desired = pick_closest_effort("max", catalog_effort_values)
             if desired is not None:
-                picked = _pick_closest_effort(desired, catalog_effort_values)
+                picked = pick_closest_effort(desired, catalog_effort_values)
                 if picked is not None:
                     payload["reasoning_effort"] = picked
         if bare_lower.startswith("gpt-5.4") and "max_tokens" in payload:
@@ -1233,7 +1200,7 @@ class CopilotProvider(BaseProvider):
                 if desired is None:
                     upstream_effort = None
                 else:
-                    upstream_effort = _pick_closest_effort(desired, catalog)
+                    upstream_effort = pick_closest_effort(desired, catalog)
         else:
             upstream_effort = downgrade_for_upstream(request.reasoning_effort)
             if request.reasoning_effort in ("xhigh", "max") and upstream_effort == "high":

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -85,13 +85,16 @@ async def _apply_thinking_budget(
     Falls back to original_model for config key matching.
 
     Returns the original request unchanged if no adjustment is needed. Explicit
-    reasoning effort takes priority over all client and server budgets.
+    reasoning effort replaces adaptive budgets. Manual enabled thinking retains
+    a normalized budget because the Anthropic wire format requires one.
     """
-    if chat_request.reasoning_effort is not None:
+    if chat_request.reasoning_effort is not None and chat_request.thinking_type == "adaptive":
         return chat_request.with_thinking(
             thinking_budget=None,
             thinking_type=chat_request.thinking_type,
         )
+    if chat_request.reasoning_effort is not None and chat_request.thinking_type != "enabled":
+        return chat_request
 
     from router_maestro.config import load_priorities_config
 
@@ -106,6 +109,8 @@ async def _apply_thinking_budget(
 
     supports_thinking = model_info.supports_thinking if model_info else False
     max_output = (model_info.max_output_tokens or 16384) if model_info else 16384
+    if chat_request.max_tokens is not None:
+        max_output = min(max_output, chat_request.max_tokens)
 
     # Use translated model for config lookup (matches cache keys)
     budget, thinking_type = resolve_thinking_budget(

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -26,7 +26,7 @@ from router_maestro.server.routes.anthropic import (
 from router_maestro.server.streaming import sse_streaming_response
 from router_maestro.utils import get_logger
 from router_maestro.utils.context_window import resolve_thinking_budget
-from router_maestro.utils.reasoning import VALID_EFFORTS
+from router_maestro.utils.reasoning import VALID_EFFORTS, pick_closest_effort
 
 logger = get_logger("server.routes.anthropic_beta")
 
@@ -125,42 +125,66 @@ def _strip_response(data: dict) -> dict:
 def _apply_thinking_budget_native(body: dict, actual_model: str) -> dict:
     """Apply effort precedence or the server budget fallback to a raw body.
 
-    Explicit ``output_config.effort`` removes a conflicting thinking budget.
-    Without effort, the existing client/server budget resolution is unchanged.
+    Explicit ``output_config.effort`` removes an adaptive thinking budget.
+    Manual enabled thinking retains a normalized budget, using the server fallback
+    when the client omits it. Without effort, budget resolution is unchanged.
     """
     effort = _sanitize_output_config(body)
+    client_thinking = body.get("thinking")
+
+    model_router = None
+    model_info = None
     if effort is not None:
-        client_thinking = body.get("thinking")
-        if isinstance(client_thinking, dict) and "budget_tokens" in client_thinking:
-            thinking = dict(client_thinking)
-            thinking.pop("budget_tokens")
-            if thinking:
-                body["thinking"] = thinking
+        model_router = get_router()
+        if hasattr(model_router, "_models_cache"):
+            cache_entry = model_router._models_cache.get(actual_model)
+            if cache_entry:
+                _, model_info = cache_entry
+        if model_info is not None and model_info.reasoning_effort_values is not None:
+            mapped_effort = pick_closest_effort(effort, model_info.reasoning_effort_values)
+            if mapped_effort is None:
+                body.pop("output_config", None)
+                effort = None
             else:
-                body.pop("thinking", None)
+                body["output_config"] = {"effort": mapped_effort}
+                effort = mapped_effort
+
+    if isinstance(client_thinking, dict) and client_thinking.get("type") == "adaptive":
+        thinking = dict(client_thinking)
+        thinking.pop("budget_tokens", None)
+        body["thinking"] = thinking
         return body
+
+    if effort is not None:
+        if not (
+            isinstance(client_thinking, dict)
+            and client_thinking.get("type") in ("enabled", "disabled")
+        ):
+            return body
 
     from router_maestro.config import load_priorities_config
 
     priorities = load_priorities_config()
     thinking_config = priorities.thinking
 
-    client_thinking = body.get("thinking")
     client_budget = None
     client_type = None
     if isinstance(client_thinking, dict):
         client_budget = client_thinking.get("budget_tokens")
         client_type = client_thinking.get("type")
 
-    model_router = get_router()
-    model_info = None
-    if hasattr(model_router, "_models_cache"):
+    if model_router is None:
+        model_router = get_router()
+    if model_info is None and hasattr(model_router, "_models_cache"):
         cache_entry = model_router._models_cache.get(actual_model)
         if cache_entry:
             _, model_info = cache_entry
 
     supports_thinking = model_info.supports_thinking if model_info else True
     max_output = (model_info.max_output_tokens or 16384) if model_info else 16384
+    request_max_output = body.get("max_tokens")
+    if isinstance(request_max_output, int):
+        max_output = min(max_output, request_max_output)
 
     budget, thinking_type = resolve_thinking_budget(
         client_budget=client_budget,
@@ -171,9 +195,12 @@ def _apply_thinking_budget_native(body: dict, actual_model: str) -> dict:
         supports_thinking=supports_thinking,
     )
 
-    if budget != client_budget or thinking_type != client_type:
-        if budget is not None and thinking_type in ("enabled", "adaptive"):
-            body["thinking"] = {"type": thinking_type, "budget_tokens": budget}
+    if thinking_type == "adaptive":
+        adaptive = dict(client_thinking) if isinstance(client_thinking, dict) else {}
+        adaptive["type"] = "adaptive"
+        adaptive.pop("budget_tokens", None)
+        body["thinking"] = adaptive
+        if budget != client_budget or thinking_type != client_type:
             logger.debug(
                 "Thinking budget adjusted: %s/%s -> %s/%s for model=%s",
                 client_type,
@@ -182,8 +209,23 @@ def _apply_thinking_budget_native(body: dict, actual_model: str) -> dict:
                 budget,
                 actual_model,
             )
-        elif thinking_type == "disabled" or budget is None:
-            body.pop("thinking", None)
+    elif thinking_type == "enabled" and budget is not None:
+        enabled = dict(client_thinking) if isinstance(client_thinking, dict) else {}
+        enabled["type"] = "enabled"
+        enabled["budget_tokens"] = budget
+        body["thinking"] = enabled
+        if budget != client_budget or thinking_type != client_type:
+            logger.debug(
+                "Thinking budget adjusted: %s/%s -> %s/%s for model=%s",
+                client_type,
+                client_budget,
+                thinking_type,
+                budget,
+                actual_model,
+            )
+    else:
+        body.pop("thinking", None)
+        if client_type is not None:
             logger.debug(
                 "Thinking removed: client had %s/%s, resolved to %s for model=%s",
                 client_type,

--- a/src/router_maestro/utils/context_window.py
+++ b/src/router_maestro/utils/context_window.py
@@ -97,7 +97,10 @@ def resolve_thinking_budget(
     """
     # 1. Client explicitly requested thinking with a budget
     if client_thinking_type in ("enabled", "adaptive") and client_budget is not None:
-        return normalize_thinking_budget(client_budget, max_output_tokens), client_thinking_type
+        budget = normalize_thinking_budget(client_budget, max_output_tokens)
+        if client_thinking_type == "enabled" and budget is None:
+            return None, None
+        return budget, client_thinking_type
 
     # 2. Client explicitly disabled thinking
     if client_thinking_type == "disabled":
@@ -107,15 +110,21 @@ def resolve_thinking_budget(
     if client_thinking_type in ("enabled", "adaptive"):
         budget = _resolve_server_budget(model_id, thinking_config)
         if budget is not None:
-            return normalize_thinking_budget(budget, max_output_tokens), client_thinking_type
+            budget = normalize_thinking_budget(budget, max_output_tokens)
+            if client_thinking_type == "enabled" and budget is None:
+                return None, None
+            return budget, client_thinking_type
         # No server default — pass through client's request without budget
+        if client_thinking_type == "enabled":
+            return None, None
         return None, client_thinking_type
 
     # 4. Client didn't specify thinking at all — check auto_enable
     if thinking_config is not None and thinking_config.auto_enable and supports_thinking:
         budget = _resolve_server_budget(model_id, thinking_config)
         if budget is not None:
-            return normalize_thinking_budget(budget, max_output_tokens), "enabled"
+            budget = normalize_thinking_budget(budget, max_output_tokens)
+            return (budget, "enabled") if budget is not None else (None, None)
 
     # 5. No thinking
     return None, None

--- a/src/router_maestro/utils/reasoning.py
+++ b/src/router_maestro/utils/reasoning.py
@@ -30,6 +30,32 @@ VARIANT_EFFORTS: tuple[str, ...] = ("high", "xhigh", "max")
 UPSTREAM_NATIVE_EFFORTS: tuple[str, ...] = ("low", "medium", "high")
 
 
+def pick_closest_effort(desired: str, allowed: list[str]) -> str | None:
+    """Pick the closest catalog-supported effort, preferring the next higher tier."""
+    if not allowed:
+        return None
+    if desired in allowed:
+        return desired
+    try:
+        target = VALID_EFFORTS.index(desired)
+    except ValueError:
+        return max(
+            allowed,
+            key=lambda value: VALID_EFFORTS.index(value) if value in VALID_EFFORTS else -1,
+        )
+    higher = [
+        value for value in allowed if value in VALID_EFFORTS and VALID_EFFORTS.index(value) > target
+    ]
+    if higher:
+        return min(higher, key=VALID_EFFORTS.index)
+    lower = [
+        value for value in allowed if value in VALID_EFFORTS and VALID_EFFORTS.index(value) < target
+    ]
+    if lower:
+        return max(lower, key=VALID_EFFORTS.index)
+    return allowed[0]
+
+
 def effort_to_budget(effort: str | None) -> int | None:
     if effort is None:
         return None

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
+from router_maestro.providers.base import ModelInfo
 from router_maestro.providers.copilot import CopilotProvider
 from router_maestro.server.routes.anthropic import ANTHROPIC_PING_FRAME
 from router_maestro.server.routes.anthropic_beta import (
@@ -219,19 +220,187 @@ class TestApplyThinkingBudgetNative:
     @patch("router_maestro.server.routes.anthropic_beta.get_router")
     @patch("router_maestro.config.load_priorities_config")
     @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
-    def test_no_effort_uses_budget_fallback(self, mock_resolve_tb, mock_config, mock_router):
+    def test_effort_preserves_required_enabled_budget(
+        self, mock_resolve_tb, mock_config, mock_router
+    ):
         mock_config.return_value = MagicMock(
             thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
         )
         mock_router.return_value = MagicMock(_models_cache={})
-        mock_resolve_tb.return_value = (16000, "adaptive")
+        mock_resolve_tb.return_value = (16000, "enabled")
+        body = {
+            "thinking": {"type": "enabled", "budget_tokens": 16000},
+            "output_config": {"effort": "xhigh"},
+        }
+
+        result = _apply_thinking_budget_native(body, "claude-opus-4.6")
+
+        assert result["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert result["output_config"] == {"effort": "xhigh"}
+        mock_resolve_tb.assert_called_once()
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_effort_maps_to_catalog_supported_tier(self, mock_resolve_tb, mock_config, mock_router):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        model_info = ModelInfo(
+            id="claude-opus-4.6",
+            name="Claude Opus 4.6",
+            provider="github-copilot",
+            max_output_tokens=64000,
+            supports_thinking=True,
+            reasoning_effort_values=["low", "medium", "high", "max"],
+        )
+        mock_router.return_value = MagicMock(
+            _models_cache={"claude-opus-4.6": ("github-copilot", model_info)}
+        )
+        mock_resolve_tb.return_value = (16000, "enabled")
 
         result = _apply_thinking_budget_native(
-            {"thinking": {"type": "adaptive"}},
+            {
+                "max_tokens": 64000,
+                "thinking": {"type": "enabled", "budget_tokens": 16000},
+                "output_config": {"effort": "xhigh"},
+            },
+            "claude-opus-4.6",
+        )
+
+        assert result["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert result["output_config"] == {"effort": "max"}
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_enabled_budget_normalization_preserves_display(
+        self, mock_resolve_tb, mock_config, mock_router
+    ):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        mock_resolve_tb.return_value = (16000, "enabled")
+
+        result = _apply_thinking_budget_native(
+            {
+                "thinking": {
+                    "type": "enabled",
+                    "budget_tokens": 16000,
+                    "display": "summarized",
+                },
+                "output_config": {"effort": "xhigh"},
+            },
+            "claude-opus-4.6",
+        )
+
+        assert result["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": 16000,
+            "display": "summarized",
+        }
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_effort_fills_missing_enabled_budget(self, mock_resolve_tb, mock_config, mock_router):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        mock_resolve_tb.return_value = (16000, "enabled")
+
+        result = _apply_thinking_budget_native(
+            {
+                "thinking": {"type": "enabled"},
+                "output_config": {"effort": "xhigh"},
+            },
+            "claude-opus-4.6",
+        )
+
+        assert result["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert result["output_config"] == {"effort": "xhigh"}
+        mock_resolve_tb.assert_called_once()
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_effort_normalizes_enabled_budget(self, mock_resolve_tb, mock_config, mock_router):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        mock_resolve_tb.return_value = (4095, "enabled")
+
+        result = _apply_thinking_budget_native(
+            {
+                "max_tokens": 4096,
+                "thinking": {"type": "enabled", "budget_tokens": 16000},
+                "output_config": {"effort": "xhigh"},
+            },
+            "claude-opus-4.6",
+        )
+
+        assert result["thinking"] == {"type": "enabled", "budget_tokens": 4095}
+        assert result["output_config"] == {"effort": "xhigh"}
+        mock_resolve_tb.assert_called_once()
+        assert mock_resolve_tb.call_args.kwargs["max_output_tokens"] == 4096
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_effort_removes_disabled_thinking(self, mock_resolve_tb, mock_config, mock_router):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        mock_resolve_tb.return_value = (None, None)
+
+        result = _apply_thinking_budget_native(
+            {
+                "thinking": {"type": "disabled", "budget_tokens": 5000},
+                "output_config": {"effort": "xhigh"},
+            },
+            "claude-opus-4.6",
+        )
+
+        assert "thinking" not in result
+        assert result["output_config"] == {"effort": "xhigh"}
+        mock_resolve_tb.assert_called_once()
+
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_adaptive_without_effort_omits_budget(self, mock_resolve_tb):
+        result = _apply_thinking_budget_native(
+            {"thinking": {"type": "adaptive", "budget_tokens": 16000}},
             "claude-opus-4.8",
         )
 
-        assert result["thinking"] == {"type": "adaptive", "budget_tokens": 16000}
+        assert result["thinking"] == {"type": "adaptive"}
+        mock_resolve_tb.assert_not_called()
+
+    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.config.load_priorities_config")
+    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    def test_enabled_without_budget_headroom_is_removed(
+        self, mock_resolve_tb, mock_config, mock_router
+    ):
+        mock_config.return_value = MagicMock(
+            thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
+        )
+        mock_router.return_value = MagicMock(_models_cache={})
+        mock_resolve_tb.return_value = (None, None)
+
+        result = _apply_thinking_budget_native(
+            {
+                "max_tokens": 1024,
+                "thinking": {"type": "enabled", "budget_tokens": 16000},
+                "output_config": {"effort": "xhigh"},
+            },
+            "claude-opus-4.6",
+        )
+
+        assert "thinking" not in result
         mock_resolve_tb.assert_called_once()
 
     @patch("router_maestro.server.routes.anthropic_beta.get_router")
@@ -588,6 +757,40 @@ class TestBetaMessagesEndpoint:
         assert forwarded["thinking"] == {"type": "adaptive"}
         assert forwarded["output_config"] == {"effort": "xhigh"}
 
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_enabled_effort_preserves_required_budget(self, mock_resolve, client):
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "ok"}],
+            "model": "claude-opus-4.6",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        }
+        mock_provider._send_with_auth_retry = AsyncMock(return_value=mock_response)
+        mock_resolve.return_value = ("github-copilot", "claude-opus-4.6", mock_provider)
+
+        resp = client.post(
+            "/api/anthropic/beta/v1/messages",
+            json={
+                "model": "claude-opus-4-6",
+                "max_tokens": 64000,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "thinking": {"type": "enabled", "budget_tokens": 16000},
+                "output_config": {"effort": "xhigh", "format": "json"},
+            },
+        )
+
+        assert resp.status_code == 200
+        forwarded = mock_provider._send_with_auth_retry.call_args.kwargs["json"]
+        assert forwarded["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert forwarded["output_config"] == {"effort": "xhigh"}
+
     @patch("router_maestro.server.routes.anthropic_beta.sse_streaming_response")
     @patch("router_maestro.server.routes.anthropic_beta._stream_passthrough")
     @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
@@ -621,6 +824,36 @@ class TestBetaMessagesEndpoint:
             stream_marker,
             keepalive_frame=ANTHROPIC_PING_FRAME,
         )
+
+    @patch("router_maestro.server.routes.anthropic_beta.sse_streaming_response")
+    @patch("router_maestro.server.routes.anthropic_beta._stream_passthrough")
+    @patch("router_maestro.server.routes.anthropic_beta._resolve_model")
+    def test_stream_enabled_effort_preserves_required_budget(
+        self, mock_resolve, mock_stream, mock_sse_response, client
+    ):
+        mock_provider = MagicMock(spec=CopilotProvider)
+        mock_provider.ensure_token = AsyncMock()
+        mock_resolve.return_value = ("github-copilot", "claude-opus-4.6", mock_provider)
+        stream_marker = object()
+        mock_stream.return_value = stream_marker
+        mock_sse_response.return_value = JSONResponse(content={"stream": "captured"})
+
+        resp = client.post(
+            "/api/anthropic/beta/v1/messages",
+            json={
+                "model": "claude-opus-4-6",
+                "max_tokens": 64000,
+                "stream": True,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "thinking": {"type": "enabled", "budget_tokens": 16000},
+                "output_config": {"effort": "xhigh", "format": "json"},
+            },
+        )
+
+        assert resp.status_code == 200
+        forwarded = mock_stream.call_args.args[1]
+        assert forwarded["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert forwarded["output_config"] == {"effort": "xhigh"}
 
     def test_missing_model_returns_400(self, client):
         """Request without model field returns 400."""

--- a/tests/test_thinking_budget_config.py
+++ b/tests/test_thinking_budget_config.py
@@ -1,6 +1,6 @@
 """Tests for configurable thinking budget (Feature 4)."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -157,8 +157,8 @@ class TestResolveThinkingBudget:
         )
         assert budget == 28000
 
-    def test_adaptive_thinking_type_preserved(self):
-        """Adaptive thinking type is preserved through resolution."""
+    def test_adaptive_thinking_budget_is_preserved_internally(self):
+        """Adaptive budget remains an internal signal for provider effort mapping."""
         budget, ttype = resolve_thinking_budget(
             client_budget=10000,
             client_thinking_type="adaptive",
@@ -167,6 +167,17 @@ class TestResolveThinkingBudget:
         )
         assert budget == 10000
         assert ttype == "adaptive"
+
+    def test_enabled_thinking_removed_without_budget_headroom(self):
+        """Enabled thinking is removed atomically when no valid budget can fit."""
+        budget, ttype = resolve_thinking_budget(
+            client_budget=16000,
+            client_thinking_type="enabled",
+            model_id="test-model",
+            max_output_tokens=1024,
+        )
+        assert budget is None
+        assert ttype is None
 
 
 class TestChatRequestWithThinking:
@@ -280,6 +291,183 @@ class TestAnthropicRouteThinkingBudget:
         assert result.reasoning_effort == "xhigh"
         router.get_model_info.assert_not_called()
         resolver.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_effort_preserves_required_enabled_budget(self, monkeypatch):
+        """Effort may coexist with the budget required by manual enabled thinking."""
+        router = MagicMock()
+        router.get_model_info = AsyncMock(return_value=None)
+        resolver = MagicMock()
+        resolver.return_value = (4096, "enabled")
+        monkeypatch.setattr(anthropic_route, "resolve_thinking_budget", resolver)
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=64000,
+            thinking_budget=4096,
+            thinking_type="enabled",
+            reasoning_effort="xhigh",
+        )
+
+        result = await _apply_thinking_budget(router, request, "claude-opus-4-6")
+
+        assert result.thinking_budget == 4096
+        assert result.thinking_type == "enabled"
+        assert result.reasoning_effort == "xhigh"
+        resolver.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_explicit_effort_fills_missing_enabled_budget(self, monkeypatch):
+        """Manual enabled thinking remains valid when the client omits its budget."""
+        monkeypatch.setattr(
+            "router_maestro.config.load_priorities_config",
+            lambda: type(
+                "Config",
+                (),
+                {"thinking": ThinkingBudgetConfig(default_budget=16000, auto_enable=False)},
+            )(),
+        )
+        model_info = ModelInfo(
+            id="claude-opus-4.6",
+            name="Claude Opus 4.6",
+            provider="github-copilot",
+            max_output_tokens=64000,
+            supports_thinking=True,
+        )
+        router = Router.__new__(Router)
+        router.providers = {}
+        router._models_cache = {
+            "claude-opus-4.6": ("github-copilot", model_info),
+            "github-copilot/claude-opus-4.6": ("github-copilot", model_info),
+        }
+        router._models_cache_ttl = TTLCache(CACHE_TTL_SECONDS)
+        router._models_cache_ttl.set(True)
+        router._priorities_cache = TTLCache(CACHE_TTL_SECONDS)
+        router._fuzzy_cache = {}
+        router._providers_ttl = TTLCache(CACHE_TTL_SECONDS)
+        router._providers_ttl.set(True)
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=64000,
+            thinking_type="enabled",
+            reasoning_effort="xhigh",
+        )
+
+        result = await _apply_thinking_budget(router, request, "claude-opus-4-6")
+
+        assert result.thinking_budget == 16000
+        assert result.thinking_type == "enabled"
+        assert result.reasoning_effort == "xhigh"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("client_budget", "expected_budget"),
+        [(500, 1024), (63999, EFFORT_TO_BUDGET["max"])],
+    )
+    async def test_explicit_effort_normalizes_enabled_budget(
+        self, monkeypatch, client_budget, expected_budget
+    ):
+        """Manual budgets remain within Anthropic's accepted token range."""
+        monkeypatch.setattr(
+            "router_maestro.config.load_priorities_config",
+            lambda: type(
+                "Config",
+                (),
+                {"thinking": ThinkingBudgetConfig(default_budget=16000, auto_enable=False)},
+            )(),
+        )
+        model_info = ModelInfo(
+            id="claude-opus-4.6",
+            name="Claude Opus 4.6",
+            provider="github-copilot",
+            max_output_tokens=64000,
+            supports_thinking=True,
+        )
+        router = MagicMock()
+        router.get_model_info = AsyncMock(return_value=model_info)
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=64000,
+            thinking_budget=client_budget,
+            thinking_type="enabled",
+            reasoning_effort="xhigh",
+        )
+
+        result = await _apply_thinking_budget(router, request, "claude-opus-4-6")
+
+        assert result.thinking_budget == expected_budget
+        assert result.thinking_type == "enabled"
+        assert result.reasoning_effort == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_enabled_budget_is_capped_by_request_max_tokens(self, monkeypatch):
+        """Client max_tokens is the wire-level upper bound for manual thinking."""
+        monkeypatch.setattr(
+            "router_maestro.config.load_priorities_config",
+            lambda: type(
+                "Config",
+                (),
+                {"thinking": ThinkingBudgetConfig(default_budget=16000, auto_enable=False)},
+            )(),
+        )
+        model_info = ModelInfo(
+            id="claude-opus-4.6",
+            name="Claude Opus 4.6",
+            provider="github-copilot",
+            max_output_tokens=64000,
+            supports_thinking=True,
+        )
+        router = MagicMock()
+        router.get_model_info = AsyncMock(return_value=model_info)
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=4096,
+            thinking_budget=16000,
+            thinking_type="enabled",
+            reasoning_effort="xhigh",
+        )
+
+        result = await _apply_thinking_budget(router, request, "claude-opus-4-6")
+
+        assert result.thinking_budget == 4095
+        assert result.thinking_type == "enabled"
+
+    @pytest.mark.asyncio
+    async def test_enabled_thinking_is_removed_without_budget_headroom(self, monkeypatch):
+        """Never emit enabled thinking when max_tokens cannot fit the minimum budget."""
+        monkeypatch.setattr(
+            "router_maestro.config.load_priorities_config",
+            lambda: type(
+                "Config",
+                (),
+                {"thinking": ThinkingBudgetConfig(default_budget=16000, auto_enable=False)},
+            )(),
+        )
+        model_info = ModelInfo(
+            id="claude-opus-4.6",
+            name="Claude Opus 4.6",
+            provider="github-copilot",
+            max_output_tokens=64000,
+            supports_thinking=True,
+        )
+        router = MagicMock()
+        router.get_model_info = AsyncMock(return_value=model_info)
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=1024,
+            thinking_budget=16000,
+            thinking_type="enabled",
+            reasoning_effort="xhigh",
+        )
+
+        result = await _apply_thinking_budget(router, request, "claude-opus-4-6")
+
+        assert result.thinking_budget is None
+        assert result.thinking_type is None
 
     @pytest.mark.asyncio
     async def test_messages_logs_inbound_thinking_metadata(self, monkeypatch):

--- a/tests/test_thinking_passthrough.py
+++ b/tests/test_thinking_passthrough.py
@@ -383,7 +383,7 @@ class TestAnthropicProviderThinking:
         request = ChatRequest(
             model="claude-sonnet-4-20250514",
             messages=[Message(role="user", content="Hello")],
-            max_tokens=4096,
+            max_tokens=64000,
             thinking_type="enabled",
             thinking_budget=16000,
         )
@@ -436,6 +436,79 @@ class TestAnthropicProviderThinking:
 
         assert payload["thinking"] == {"type": "adaptive"}
         assert payload["output_config"] == {"effort": "xhigh"}
+
+    def test_anthropic_provider_omits_adaptive_budget_without_effort(self):
+        """Adaptive thinking is a type-only wire union even without effort."""
+        from router_maestro.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        request = ChatRequest(
+            model="claude-opus-4.8",
+            messages=[Message(role="user", content="Hello")],
+            max_tokens=64000,
+            thinking_type="adaptive",
+            thinking_budget=16000,
+        )
+
+        payload = provider._build_payload(request)
+
+        assert payload["thinking"] == {"type": "adaptive"}
+
+    def test_anthropic_provider_preserves_enabled_budget_with_effort(self):
+        """Manual thinking remains a valid enabled union when effort is present."""
+        from router_maestro.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="Hello")],
+            max_tokens=64000,
+            thinking_type="enabled",
+            thinking_budget=16000,
+            reasoning_effort="xhigh",
+        )
+
+        payload = provider._build_payload(request)
+
+        assert payload["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+        assert payload["output_config"] == {"effort": "xhigh"}
+
+    def test_anthropic_provider_omits_enabled_thinking_without_budget(self):
+        """Never emit the enabled union without its required budget."""
+        from router_maestro.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="Hello")],
+            max_tokens=1024,
+            thinking_type="enabled",
+            reasoning_effort="xhigh",
+        )
+
+        payload = provider._build_payload(request)
+
+        assert "thinking" not in payload
+        assert payload["output_config"] == {"effort": "xhigh"}
+
+    def test_anthropic_provider_caps_enabled_budget_to_payload_max_tokens(self):
+        """Provider normalization protects non-Anthropic entry routes too."""
+        from router_maestro.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider()
+        request = ChatRequest(
+            model="claude-opus-4.6",
+            messages=[Message(role="user", content="Hello")],
+            thinking_type="enabled",
+            thinking_budget=8192,
+            reasoning_effort="high",
+        )
+
+        payload = provider._build_payload(request)
+
+        assert payload["max_tokens"] == 4096
+        assert payload["thinking"] == {"type": "enabled", "budget_tokens": 4095}
+        assert payload["output_config"] == {"effort": "high"}
 
     @pytest.mark.asyncio
     async def test_anthropic_provider_omits_disabled_thinking(self):


### PR DESCRIPTION
## Summary

- preserve and normalize the required `budget_tokens` field when manual Anthropic thinking is combined with `output_config.effort`
- canonicalize enabled/adaptive/disabled thinking across standard Anthropic and Copilot beta-native paths, including request token caps and provider-level safeguards
- map beta-native Copilot effort values to each model catalog's advertised tiers, sharing the same selector used by chat and Responses

## Verification

- `uv run pytest tests/ -q` — 1048 passed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`
- live Copilot beta-native request: `claude-opus-4-6[1m]` + `thinking.type=enabled` + `budget_tokens=1024` + `effort=xhigh` returned HTTP 200 with thinking and text blocks
- independent code and protocol reviews: no remaining findings