### PR TITLE
fix: add gpt-5.6 Responses models

### DIFF
--- a/src/router_maestro/utils/responses_bridge.py
+++ b/src/router_maestro/utils/responses_bridge.py
@@ -43,7 +43,9 @@ RESPONSES_ELIGIBLE_MODELS: frozenset[str] = frozenset(
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.5",
-        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5-mini",
     }
 )
@@ -62,8 +64,7 @@ def _bare_model(model: str) -> str:
 def is_model_responses_eligible(model: str) -> bool:
     """Whether the upstream serves this model via /responses."""
     bare = _bare_model(model)
-    # Exact match in allowlist, or any gpt-5.6-* variant (hyphenated suffix).
-    return bare in RESPONSES_ELIGIBLE_MODELS or bare.startswith("gpt-5.6-")
+    return bare in RESPONSES_ELIGIBLE_MODELS
 
 
 def should_use_responses_for_chat(request: ChatRequest, provider_name: str) -> bool:

--- a/src/router_maestro/utils/responses_bridge.py
+++ b/src/router_maestro/utils/responses_bridge.py
@@ -43,6 +43,7 @@ RESPONSES_ELIGIBLE_MODELS: frozenset[str] = frozenset(
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.5",
+        "gpt-5.6",
         "gpt-5-mini",
     }
 )
@@ -60,7 +61,9 @@ def _bare_model(model: str) -> str:
 
 def is_model_responses_eligible(model: str) -> bool:
     """Whether the upstream serves this model via /responses."""
-    return _bare_model(model) in RESPONSES_ELIGIBLE_MODELS
+    bare = _bare_model(model)
+    # Exact match in allowlist, or any gpt-5.6-* variant (hyphenated suffix).
+    return bare in RESPONSES_ELIGIBLE_MODELS or bare.startswith("gpt-5.6-")
 
 
 def should_use_responses_for_chat(request: ChatRequest, provider_name: str) -> bool:

--- a/tests/test_responses_bridge.py
+++ b/tests/test_responses_bridge.py
@@ -57,11 +57,16 @@ class TestModelEligibility:
             "gpt-5.2",
             "gpt-5.4",
             "gpt-5.5",
+            "gpt-5.6",
             "gpt-5-mini",
             "gpt-5.4-mini",
             "gpt-5.2-codex",
             "gpt-5.3-codex",
+            "gpt-5.6-codex",
+            "gpt-5.6-sol",
             "github-copilot/gpt-5.4",  # provider prefix
+            "github-copilot/gpt-5.6",
+            "github-copilot/gpt-5.6-sol",
         ],
     )
     def test_eligible(self, model):
@@ -75,7 +80,12 @@ class TestModelEligibility:
             "gemini-3.1-pro-preview",
             "gpt-4.1",
             "gpt-4o",
+            "gpt-5.60",
+            "gpt-5.60-sol",
+            "gpt-5.6sol",
             "github-copilot/claude-opus-4.6",
+            "github-copilot/gpt-5.60",
+            "github-copilot/gpt-5.6sol",
         ],
     )
     def test_ineligible(self, model):

--- a/tests/test_responses_bridge.py
+++ b/tests/test_responses_bridge.py
@@ -57,16 +57,17 @@ class TestModelEligibility:
             "gpt-5.2",
             "gpt-5.4",
             "gpt-5.5",
-            "gpt-5.6",
             "gpt-5-mini",
             "gpt-5.4-mini",
             "gpt-5.2-codex",
             "gpt-5.3-codex",
-            "gpt-5.6-codex",
             "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
             "github-copilot/gpt-5.4",  # provider prefix
-            "github-copilot/gpt-5.6",
             "github-copilot/gpt-5.6-sol",
+            "github-copilot/gpt-5.6-terra",
+            "github-copilot/gpt-5.6-luna",
         ],
     )
     def test_eligible(self, model):
@@ -80,10 +81,14 @@ class TestModelEligibility:
             "gemini-3.1-pro-preview",
             "gpt-4.1",
             "gpt-4o",
+            "gpt-5.6",  # bare gpt-5.6 is NOT eligible (exact-only)
+            "gpt-5.6-codex",  # gpt-5.6-codex is NOT eligible (exact-only)
+            "gpt-5.6-other",  # unlisted gpt-5.6 variant is NOT eligible
             "gpt-5.60",
             "gpt-5.60-sol",
             "gpt-5.6sol",
             "github-copilot/claude-opus-4.6",
+            "github-copilot/gpt-5.6",  # provider-prefixed bare gpt-5.6 is NOT eligible
             "github-copilot/gpt-5.60",
             "github-copilot/gpt-5.6sol",
         ],


### PR DESCRIPTION
## Summary
- add exact Copilot Responses eligibility for gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna
- preserve provider-prefix stripping and all existing eligible models
- keep bare gpt-5.6, gpt-5.6-codex, and unlisted variants ineligible

## Testing
- uv run pytest tests/test_responses_bridge.py::TestModelEligibility -v (29 passed)
- uv run pytest tests/test_responses_bridge.py -q (147 passed)
- uv run ruff check src/router_maestro/utils/responses_bridge.py tests/test_responses_bridge.py