### PR TITLE
chore: bump version to 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.5.4 (2026-07-10)
+
+### Fixes
+
+- **Anthropic manual thinking with effort.** Preserve and normalize the
+  protocol-required `thinking.budget_tokens` when `thinking.type="enabled"`
+  and `output_config.effort` are both present across standard and beta-native
+  routes. Copilot-native requests also map effort to the closest tier
+  advertised by the live model catalog, preventing unsupported values such as
+  Opus 4.6 `xhigh`.
+
+---
+
 ## v0.5.3 (2026-07-10)
 
 ### Changes
@@ -13,12 +26,6 @@ All notable changes to Router-Maestro are documented here.
   service and document the opt-in environment variable in `.env.example`.
 
 ### Fixes
-
-- **Anthropic manual thinking with effort.** Preserve `thinking.budget_tokens`
-  when `thinking.type="enabled"` and `output_config.effort` are both present,
-  avoiding invalid enabled-thinking payloads in standard and beta-native routes.
-  The Copilot beta-native path also maps effort to the closest tier advertised
-  by the model catalog, preventing unsupported values such as Opus 4.6 `xhigh`.
 
 - **Anthropic adaptive effort passthrough (#120).** Preserve typed
   `output_config.effort` through standard and beta-native Anthropic routes and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.5.3"
+version = "0.5.4"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1049,7 +1049,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- bump Router-Maestro from `0.5.3` to `0.5.4` in `pyproject.toml`, package `__version__`, and `uv.lock`
- add the `v0.5.4` changelog section for the Anthropic manual-thinking/effort compatibility fix
- move that fix note out of the already-published `v0.5.3` section

## Verification

- `uv run pytest tests/ -q` — 1048 passed
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`
- `uv build` — generated `router_maestro-0.5.4.tar.gz` and `router_maestro-0.5.4-py3-none-any.whl`
- verified wheel and sdist metadata both report version `0.5.4`