### PR TITLE
refactor: harden runtime state and request lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Following XDG Base Directory specification:
 | | `priorities.json` | Model priorities and fallback |
 | | `contexts.json` | Deployment contexts |
 | **Data** | `~/.local/share/router-maestro/` | |
-| | `auth.json` | OAuth tokens |
+| | `auth.json` | Provider OAuth and API-key credentials |
 | | `server.json` | Legacy server state; current server API keys are stored in `contexts.json` |
 
 ### Custom Providers
@@ -482,17 +482,36 @@ Add OpenAI-compatible providers in `~/.config/router-maestro/providers.json`:
       "models": {
         "llama3": {"name": "Llama 3"},
         "mistral": {"name": "Mistral 7B"}
+      },
+      "options": {
+        "allow_unauthenticated": true
       }
     }
   }
 }
 ```
 
-Set API keys via environment variables (uppercase, hyphens → underscores):
+Custom-provider credentials are resolved in this order:
+
+1. A non-empty environment variable. By default its name is the provider ID in
+   uppercase with punctuation replaced by underscores, followed by `_API_KEY`.
+2. An API key saved in Router-Maestro's credential repository with
+   `router-maestro auth login <provider>`.
+3. No credential, only when `options.allow_unauthenticated` is explicitly
+   `true`. Anonymous requests do not include an `Authorization` header.
+
+For example, `ollama` uses `OLLAMA_API_KEY` and `my-provider` uses
+`MY_PROVIDER_API_KEY`:
 
 ```bash
 export OLLAMA_API_KEY="sk-..."
 ```
+
+Set `options.api_key_env` to a valid environment-variable name when a provider
+needs a different name. Provider definitions and their authentication
+requirements are obtained from the active server, so the same login command
+works for local and remote contexts. Only a local context may fall back to the
+local `providers.json` while its server is unavailable.
 
 ### Hot-Reload
 

--- a/src/router_maestro/auth/__init__.py
+++ b/src/router_maestro/auth/__init__.py
@@ -1,18 +1,32 @@
 """Auth module for router-maestro."""
 
+from router_maestro.auth.discovery import (
+    BUILTIN_PROVIDER_AUTH_DEFINITIONS,
+    ProviderAuthDefinition,
+    ProviderAuthSource,
+    provider_auth_definitions,
+)
 from router_maestro.auth.manager import AuthManager, run_async
+from router_maestro.auth.repository import CredentialRepository
 from router_maestro.auth.storage import (
     ApiKeyCredential,
     AuthStorage,
     AuthType,
+    Credential,
     OAuthCredential,
 )
 
 __all__ = [
     "AuthManager",
+    "CredentialRepository",
     "AuthStorage",
     "AuthType",
+    "Credential",
     "OAuthCredential",
     "ApiKeyCredential",
     "run_async",
+    "ProviderAuthDefinition",
+    "ProviderAuthSource",
+    "BUILTIN_PROVIDER_AUTH_DEFINITIONS",
+    "provider_auth_definitions",
 ]

--- a/src/router_maestro/auth/discovery.py
+++ b/src/router_maestro/auth/discovery.py
@@ -1,0 +1,95 @@
+"""Shared definitions for provider authentication discovery."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from router_maestro.auth.storage import AuthType
+from router_maestro.config.providers import ProvidersConfig, default_custom_api_key_env
+
+
+class ProviderAuthSource(StrEnum):
+    """Origin of a provider authentication definition."""
+
+    BUILTIN = "builtin"
+    CUSTOM = "custom"
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAuthDefinition:
+    """Non-secret information needed to present one provider login flow."""
+
+    provider: str
+    display_name: str
+    auth_type: AuthType
+    credential_required: bool
+    source: ProviderAuthSource
+    api_key_env: str | None = None
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> ProviderAuthDefinition:
+        """Validate a server discovery record at the CLI boundary."""
+        required = value.get("credential_required")
+        if not isinstance(required, bool):
+            raise TypeError("credential_required must be a boolean")
+        api_key_env = value.get("api_key_env")
+        if api_key_env is not None and not isinstance(api_key_env, str):
+            raise TypeError("api_key_env must be a string or null")
+        return cls(
+            provider=str(value["provider"]),
+            display_name=str(value["display_name"]),
+            auth_type=AuthType(value["auth_type"]),
+            credential_required=required,
+            source=ProviderAuthSource(value["source"]),
+            api_key_env=api_key_env,
+        )
+
+
+BUILTIN_PROVIDER_AUTH_DEFINITIONS = (
+    ProviderAuthDefinition(
+        provider="github-copilot",
+        display_name="GitHub Copilot",
+        auth_type=AuthType.OAUTH,
+        credential_required=True,
+        source=ProviderAuthSource.BUILTIN,
+    ),
+    ProviderAuthDefinition(
+        provider="openai",
+        display_name="OpenAI",
+        auth_type=AuthType.API_KEY,
+        credential_required=True,
+        source=ProviderAuthSource.BUILTIN,
+    ),
+    ProviderAuthDefinition(
+        provider="anthropic",
+        display_name="Anthropic",
+        auth_type=AuthType.API_KEY,
+        credential_required=True,
+        source=ProviderAuthSource.BUILTIN,
+    ),
+)
+
+
+def provider_auth_definitions(
+    config: ProvidersConfig,
+) -> tuple[ProviderAuthDefinition, ...]:
+    """Return stable builtin-first definitions for one server configuration."""
+    custom = []
+    for provider_name in sorted(config.providers, key=str.casefold):
+        provider = config.providers[provider_name]
+        custom.append(
+            ProviderAuthDefinition(
+                provider=provider_name,
+                display_name=provider_name,
+                auth_type=AuthType.API_KEY,
+                credential_required=not provider.options.allow_unauthenticated,
+                source=ProviderAuthSource.CUSTOM,
+                api_key_env=(
+                    provider.options.api_key_env or default_custom_api_key_env(provider_name)
+                ),
+            )
+        )
+    return (*BUILTIN_PROVIDER_AUTH_DEFINITIONS, *custom)

--- a/src/router_maestro/auth/manager.py
+++ b/src/router_maestro/auth/manager.py
@@ -11,43 +11,92 @@ from router_maestro.auth.github_oauth import (
     poll_access_token,
     request_device_code,
 )
+from router_maestro.auth.repository import CredentialRepository
 from router_maestro.auth.storage import (
     ApiKeyCredential,
     AuthStorage,
+    Credential,
     OAuthCredential,
 )
 
 console = Console()
 
 
+class _RepositoryStorageAdapter:
+    """Compatibility surface for callers not yet migrated off ``manager.storage``."""
+
+    def __init__(self, repository: CredentialRepository) -> None:
+        self._repository = repository
+
+    def get(self, provider: str) -> Credential | None:
+        return self._repository.get_provider(provider)
+
+    def set(self, provider: str, credential: Credential) -> None:
+        self._repository.update_provider(provider, credential)
+
+    def remove(self, provider: str) -> bool:
+        return self._repository.remove_provider(provider)
+
+    def list_providers(self) -> list[str]:
+        return self._repository.list_providers()
+
+    def save(self) -> None:
+        """Mutations are already persisted atomically by ``set`` and ``remove``."""
+
+
 class AuthManager:
     """Manager for authentication with various providers."""
 
-    def __init__(self) -> None:
-        self.storage = AuthStorage.load()
+    def __init__(self, repository: CredentialRepository | None = None) -> None:
+        self.repository = repository or CredentialRepository()
+        self._storage_adapter = _RepositoryStorageAdapter(self.repository)
+
+    @property
+    def storage(self) -> _RepositoryStorageAdapter | AuthStorage:
+        """Compatibility adapter; new code should use repository-backed methods."""
+        legacy = getattr(self, "_legacy_storage", None)
+        if legacy is not None:
+            return legacy
+        return self._storage_adapter
+
+    @storage.setter
+    def storage(self, storage: AuthStorage) -> None:
+        """Retain the existing in-memory injection seam used by provider tests."""
+        self._legacy_storage = storage
+
+    @property
+    def uses_legacy_storage(self) -> bool:
+        return getattr(self, "_legacy_storage", None) is not None
 
     def save(self) -> None:
-        """Save credentials to storage."""
-        self.storage.save()
+        """Flush explicitly injected legacy storage; repository writes are immediate."""
+        if self.uses_legacy_storage:
+            self.storage.save()
 
     def list_authenticated(self) -> list[str]:
         """List all authenticated providers."""
-        return self.storage.list_providers()
+        if self.uses_legacy_storage:
+            return self.storage.list_providers()
+        return self.repository.list_providers()
 
     def is_authenticated(self, provider: str) -> bool:
         """Check if a provider is authenticated."""
-        return self.storage.get(provider) is not None
+        return self.get_credential(provider) is not None
 
-    def get_credential(self, provider: str):
+    def get_credential(self, provider: str) -> Credential | None:
         """Get credential for a provider."""
-        return self.storage.get(provider)
+        if self.uses_legacy_storage:
+            return self.storage.get(provider)
+        return self.repository.get_provider(provider)
 
     def logout(self, provider: str) -> bool:
         """Log out from a provider."""
-        result = self.storage.remove(provider)
-        if result:
-            self.save()
-        return result
+        if self.uses_legacy_storage:
+            result = self.storage.remove(provider)
+            if result:
+                self.save()
+            return result
+        return self.repository.remove_provider(provider)
 
     async def login_copilot(self) -> bool:
         """Authenticate with GitHub Copilot using Device Flow.
@@ -100,16 +149,17 @@ class AuthManager:
                 return False
 
             # Step 5: Save credentials
-            self.storage.set(
-                "github-copilot",
-                OAuthCredential(
-                    refresh=access_token.access_token,  # GitHub token for refresh
-                    access=copilot_token.token,  # Copilot token for API calls
-                    expires=copilot_token.expires_at,
-                    api_endpoint=copilot_token.api_endpoint,
-                ),
+            credential = OAuthCredential(
+                refresh=access_token.access_token,  # GitHub token for refresh
+                access=copilot_token.token,  # Copilot token for API calls
+                expires=copilot_token.expires_at,
+                api_endpoint=copilot_token.api_endpoint,
             )
-            self.save()
+            if self.uses_legacy_storage:
+                self.storage.set("github-copilot", credential)
+                self.save()
+            else:
+                self.repository.update_provider("github-copilot", credential)
 
             console.print(
                 "[bold green]Successfully authenticated with GitHub Copilot![/bold green]"
@@ -126,8 +176,12 @@ class AuthManager:
         Returns:
             True if authentication was successful
         """
-        self.storage.set(provider, ApiKeyCredential(key=api_key))
-        self.save()
+        credential = ApiKeyCredential(key=api_key)
+        if self.uses_legacy_storage:
+            self.storage.set(provider, credential)
+            self.save()
+        else:
+            self.repository.update_provider(provider, credential)
         console.print(f"[green]Successfully saved API key for {provider}[/green]")
         return True
 

--- a/src/router_maestro/auth/repository.py
+++ b/src/router_maestro/auth/repository.py
@@ -57,3 +57,24 @@ class CredentialRepository:
                 return False
             storage.save(self.path)
             return True
+
+    def compare_and_swap_provider(
+        self,
+        provider: str,
+        *,
+        expected: Credential | None,
+        replacement: Credential | None,
+    ) -> bool:
+        """Conditionally replace one credential without disturbing concurrent writers."""
+        with self._lock:
+            storage = AuthStorage.load(self.path)
+            if storage.get(provider) != expected:
+                return False
+            if replacement is None:
+                if expected is None:
+                    return True
+                storage.remove(provider)
+            else:
+                storage.set(provider, replacement.model_copy(deep=True))
+            storage.save(self.path)
+            return True

--- a/src/router_maestro/auth/repository.py
+++ b/src/router_maestro/auth/repository.py
@@ -1,0 +1,59 @@
+"""Atomic, single-provider credential persistence."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from router_maestro.auth.storage import AuthStorage, Credential
+from router_maestro.config.paths import AUTH_FILE
+
+_LOCKS_GUARD = threading.Lock()
+_PATH_LOCKS: dict[Path, threading.RLock] = {}
+
+
+def _canonical_path(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _lock_for(path: Path) -> threading.RLock:
+    with _LOCKS_GUARD:
+        return _PATH_LOCKS.setdefault(path, threading.RLock())
+
+
+class CredentialRepository:
+    """Read the latest auth file and atomically patch one provider at a time."""
+
+    def __init__(self, path: Path = AUTH_FILE) -> None:
+        self.path = _canonical_path(path)
+        self._lock = _lock_for(self.path)
+
+    def read(self) -> AuthStorage:
+        """Return a defensive snapshot of the latest credential file."""
+        with self._lock:
+            return AuthStorage.load(self.path).model_copy(deep=True)
+
+    def get_provider(self, provider: str) -> Credential | None:
+        """Return a defensive copy of one provider credential."""
+        credential = self.read().get(provider)
+        return credential.model_copy(deep=True) if credential is not None else None
+
+    def list_providers(self) -> list[str]:
+        """Return provider names from the latest credential file."""
+        return self.read().list_providers()
+
+    def update_provider(self, provider: str, credential: Credential) -> None:
+        """Read latest, replace one provider, and atomically persist the result."""
+        with self._lock:
+            storage = AuthStorage.load(self.path)
+            storage.set(provider, credential.model_copy(deep=True))
+            storage.save(self.path)
+
+    def remove_provider(self, provider: str) -> bool:
+        """Read latest and remove one provider without disturbing other entries."""
+        with self._lock:
+            storage = AuthStorage.load(self.path)
+            if not storage.remove(provider):
+                return False
+            storage.save(self.path)
+            return True

--- a/src/router_maestro/cli/auth.py
+++ b/src/router_maestro/cli/auth.py
@@ -1,8 +1,8 @@
 """Authentication management commands."""
 
 import asyncio
-from collections.abc import Callable
-from typing import Protocol
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Protocol
 
 import typer
 from rich.console import Console
@@ -10,30 +10,24 @@ from rich.prompt import Prompt
 from rich.table import Table
 
 from router_maestro.auth.discovery import (
-    BUILTIN_PROVIDER_AUTH_DEFINITIONS,
     ProviderAuthDefinition,
     provider_auth_definitions,
 )
 from router_maestro.cli.client import AdminClient, ServerNotRunningError, get_admin_client
+from router_maestro.config import load_contexts_config
 from router_maestro.config.providers import ProvidersConfig
 from router_maestro.config.settings import load_providers_config
 
 app = typer.Typer(no_args_is_help=True)
 console = Console()
 
-PROVIDERS = {
-    definition.provider: {
-        "name": definition.display_name,
-        "auth_type": definition.auth_type.value,
-    }
-    for definition in BUILTIN_PROVIDER_AUTH_DEFINITIONS
-}
-
 
 class AuthProviderDiscoveryClient(Protocol):
     """Adapter supplied by the shared AdminClient integration."""
 
-    async def list_auth_providers(self) -> list[dict]: ...
+    async def list_auth_providers(
+        self,
+    ) -> Sequence[ProviderAuthDefinition | Mapping[str, Any]]: ...
 
 
 async def discover_auth_providers(
@@ -73,6 +67,15 @@ def login(
     """Authenticate with a provider (interactive selection if not specified)."""
     client = get_admin_client()
 
+    try:
+        context_name = load_contexts_config().current
+        definitions = asyncio.run(discover_auth_providers(client, context_name=context_name))
+    except Exception as e:
+        _handle_server_error(e)
+        return
+
+    providers = {definition.provider: definition for definition in definitions}
+
     if provider is None:
         # Interactive selection - get current status from server
         try:
@@ -83,32 +86,36 @@ def login(
             return
 
         console.print("\n[bold]Available providers:[/bold]")
-        for i, (key, info) in enumerate(PROVIDERS.items(), 1):
-            status = "[green]✓[/green]" if key in auth_providers else "[dim]○[/dim]"
-            console.print(f"  {i}. {status} {info['name']} ({key})")
+        for i, definition in enumerate(definitions, 1):
+            status = "[green]✓[/green]" if definition.provider in auth_providers else "[dim]○[/dim]"
+            console.print(f"  {i}. {status} {definition.display_name} ({definition.provider})")
 
         console.print()
         choice = Prompt.ask(
             "Select provider",
-            choices=[str(i) for i in range(1, len(PROVIDERS) + 1)],
+            choices=[str(i) for i in range(1, len(definitions) + 1)],
         )
-        provider = list(PROVIDERS.keys())[int(choice) - 1]
+        provider = definitions[int(choice) - 1].provider
 
-    if provider not in PROVIDERS:
+    if provider not in providers:
         console.print(f"[red]Unknown provider: {provider}[/red]")
-        console.print(f"[dim]Available: {', '.join(PROVIDERS.keys())}[/dim]")
+        console.print(f"[dim]Available: {', '.join(providers)}[/dim]")
         raise typer.Exit(1)
 
-    provider_info = PROVIDERS[provider]
-    console.print(f"\n[bold]Authenticating with {provider_info['name']}...[/bold]\n")
+    provider_info = providers[provider]
+    console.print(f"\n[bold]Authenticating with {provider_info.display_name}...[/bold]\n")
 
     asyncio.run(_do_login(client, provider, provider_info))
 
 
-async def _do_login(client: AdminClient, provider: str, provider_info: dict) -> None:
+async def _do_login(
+    client: AdminClient,
+    provider: str,
+    provider_info: ProviderAuthDefinition,
+) -> None:
     """Handle authentication flow via HTTP API."""
     try:
-        if provider_info["auth_type"] == "oauth":
+        if provider_info.auth_type.value == "oauth":
             # OAuth device flow
             result = await client.login_oauth(provider)
 
@@ -137,7 +144,7 @@ async def _do_login(client: AdminClient, provider: str, provider_info: dict) -> 
                 # status == "pending" - continue polling
         else:
             # API key auth
-            api_key = Prompt.ask(f"Enter API key for {provider_info['name']}", password=True)
+            api_key = Prompt.ask(f"Enter API key for {provider_info.display_name}", password=True)
             if not api_key:
                 console.print("[red]API key cannot be empty[/red]")
                 raise typer.Exit(1)

--- a/src/router_maestro/cli/auth.py
+++ b/src/router_maestro/cli/auth.py
@@ -1,22 +1,60 @@
 """Authentication management commands."""
 
 import asyncio
+from collections.abc import Callable
+from typing import Protocol
 
 import typer
 from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
 
+from router_maestro.auth.discovery import (
+    BUILTIN_PROVIDER_AUTH_DEFINITIONS,
+    ProviderAuthDefinition,
+    provider_auth_definitions,
+)
 from router_maestro.cli.client import AdminClient, ServerNotRunningError, get_admin_client
+from router_maestro.config.providers import ProvidersConfig
+from router_maestro.config.settings import load_providers_config
 
 app = typer.Typer(no_args_is_help=True)
 console = Console()
 
 PROVIDERS = {
-    "github-copilot": {"name": "GitHub Copilot", "auth_type": "oauth"},
-    "openai": {"name": "OpenAI", "auth_type": "api"},
-    "anthropic": {"name": "Anthropic", "auth_type": "api"},
+    definition.provider: {
+        "name": definition.display_name,
+        "auth_type": definition.auth_type.value,
+    }
+    for definition in BUILTIN_PROVIDER_AUTH_DEFINITIONS
 }
+
+
+class AuthProviderDiscoveryClient(Protocol):
+    """Adapter supplied by the shared AdminClient integration."""
+
+    async def list_auth_providers(self) -> list[dict]: ...
+
+
+async def discover_auth_providers(
+    client: AuthProviderDiscoveryClient,
+    *,
+    context_name: str,
+    load_local_config: Callable[[], ProvidersConfig] = load_providers_config,
+) -> tuple[ProviderAuthDefinition, ...]:
+    """Prefer server definitions; only local connection failure may use local config."""
+    try:
+        records = await client.list_auth_providers()
+    except ServerNotRunningError:
+        if context_name != "local":
+            raise
+        return provider_auth_definitions(load_local_config())
+    return tuple(
+        record
+        if isinstance(record, ProviderAuthDefinition)
+        else ProviderAuthDefinition.from_mapping(record)
+        for record in records
+    )
 
 
 def _handle_server_error(e: Exception) -> None:

--- a/src/router_maestro/cli/client.py
+++ b/src/router_maestro/cli/client.py
@@ -25,6 +25,14 @@ class ServerNotRunningError(AdminClientError):
         )
 
 
+class AdminConfigConflictError(AdminClientError):
+    """A runtime configuration mutation used a stale content revision."""
+
+    def __init__(self, current_revision: str | None) -> None:
+        self.current_revision = current_revision
+        super().__init__("Runtime configuration changed; refresh and retry")
+
+
 class AdminClient:
     """HTTP client for server admin operations.
 
@@ -214,6 +222,35 @@ class AdminClient:
             self._handle_connection_error(e)
             return {}
 
+    async def get_runtime_config(self) -> dict:
+        """Get the complete versioned runtime configuration."""
+        return await self.get_priorities()
+
+    async def patch_runtime_config(self, *, config: dict, revision: str) -> dict:
+        """Replace runtime configuration when revision is still current."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.patch(
+                    f"{self.endpoint}/api/admin/priorities",
+                    headers=self._get_headers(),
+                    json={**config, "revision": revision},
+                )
+                if response.status_code == 409:
+                    current_revision = None
+                    try:
+                        detail = response.json().get("detail", {})
+                        current_revision = detail.get("current_revision")
+                    except (TypeError, ValueError):
+                        pass
+                    raise AdminConfigConflictError(current_revision)
+                response.raise_for_status()
+                return response.json()
+        except AdminConfigConflictError:
+            raise
+        except httpx.HTTPError as e:
+            self._handle_connection_error(e)
+            return {}
+
     async def set_priorities(self, priorities: list[str], fallback: dict | None = None) -> bool:
         """Set priority configuration.
 
@@ -224,22 +261,13 @@ class AdminClient:
         Returns:
             True if successful
         """
-        try:
-            async with httpx.AsyncClient() as client:
-                payload: dict = {"priorities": priorities}
-                if fallback is not None:
-                    payload["fallback"] = fallback
-
-                response = await client.put(
-                    f"{self.endpoint}/api/admin/priorities",
-                    headers=self._get_headers(),
-                    json=payload,
-                )
-                response.raise_for_status()
-                return True
-        except httpx.HTTPError as e:
-            self._handle_connection_error(e)
-            return False
+        current = await self.get_runtime_config()
+        revision = current.pop("revision")
+        current["priorities"] = priorities
+        if fallback is not None:
+            current["fallback"] = fallback
+        await self.patch_runtime_config(config=current, revision=revision)
+        return True
 
     async def test_connection(self) -> dict:
         """Test connection to the server.

--- a/src/router_maestro/cli/client.py
+++ b/src/router_maestro/cli/client.py
@@ -6,6 +6,7 @@ This ensures consistent behavior between local and remote contexts.
 
 import httpx
 
+from router_maestro.auth.discovery import ProviderAuthDefinition
 from router_maestro.config import load_contexts_config
 
 
@@ -75,6 +76,21 @@ class AdminClient:
         except httpx.HTTPError as e:
             self._handle_connection_error(e)
             return []  # unreachable, for type checker
+
+    async def list_auth_providers(self) -> tuple[ProviderAuthDefinition, ...]:
+        """List typed provider authentication definitions exposed by the server."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.endpoint}/api/admin/auth/providers",
+                    headers=self._get_headers(),
+                )
+                response.raise_for_status()
+                records = response.json().get("providers", [])
+                return tuple(ProviderAuthDefinition.from_mapping(record) for record in records)
+        except httpx.HTTPError as e:
+            self._handle_connection_error(e)
+            return ()  # unreachable, for type checker
 
     async def login_oauth(self, provider: str) -> dict:
         """Initiate OAuth login.

--- a/src/router_maestro/cli/model.py
+++ b/src/router_maestro/cli/model.py
@@ -140,10 +140,9 @@ def priority_add(
     client = get_admin_client()
 
     try:
-        # Get current priorities
-        data = asyncio.run(client.get_priorities())
+        data = asyncio.run(client.get_runtime_config())
+        revision = data.pop("revision")
         priorities = data.get("priorities", [])
-        fallback = data.get("fallback")
 
         # Remove if already exists
         if model_key in priorities:
@@ -156,8 +155,8 @@ def priority_add(
             pos = position - 1  # Convert 1-based to 0-based
             priorities.insert(pos, model_key)
 
-        # Save
-        asyncio.run(client.set_priorities(priorities, fallback))
+        data["priorities"] = priorities
+        asyncio.run(client.patch_runtime_config(config=data, revision=revision))
 
         if position:
             console.print(f"[green]Added '{model_key}' at position {position}[/green]")
@@ -180,14 +179,14 @@ def priority_remove(
     client = get_admin_client()
 
     try:
-        # Get current priorities
-        data = asyncio.run(client.get_priorities())
+        data = asyncio.run(client.get_runtime_config())
+        revision = data.pop("revision")
         priorities = data.get("priorities", [])
-        fallback = data.get("fallback")
 
         if model_key in priorities:
             priorities.remove(model_key)
-            asyncio.run(client.set_priorities(priorities, fallback))
+            data["priorities"] = priorities
+            asyncio.run(client.patch_runtime_config(config=data, revision=revision))
             console.print(f"[green]Removed '{model_key}' from priority list[/green]")
         else:
             console.print(f"[yellow]'{model_key}' was not in the priority list[/yellow]")
@@ -202,9 +201,10 @@ def priority_clear() -> None:
     client = get_admin_client()
 
     try:
-        data = asyncio.run(client.get_priorities())
-        fallback = data.get("fallback")
-        asyncio.run(client.set_priorities([], fallback))
+        data = asyncio.run(client.get_runtime_config())
+        revision = data.pop("revision")
+        data["priorities"] = []
+        asyncio.run(client.patch_runtime_config(config=data, revision=revision))
         console.print("[green]Cleared all priorities[/green]")
     except Exception as e:
         _handle_server_error(e)
@@ -270,9 +270,8 @@ def fallback_set(
     client = get_admin_client()
 
     try:
-        # Get current config
-        data = asyncio.run(client.get_priorities())
-        priorities = data.get("priorities", [])
+        data = asyncio.run(client.get_runtime_config())
+        revision = data.pop("revision")
         fallback = data.get("fallback", {})
 
         # Update fallback config
@@ -281,8 +280,8 @@ def fallback_set(
         if max_retries is not None:
             fallback["maxRetries"] = max_retries
 
-        # Save
-        asyncio.run(client.set_priorities(priorities, fallback))
+        data["fallback"] = fallback
+        asyncio.run(client.patch_runtime_config(config=data, revision=revision))
 
         console.print("[green]Fallback configuration updated[/green]")
 

--- a/src/router_maestro/config/__init__.py
+++ b/src/router_maestro/config/__init__.py
@@ -23,6 +23,11 @@ from router_maestro.config.providers import (
     ModelConfig,
     ProvidersConfig,
 )
+from router_maestro.config.repository import (
+    RuntimeConfigConflictError,
+    RuntimeConfigRepository,
+    RuntimeConfigSnapshot,
+)
 from router_maestro.config.server import (
     get_current_context_api_key,
     get_or_create_api_key,
@@ -57,6 +62,9 @@ __all__ = [
     "FallbackStrategy",
     "ModelOverride",
     "ThinkingBudgetConfig",
+    "RuntimeConfigConflictError",
+    "RuntimeConfigRepository",
+    "RuntimeConfigSnapshot",
     # Context models
     "ContextConfig",
     "ContextsConfig",

--- a/src/router_maestro/config/providers.py
+++ b/src/router_maestro/config/providers.py
@@ -1,10 +1,19 @@
 """Provider and model configuration models."""
 
-from typing import Any
+import re
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from router_maestro.routing.model_ref import validate_provider_id
+
+
+def default_custom_api_key_env(provider: str) -> str:
+    """Derive ``MY_PROVIDER_API_KEY`` from one public provider identifier."""
+    validate_provider_id(provider)
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", provider).strip("_").upper()
+    if not normalized:
+        raise ValueError("provider ID must contain a letter or digit for env-key derivation")
+    return f"{normalized}_API_KEY"
 
 
 class ModelConfig(BaseModel):
@@ -13,13 +22,32 @@ class ModelConfig(BaseModel):
     name: str = Field(default="", description="Display name for the model")
 
 
+class CustomProviderOptions(BaseModel):
+    """Runtime options supported by an OpenAI-compatible custom provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_key_env: str | None = Field(
+        default=None,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+        description="Environment variable that may supply the provider API key",
+    )
+    allow_unauthenticated: bool = Field(
+        default=False,
+        description="Permit requests without an Authorization header",
+    )
+
+
 class CustomProviderConfig(BaseModel):
     """Configuration for a custom (OpenAI-compatible) provider."""
 
     type: str = Field(default="openai-compatible", description="Provider type")
     baseURL: str = Field(..., description="Base URL for API requests")  # noqa: N815
     models: dict[str, ModelConfig] = Field(default_factory=dict, description="Model configurations")
-    options: dict[str, Any] = Field(default_factory=dict, description="Additional provider options")
+    options: CustomProviderOptions = Field(
+        default_factory=CustomProviderOptions,
+        description="Typed provider runtime options",
+    )
 
 
 class ProvidersConfig(BaseModel):

--- a/src/router_maestro/config/providers.py
+++ b/src/router_maestro/config/providers.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from router_maestro.routing.model_ref import validate_provider_id
 
+RESERVED_PROVIDER_NAMES = frozenset({"github-copilot", "openai", "anthropic"})
+
 
 def default_custom_api_key_env(provider: str) -> str:
     """Derive ``MY_PROVIDER_API_KEY`` from one public provider identifier."""
@@ -69,6 +71,10 @@ class ProvidersConfig(BaseModel):
         for provider_name in providers:
             validate_provider_id(provider_name)
             canonical_name = provider_name.casefold()
+            if canonical_name in RESERVED_PROVIDER_NAMES:
+                raise ValueError(
+                    f"provider name '{provider_name}' is reserved for a built-in provider"
+                )
             duplicate = canonical_names.get(canonical_name)
             if duplicate is not None:
                 raise ValueError(

--- a/src/router_maestro/config/repository.py
+++ b/src/router_maestro/config/repository.py
@@ -1,0 +1,135 @@
+"""Versioned runtime configuration snapshots and persistence."""
+
+import hashlib
+import json
+import os
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from router_maestro.config.paths import PRIORITIES_FILE
+from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.config.settings import load_config, write_json_owner_only
+
+_LOCK_REGISTRY_GUARD = threading.Lock()
+_LOCKS_BY_PATH: dict[str, threading.RLock] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeConfigSnapshot:
+    """An immutable serialized runtime configuration at one content revision."""
+
+    revision: str
+    canonical_json: bytes = field(repr=False)
+
+    @property
+    def config(self) -> PrioritiesConfig:
+        """Return a fresh validated model for this snapshot."""
+        return PrioritiesConfig.model_validate_json(self.canonical_json)
+
+
+class RuntimeConfigConflictError(RuntimeError):
+    """Raised when a compare-and-swap uses a stale revision."""
+
+    expected_revision: str
+    current_revision: str
+
+    def __init__(
+        self,
+        *,
+        expected_revision: str,
+        current_revision: str,
+    ) -> None:
+        self.expected_revision = expected_revision
+        self.current_revision = current_revision
+        super().__init__(
+            "Runtime configuration revision conflict: "
+            f"expected {expected_revision}, current {current_revision}"
+        )
+
+
+def canonical_runtime_config_bytes(config: PrioritiesConfig) -> bytes:
+    """Serialize validated runtime configuration into stable canonical JSON."""
+    validated = PrioritiesConfig.model_validate(config.model_dump(mode="json"))
+    payload = validated.model_dump(
+        mode="json",
+        exclude_none=False,
+        exclude_defaults=False,
+    )
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def runtime_config_revision(canonical_json: bytes) -> str:
+    """Return the SHA-256 content revision for canonical configuration bytes."""
+    return hashlib.sha256(canonical_json).hexdigest()
+
+
+def _lock_key(path: Path) -> str:
+    return os.path.normcase(str(path.expanduser().resolve(strict=False)))
+
+
+def _lock_for_path(path: Path) -> threading.RLock:
+    key = _lock_key(path)
+    with _LOCK_REGISTRY_GUARD:
+        return _LOCKS_BY_PATH.setdefault(key, threading.RLock())
+
+
+def _snapshot(config: PrioritiesConfig) -> RuntimeConfigSnapshot:
+    canonical_json = canonical_runtime_config_bytes(config)
+    return RuntimeConfigSnapshot(
+        revision=runtime_config_revision(canonical_json),
+        canonical_json=canonical_json,
+    )
+
+
+class RuntimeConfigRepository:
+    """Coordinate in-process reads and atomic writes of runtime configuration."""
+
+    def __init__(self, path: Path = PRIORITIES_FILE) -> None:
+        self.path = path
+        self._lock = _lock_for_path(path)
+
+    def read(self) -> RuntimeConfigSnapshot:
+        """Read and validate the latest runtime configuration snapshot."""
+        with self._lock:
+            config = load_config(self.path, PrioritiesConfig, PrioritiesConfig.get_default)
+            return _snapshot(config)
+
+    def compare_and_swap(
+        self,
+        *,
+        expected_revision: str,
+        replacement: PrioritiesConfig,
+    ) -> RuntimeConfigSnapshot:
+        """Persist replacement only when expected_revision is still current."""
+        replacement_snapshot = _snapshot(replacement)
+        with self._lock:
+            current = self.read()
+            if current.revision != expected_revision:
+                raise RuntimeConfigConflictError(
+                    expected_revision=expected_revision,
+                    current_revision=current.revision,
+                )
+            if current.canonical_json == replacement_snapshot.canonical_json:
+                return current
+            write_json_owner_only(
+                self.path,
+                json.loads(replacement_snapshot.canonical_json),
+            )
+            return replacement_snapshot
+
+    def write_compat(self, replacement: PrioritiesConfig) -> RuntimeConfigSnapshot:
+        """Persist replacement with legacy last-writer-wins behavior."""
+        replacement_snapshot = _snapshot(replacement)
+        with self._lock:
+            write_json_owner_only(
+                self.path,
+                json.loads(replacement_snapshot.canonical_json),
+            )
+            return replacement_snapshot

--- a/src/router_maestro/config/repository.py
+++ b/src/router_maestro/config/repository.py
@@ -101,6 +101,10 @@ class RuntimeConfigRepository:
             config = load_config(self.path, PrioritiesConfig, PrioritiesConfig.get_default)
             return _snapshot(config)
 
+    def prepare(self, replacement: PrioritiesConfig) -> RuntimeConfigSnapshot:
+        """Validate and canonicalize a candidate without persisting it."""
+        return _snapshot(replacement)
+
     def compare_and_swap(
         self,
         *,

--- a/src/router_maestro/config/settings.py
+++ b/src/router_maestro/config/settings.py
@@ -107,12 +107,16 @@ def save_providers_config(config: ProvidersConfig) -> None:
 
 def load_priorities_config() -> PrioritiesConfig:
     """Load priorities configuration."""
-    return load_config(PRIORITIES_FILE, PrioritiesConfig, PrioritiesConfig.get_default)
+    from router_maestro.config.repository import RuntimeConfigRepository
+
+    return RuntimeConfigRepository(PRIORITIES_FILE).read().config
 
 
 def save_priorities_config(config: PrioritiesConfig) -> None:
     """Save priorities configuration."""
-    save_config(PRIORITIES_FILE, config)
+    from router_maestro.config.repository import RuntimeConfigRepository
+
+    RuntimeConfigRepository(PRIORITIES_FILE).write_compat(config)
 
 
 def load_contexts_config() -> ContextsConfig:

--- a/src/router_maestro/pipeline/leak_guard.py
+++ b/src/router_maestro/pipeline/leak_guard.py
@@ -259,8 +259,13 @@ class RawFrameLeakGuard:
     content_block_delta events and feeds them to an inner LeakGuard.
     """
 
-    def __init__(self, allowed_tool_names: set[str] | None = None):
-        self._inner = LeakGuard(allowed_tool_names=allowed_tool_names)
+    def __init__(
+        self,
+        allowed_tool_names: set[str] | None = None,
+        *,
+        inner: LeakGuard | None = None,
+    ):
+        self._inner = inner or LeakGuard(allowed_tool_names=allowed_tool_names)
 
     def feed_frame(self, event_type: str, data_str: str) -> str | None:
         """Feed a raw SSE frame. Returns abort reason if leak detected."""

--- a/src/router_maestro/pipeline/request_pipeline.py
+++ b/src/router_maestro/pipeline/request_pipeline.py
@@ -50,6 +50,7 @@ class RequestPipeline:
         "_outcome",
         "_wire_status",
         "_request_id",
+        "_defer_flush",
     )
 
     def __init__(
@@ -59,6 +60,8 @@ class RequestPipeline:
         leak_guard: LeakGuard | None,
         audit: AuditTrace | None,
         config: PrioritiesConfig,
+        *,
+        defer_flush: bool = False,
     ):
         self._request_id = request_id
         self._guards = guards
@@ -68,6 +71,7 @@ class RequestPipeline:
         self._finished = False
         self._outcome: TerminalOutcome | None = None
         self._wire_status: int | None = None
+        self._defer_flush = defer_flush
 
     @classmethod
     def create(
@@ -77,7 +81,17 @@ class RequestPipeline:
         tool_names: set[str] | None = None,
     ) -> RequestPipeline:
         """Factory: build a pipeline from current configuration."""
-        config = load_priorities_config()
+        context = None
+        try:
+            from router_maestro.runtime.request_context import get_current_request_context
+
+            context = get_current_request_context()
+        except ImportError:
+            pass
+        if context is not None and context.pipeline is not None:
+            return context.pipeline
+
+        config = context.config if context is not None else load_priorities_config()
         guards_cfg = config.guards
 
         guards: list = []
@@ -95,18 +109,22 @@ class RequestPipeline:
                 )
             )
 
-        audit: AuditTrace | None = None
-        if is_tracing_enabled(config.audit.enabled):
+        audit = context.audit if context is not None else None
+        if context is None and is_tracing_enabled(config.audit.enabled):
             trace_dir = get_trace_dir(config.audit.trace_dir)
             audit = AuditTrace(request_id, trace_dir)
 
-        return cls(
+        pipeline = cls(
             request_id=request_id,
             guards=guards,
             leak_guard=leak_guard,
             audit=audit,
             config=config,
+            defer_flush=context is not None,
         )
+        if context is not None:
+            context.pipeline = pipeline
+        return pipeline
 
     @property
     def audit(self) -> AuditTrace | None:
@@ -225,7 +243,7 @@ class RequestPipeline:
         self._finished = True
         self._wire_status = wire_status
         self._outcome = outcome
-        if self._audit:
+        if self._audit and not self._defer_flush:
             self._audit.record_outbound(
                 wire_status,
                 body_summary=body_summary,

--- a/src/router_maestro/providers/anthropic.py
+++ b/src/router_maestro/providers/anthropic.py
@@ -31,6 +31,13 @@ logger = get_logger("providers.anthropic")
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1"
 
 
+def _request_audit():
+    from router_maestro.runtime import get_current_request_context
+
+    context = get_current_request_context()
+    return context.audit if context is not None else None
+
+
 class AnthropicProvider(BaseProvider):
     """Anthropic Claude provider."""
 
@@ -241,16 +248,27 @@ class AnthropicProvider(BaseProvider):
     async def chat_completion(self, request: ChatRequest) -> ChatResponse:
         """Generate a chat completion via Anthropic."""
         payload = self._build_payload(request)
+        url = f"{self.base_url}/messages"
+        headers = self._get_headers()
+        audit = _request_audit()
+        if audit is not None:
+            audit.record_upstream("POST", url, headers, payload)
 
         logger.debug("Anthropic chat completion: model=%s", request.model)
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(
-                    f"{self.base_url}/messages",
+                    url,
                     json=payload,
-                    headers=self._get_headers(),
+                    headers=headers,
                     timeout=TIMEOUT_NON_STREAMING,
                 )
+                if audit is not None:
+                    audit.record_upstream_response(
+                        response.status_code,
+                        dict(response.headers),
+                        response.content,
+                    )
                 response.raise_for_status()
                 try:
                     data = response.json()
@@ -280,6 +298,11 @@ class AnthropicProvider(BaseProvider):
     async def chat_completion_stream(self, request: ChatRequest) -> AsyncIterator[ChatStreamChunk]:
         """Generate a streaming chat completion via Anthropic."""
         payload = self._build_payload(request, stream=True)
+        url = f"{self.base_url}/messages"
+        headers = self._get_headers()
+        audit = _request_audit()
+        if audit is not None:
+            audit.record_upstream("POST", url, headers, payload)
 
         logger.debug("Anthropic streaming chat: model=%s", request.model)
         decoder = AnthropicStreamDecoder(
@@ -289,11 +312,17 @@ class AnthropicProvider(BaseProvider):
             try:
                 async with client.stream(
                     "POST",
-                    f"{self.base_url}/messages",
+                    url,
                     json=payload,
-                    headers=self._get_headers(),
+                    headers=headers,
                     timeout=TIMEOUT_STREAMING,
                 ) as response:
+                    if audit is not None:
+                        audit.record_upstream_response(
+                            response.status_code,
+                            dict(response.headers),
+                            stream_summary="stream opened",
+                        )
                     response.raise_for_status()
 
                     async for line in response.aiter_lines():

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -358,6 +358,8 @@ class ChatResponse:
     # Router-selected identity. Providers leave this unset; Router attaches the
     # exact candidate so protocol boundaries never infer raw/public provenance.
     selected_model: "ModelRef | None" = None
+    # Canonical provider semantics. Appended to preserve positional construction.
+    terminal_outcome: TerminalOutcome | None = None
 
 
 @dataclass

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -563,7 +563,10 @@ class CopilotProvider(BaseProvider):
 
     async def close(self) -> None:
         """Close the HTTP client. Called during app shutdown."""
-        await self._transport.close()
+        try:
+            await self._catalog.aclose()
+        finally:
+            await self._transport.close()
 
     async def count_native_anthropic_tokens(
         self,

--- a/src/router_maestro/providers/copilot_support/auth_session.py
+++ b/src/router_maestro/providers/copilot_support/auth_session.py
@@ -151,7 +151,12 @@ class CopilotAuthSession:
 
     async def persist_credential(self, credential: OAuthCredential) -> None:
         """Store and flush a credential without blocking the event loop."""
-        if self.auth_manager.uses_legacy_storage:
+        uses_legacy_storage = getattr(
+            self.auth_manager,
+            "uses_legacy_storage",
+            not hasattr(self.auth_manager, "repository"),
+        )
+        if uses_legacy_storage:
             self.auth_manager.storage.set(self.provider_name, credential)
             await asyncio.to_thread(self.auth_manager.save)
             return

--- a/src/router_maestro/providers/copilot_support/auth_session.py
+++ b/src/router_maestro/providers/copilot_support/auth_session.py
@@ -9,7 +9,7 @@ from typing import Any, NoReturn
 
 import httpx
 
-from router_maestro.auth import AuthManager, AuthType
+from router_maestro.auth import AuthManager, AuthType, CredentialRepository
 from router_maestro.auth.github_oauth import GitHubOAuthError, get_copilot_token
 from router_maestro.auth.storage import OAuthCredential
 from router_maestro.providers.base import ProviderError, ProviderFailureKind
@@ -26,8 +26,9 @@ class CopilotAuthSession:
 
     provider_name = "github-copilot"
 
-    def __init__(self) -> None:
-        self.auth_manager = AuthManager()
+    def __init__(self, credential_repository: CredentialRepository | None = None) -> None:
+        self.credential_repository = credential_repository or CredentialRepository()
+        self.auth_manager = AuthManager(self.credential_repository)
         self.cached_token: str | None = None
         self.token_expires: int = 0
         self.api_base = COPILOT_BASE_URL
@@ -150,8 +151,15 @@ class CopilotAuthSession:
 
     async def persist_credential(self, credential: OAuthCredential) -> None:
         """Store and flush a credential without blocking the event loop."""
-        self.auth_manager.storage.set(self.provider_name, credential)
-        await asyncio.to_thread(self.auth_manager.save)
+        if self.auth_manager.uses_legacy_storage:
+            self.auth_manager.storage.set(self.provider_name, credential)
+            await asyncio.to_thread(self.auth_manager.save)
+            return
+        await asyncio.to_thread(
+            self.auth_manager.repository.update_provider,
+            self.provider_name,
+            credential,
+        )
 
     async def refresh_for_auth_status(
         self,

--- a/src/router_maestro/providers/copilot_support/catalog.py
+++ b/src/router_maestro/providers/copilot_support/catalog.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from collections.abc import Awaitable, Callable, Mapping
+from contextvars import Context
 from copy import deepcopy
 from typing import Any, NoReturn
 
@@ -127,6 +130,9 @@ class CopilotCatalog:
 
     def __init__(self) -> None:
         self.models_ttl_cache: TTLCache[list[ModelInfo]] = TTLCache(MODELS_CACHE_TTL)
+        self._refresh_lock = asyncio.Lock()
+        self._refresh_task: asyncio.Task[list[ModelInfo]] | None = None
+        self._closed = False
 
     def effort_values(self, model: str) -> list[str] | None:
         cached = self.models_ttl_cache.get()
@@ -135,7 +141,7 @@ class CopilotCatalog:
         bare = model.split("/", 1)[1] if "/" in model else model
         for info in cached:
             if info.id == bare or info.id == model:
-                return info.reasoning_effort_values
+                return deepcopy(info.reasoning_effort_values)
         return None
 
     def operation_support(self, model: str, operation: Operation) -> bool | None:
@@ -257,12 +263,90 @@ class CopilotCatalog:
         derive_operations: Callable[[Mapping[str, Any]], dict[str, bool]],
         raise_protocol_error: Callable[..., NoReturn],
     ) -> list[ModelInfo]:
-        if not force_refresh:
-            cached = self.models_ttl_cache.get()
-            if cached is not None:
-                logger.debug("Using cached Copilot models (%d models)", len(cached))
-                return deepcopy(cached)
+        cached = self.models_ttl_cache.get()
+        if cached is not None and not force_refresh:
+            logger.debug("Using cached Copilot models (%d models)", len(cached))
+            return deepcopy(cached)
 
+        stale = self.models_ttl_cache.peek()
+        task = await self._get_or_start_refresh(
+            detached=stale is not None and not force_refresh,
+            provider_name=provider_name,
+            ensure_token=ensure_token,
+            send=send,
+            normalize_endpoints=normalize_endpoints,
+            derive_operations=derive_operations,
+            raise_protocol_error=raise_protocol_error,
+        )
+        if stale is not None and not force_refresh:
+            logger.debug("Serving stale Copilot models while refreshing")
+            return deepcopy(stale)
+        return deepcopy(await asyncio.shield(task))
+
+    async def _get_or_start_refresh(
+        self,
+        *,
+        detached: bool,
+        provider_name: str,
+        ensure_token: Callable[[], Awaitable[None]],
+        send: Callable[..., Awaitable[httpx.Response]],
+        normalize_endpoints: Callable[[Mapping[str, Any]], tuple[str, ...] | None],
+        derive_operations: Callable[[Mapping[str, Any]], dict[str, bool]],
+        raise_protocol_error: Callable[..., NoReturn],
+    ) -> asyncio.Task[list[ModelInfo]]:
+        async with self._refresh_lock:
+            if self._closed:
+                raise RuntimeError("Copilot catalog is closed")
+            if self._refresh_task is not None and not self._refresh_task.done():
+                return self._refresh_task
+            refresh = self._refresh(
+                provider_name=provider_name,
+                ensure_token=ensure_token,
+                send=send,
+                normalize_endpoints=normalize_endpoints,
+                derive_operations=derive_operations,
+                raise_protocol_error=raise_protocol_error,
+            )
+            task = (
+                asyncio.create_task(refresh, context=Context())
+                if detached
+                else asyncio.create_task(refresh)
+            )
+            task.add_done_callback(self._observe_refresh_result)
+            self._refresh_task = task
+            return task
+
+    @staticmethod
+    def _observe_refresh_result(task: asyncio.Task[list[ModelInfo]]) -> None:
+        """Retrieve detached refresh failures even when stale callers do not await them."""
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.warning("Background Copilot catalog refresh failed", exc_info=error)
+
+    async def aclose(self) -> None:
+        """Cancel and join the detached refresh before its transport is closed."""
+        async with self._refresh_lock:
+            self._closed = True
+            task = self._refresh_task
+            self._refresh_task = None
+            if task is not None and not task.done():
+                task.cancel()
+        if task is not None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    async def _refresh(
+        self,
+        *,
+        provider_name: str,
+        ensure_token: Callable[[], Awaitable[None]],
+        send: Callable[..., Awaitable[httpx.Response]],
+        normalize_endpoints: Callable[[Mapping[str, Any]], tuple[str, ...] | None],
+        derive_operations: Callable[[Mapping[str, Any]], dict[str, bool]],
+        raise_protocol_error: Callable[..., NoReturn],
+    ) -> list[ModelInfo]:
         logger.debug("Fetching Copilot models from API")
         try:
             await ensure_token()
@@ -282,7 +366,7 @@ class CopilotCatalog:
             logger.info("Fetched %d Copilot models", len(models))
             return deepcopy(models)
         except (httpx.HTTPError, ProviderError) as error:
-            stale = self.models_ttl_cache._value
+            stale = self.models_ttl_cache.peek()
             if stale is not None:
                 logger.warning(
                     "Failed to refresh Copilot models, using stale cache (%s)",

--- a/src/router_maestro/providers/copilot_support/transport.py
+++ b/src/router_maestro/providers/copilot_support/transport.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 import httpx
 
+from router_maestro.pipeline.beta_strip import strip_beta_tokens
 from router_maestro.providers.base import (
     TIMEOUT_NON_STREAMING,
     Message,
@@ -25,6 +26,13 @@ from router_maestro.providers.copilot_support.auth_session import (
 from router_maestro.utils import get_logger
 
 logger = get_logger("providers.copilot.transport")
+
+
+def _request_audit():
+    from router_maestro.runtime import get_current_request_context
+
+    context = get_current_request_context()
+    return context.audit if context is not None else None
 
 
 class CopilotTransport:
@@ -94,6 +102,16 @@ class CopilotTransport:
             headers["X-Initiator"] = self.chat_initiator(messages)
         if vision_request:
             headers["Copilot-Vision-Request"] = "true"
+        from router_maestro.runtime import get_current_request_context
+
+        context = get_current_request_context()
+        if context is not None:
+            anthropic_beta = strip_beta_tokens(
+                context.request_header("anthropic-beta"),
+                context.config.beta_strip,
+            )
+            if anthropic_beta is not None:
+                headers["anthropic-beta"] = anthropic_beta
         return headers
 
     def get_client(self) -> httpx.AsyncClient:
@@ -155,18 +173,22 @@ class CopilotTransport:
         active_client = client or get_client()
         headers_kwargs = headers_kwargs or {}
         for attempt in range(2):
+            headers = get_headers(**headers_kwargs)
+            audit = _request_audit()
+            if audit is not None:
+                audit.record_upstream(method, self.url(path), headers, json)
             try:
                 if method == "GET":
                     response = await active_client.get(
                         self.url(path),
-                        headers=get_headers(**headers_kwargs),
+                        headers=headers,
                         timeout=timeout,
                     )
                 else:
                     response = await active_client.post(
                         self.url(path),
                         json=json,
-                        headers=get_headers(**headers_kwargs),
+                        headers=headers,
                         timeout=timeout,
                     )
             except (httpx.RemoteProtocolError, httpx.PoolTimeout, httpx.ConnectError) as error:
@@ -188,6 +210,12 @@ class CopilotTransport:
                     model=model,
                     cause=error,
                 ) from error
+            if audit is not None:
+                audit.record_upstream_response(
+                    response.status_code,
+                    dict(response.headers),
+                    response.content,
+                )
             if attempt == 0 and await refresh_for_auth_status(path, response.status_code):
                 continue
             if response.status_code in AUTH_RETRY_STATUSES:
@@ -216,12 +244,16 @@ class CopilotTransport:
         raise_auth_failure = raise_auth_failure or self.auth.raise_auth_failure
         client = get_client()
         for attempt in range(2):
+            headers = get_headers(**headers_kwargs)
+            audit = _request_audit()
+            if audit is not None:
+                audit.record_upstream("POST", self.url(path), headers, json)
             try:
                 cm: AbstractAsyncContextManager[httpx.Response] = client.stream(
                     "POST",
                     self.url(path),
                     json=json,
-                    headers=get_headers(**headers_kwargs),
+                    headers=headers,
                 )
                 response = await cm.__aenter__()
             except (httpx.RemoteProtocolError, httpx.PoolTimeout, httpx.ConnectError) as error:
@@ -243,6 +275,12 @@ class CopilotTransport:
                     model=model,
                     cause=error,
                 ) from error
+            if audit is not None:
+                audit.record_upstream_response(
+                    response.status_code,
+                    dict(response.headers),
+                    stream_summary="stream opened",
+                )
             if attempt == 0 and response.status_code in AUTH_RETRY_STATUSES:
                 with contextlib.suppress(Exception):
                     await response.aread()

--- a/src/router_maestro/providers/custom_factory.py
+++ b/src/router_maestro/providers/custom_factory.py
@@ -1,0 +1,79 @@
+"""Construction and credential resolution for custom providers."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from router_maestro.auth.repository import CredentialRepository
+from router_maestro.auth.storage import ApiKeyCredential
+from router_maestro.config.providers import CustomProviderConfig, default_custom_api_key_env
+from router_maestro.providers.openai_compat import OpenAICompatibleProvider
+
+
+class CustomCredentialSource(StrEnum):
+    """Configured source of a custom provider credential."""
+
+    ENVIRONMENT = "environment"
+    REPOSITORY = "repository"
+    ANONYMOUS = "anonymous"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCustomCredential:
+    """A resolved credential without exposing its value in repr output."""
+
+    source: CustomCredentialSource
+    api_key: str | None = field(repr=False)
+
+
+def resolve_custom_provider_credential(
+    provider_name: str,
+    provider_config: CustomProviderConfig,
+    *,
+    credential_repository: CredentialRepository,
+    environ: Mapping[str, str] | None = None,
+) -> ResolvedCustomCredential | None:
+    """Resolve environment, repository, then explicit anonymous access."""
+    environment = os.environ if environ is None else environ
+    env_name = provider_config.options.api_key_env or default_custom_api_key_env(provider_name)
+    env_key = environment.get(env_name)
+    if env_key:
+        return ResolvedCustomCredential(CustomCredentialSource.ENVIRONMENT, env_key)
+
+    credential = credential_repository.get_provider(provider_name)
+    if isinstance(credential, ApiKeyCredential) and credential.key:
+        return ResolvedCustomCredential(CustomCredentialSource.REPOSITORY, credential.key)
+
+    if provider_config.options.allow_unauthenticated:
+        return ResolvedCustomCredential(CustomCredentialSource.ANONYMOUS, None)
+    return None
+
+
+def create_custom_provider(
+    provider_name: str,
+    provider_config: CustomProviderConfig,
+    *,
+    credential_repository: CredentialRepository,
+    environ: Mapping[str, str] | None = None,
+) -> OpenAICompatibleProvider | None:
+    """Build one supported provider when its credential policy is satisfied."""
+    if provider_config.type != "openai-compatible":
+        return None
+    credential = resolve_custom_provider_credential(
+        provider_name,
+        provider_config,
+        credential_repository=credential_repository,
+        environ=environ,
+    )
+    if credential is None:
+        return None
+    return OpenAICompatibleProvider(
+        name=provider_name,
+        base_url=provider_config.baseURL,
+        api_key=credential.api_key,
+        models={model_id: config.name for model_id, config in provider_config.models.items()},
+        allow_unauthenticated=credential.source is CustomCredentialSource.ANONYMOUS,
+    )

--- a/src/router_maestro/providers/openai.py
+++ b/src/router_maestro/providers/openai.py
@@ -4,7 +4,7 @@ import httpx
 
 from router_maestro.auth import AuthManager, AuthType
 from router_maestro.providers.base import ModelInfo, ProviderError, ProviderFailureKind
-from router_maestro.providers.openai_base import OpenAIChatProvider
+from router_maestro.providers.openai_base import OpenAIChatProvider, _request_audit
 from router_maestro.utils import get_logger
 
 logger = get_logger("providers.openai")
@@ -49,13 +49,24 @@ class OpenAIProvider(OpenAIChatProvider):
     async def list_models(self) -> list[ModelInfo]:
         """List available OpenAI models."""
         logger.debug("Fetching OpenAI models")
+        url = f"{self.base_url}/models"
+        headers = self._get_headers()
+        audit = _request_audit()
+        if audit is not None:
+            audit.record_upstream("GET", url, headers, None)
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{self.base_url}/models",
-                    headers=self._get_headers(),
+                    url,
+                    headers=headers,
                     timeout=30.0,
                 )
+                if audit is not None:
+                    audit.record_upstream_response(
+                        response.status_code,
+                        dict(response.headers),
+                        response.content,
+                    )
                 response.raise_for_status()
                 model_ids = self._parse_model_catalog(response)
 

--- a/src/router_maestro/providers/openai_base.py
+++ b/src/router_maestro/providers/openai_base.py
@@ -22,6 +22,13 @@ from router_maestro.routing.model_ref import validate_upstream_model_id
 from router_maestro.utils.reasoning import budget_to_effort, downgrade_for_upstream
 
 
+def _request_audit():
+    from router_maestro.runtime import get_current_request_context
+
+    context = get_current_request_context()
+    return context.audit if context is not None else None
+
+
 class OpenAIChatProvider(BaseProvider, ABC):
     """Shared OpenAI-compatible chat behavior."""
 
@@ -147,15 +154,26 @@ class OpenAIChatProvider(BaseProvider, ABC):
     async def chat_completion(self, request: ChatRequest) -> ChatResponse:
         payload = self._build_payload(request, stream=False)
         label = self._error_label()
+        url = f"{self.base_url}/chat/completions"
+        headers = self._get_headers()
+        audit = _request_audit()
+        if audit is not None:
+            audit.record_upstream("POST", url, headers, payload)
 
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.post(
-                    f"{self.base_url}/chat/completions",
+                    url,
                     json=payload,
-                    headers=self._get_headers(),
+                    headers=headers,
                     timeout=TIMEOUT_NON_STREAMING,
                 )
+                if audit is not None:
+                    audit.record_upstream_response(
+                        response.status_code,
+                        dict(response.headers),
+                        response.content,
+                    )
                 response.raise_for_status()
                 try:
                     data = response.json()
@@ -249,16 +267,27 @@ class OpenAIChatProvider(BaseProvider, ABC):
     async def chat_completion_stream(self, request: ChatRequest) -> AsyncIterator[ChatStreamChunk]:
         payload = self._build_payload(request, stream=True)
         label = self._error_label()
+        url = f"{self.base_url}/chat/completions"
+        headers = self._get_headers()
+        audit = _request_audit()
+        if audit is not None:
+            audit.record_upstream("POST", url, headers, payload)
 
         async with httpx.AsyncClient() as client:
             try:
                 async with client.stream(
                     "POST",
-                    f"{self.base_url}/chat/completions",
+                    url,
                     json=payload,
-                    headers=self._get_headers(),
+                    headers=headers,
                     timeout=TIMEOUT_STREAMING,
                 ) as response:
+                    if audit is not None:
+                        audit.record_upstream_response(
+                            response.status_code,
+                            dict(response.headers),
+                            stream_summary="stream opened",
+                        )
                     # Streamed responses defer body reads; if the upstream
                     # returns an error status, pull the body *inside* the
                     # stream context so the connection is still open. After

--- a/src/router_maestro/providers/openai_compat.py
+++ b/src/router_maestro/providers/openai_compat.py
@@ -16,8 +16,10 @@ class OpenAICompatibleProvider(OpenAIChatProvider):
         self,
         name: str,
         base_url: str,
-        api_key: str,
+        api_key: str | None,
         models: dict[str, str] | None = None,
+        *,
+        allow_unauthenticated: bool = False,
     ) -> None:
         """Initialize the provider.
 
@@ -26,22 +28,24 @@ class OpenAICompatibleProvider(OpenAIChatProvider):
             base_url: Base URL for API requests
             api_key: API key for authentication
             models: Dict of model_id -> display_name
+            allow_unauthenticated: Whether the configured endpoint explicitly permits no key
         """
         self.name = name
         super().__init__(base_url=base_url, logger=logger)
         self.api_key = api_key
+        self.allow_unauthenticated = allow_unauthenticated
         self._models = models or {}
 
     def is_authenticated(self) -> bool:
-        """Check if authenticated (always true for custom providers)."""
-        return bool(self.api_key)
+        """Check whether a key exists or anonymous access was explicitly allowed."""
+        return bool(self.api_key) or self.allow_unauthenticated
 
     def _get_headers(self) -> dict[str, str]:
         """Get headers for API requests."""
-        return {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
 
     def _error_label(self) -> str:
         return self.name

--- a/src/router_maestro/providers/openai_compat.py
+++ b/src/router_maestro/providers/openai_compat.py
@@ -3,7 +3,7 @@
 import httpx
 
 from router_maestro.providers.base import ModelInfo
-from router_maestro.providers.openai_base import OpenAIChatProvider
+from router_maestro.providers.openai_base import OpenAIChatProvider, _request_audit
 from router_maestro.utils import get_logger
 
 logger = get_logger("providers.openai_compat")
@@ -59,13 +59,24 @@ class OpenAICompatibleProvider(OpenAIChatProvider):
             ]
 
         # Try to fetch from API
+        url = f"{self.base_url}/models"
+        headers = self._get_headers()
+        audit = _request_audit()
+        if audit is not None:
+            audit.record_upstream("GET", url, headers, None)
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
-                    f"{self.base_url}/models",
-                    headers=self._get_headers(),
+                    url,
+                    headers=headers,
                     timeout=30.0,
                 )
+                if audit is not None:
+                    audit.record_upstream_response(
+                        response.status_code,
+                        dict(response.headers),
+                        response.content,
+                    )
                 response.raise_for_status()
                 model_ids = self._parse_model_catalog(response)
 

--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -1,11 +1,12 @@
 """Model router with priority-based selection and fallback."""
 
+import asyncio
+import inspect
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from copy import deepcopy
-from dataclasses import replace
-from typing import TypeVar
+from dataclasses import dataclass, replace
+from typing import Generic, TypeVar, cast
 
-from router_maestro.auth import ApiKeyCredential, AuthManager
 from router_maestro.config import (
     FallbackStrategy,
     PrioritiesConfig,
@@ -20,7 +21,6 @@ from router_maestro.providers import (
     ChatStreamChunk,
     CopilotProvider,
     ModelInfo,
-    OpenAICompatibleProvider,
     OpenAIProvider,
     ProviderError,
     ProviderFailureKind,
@@ -79,6 +79,344 @@ _router_instance: "Router | None" = None
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")
 ChunkT = TypeVar("ChunkT")
+RouterT = TypeVar("RouterT")
+
+
+@dataclass(slots=True)
+class _RouterGeneration(Generic[RouterT]):
+    generation_id: int
+    router: RouterT
+    config_snapshot: object | None = None
+    references: int = 0
+    retired: bool = False
+    closing: bool = False
+    closed: bool = False
+    closed_event: asyncio.Event | None = None
+
+    def event(self) -> asyncio.Event:
+        if self.closed_event is None:
+            self.closed_event = asyncio.Event()
+        return self.closed_event
+
+
+async def _close_router_resources(router: object) -> None:
+    close = getattr(router, "close", None)
+    if callable(close):
+        result = close()
+        if inspect.isawaitable(result):
+            await result
+        return
+
+    providers = getattr(router, "providers", {})
+    seen: set[int] = set()
+    for provider in providers.values():
+        if id(provider) in seen:
+            continue
+        seen.add(id(provider))
+        provider_close = getattr(provider, "close", None)
+        if not callable(provider_close):
+            continue
+        result = provider_close()
+        if inspect.isawaitable(result):
+            await result
+
+
+async def _await_task_ignoring_cancellation(task: asyncio.Task[RouterT]) -> tuple[RouterT, bool]:
+    """Wait through repeated caller cancellation and report whether it occurred."""
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    return task.result(), cancelled
+
+
+async def _close_uninstalled_router(router: object) -> None:
+    close_task = asyncio.create_task(_close_router_resources(router))
+    await _await_task_ignoring_cancellation(close_task)
+
+
+class RouterLease(Generic[RouterT]):
+    """Idempotent reference to one immutable Router generation."""
+
+    def __init__(
+        self,
+        owner: "RouterOwner[RouterT]",
+        generation: _RouterGeneration[RouterT],
+    ) -> None:
+        self._owner = owner
+        self._generation = generation
+        self._release_lock = asyncio.Lock()
+        self._released = False
+
+    @property
+    def generation_id(self) -> int:
+        return self._generation.generation_id
+
+    @property
+    def router(self) -> RouterT:
+        return self._generation.router
+
+    @property
+    def config_snapshot(self) -> object | None:
+        return self._generation.config_snapshot
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    async def release(self) -> None:
+        """Release this generation reference exactly once."""
+        async with self._release_lock:
+            if self._released:
+                return
+            release_task = asyncio.create_task(self._owner._release(self._generation))
+            _, cancelled = await _await_task_ignoring_cancellation(release_task)
+            self._released = True
+            if cancelled:
+                raise asyncio.CancelledError
+
+    async def __aenter__(self) -> "RouterLease[RouterT]":
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.release()
+
+
+class RouterOwner(Generic[RouterT]):
+    """Own atomically swappable Router generations and their resources."""
+
+    def __init__(
+        self,
+        factory: Callable[[object | None], RouterT | Awaitable[RouterT]] | None = None,
+    ) -> None:
+        self._factory = factory or cast(
+            Callable[[object | None], RouterT],
+            lambda snapshot: Router(
+                config_snapshot=snapshot,
+                managed_generation=True,
+            ),
+        )
+        self._operation_lock = asyncio.Lock()
+        self._state_lock = asyncio.Lock()
+        self._active: _RouterGeneration[RouterT] | None = None
+        self._generations: dict[int, _RouterGeneration[RouterT]] = {}
+        self._next_generation_id = 1
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
+        self._close_task: asyncio.Task[None] | None = None
+        self._closing = False
+        self._closed = False
+
+    async def _build(self, config_snapshot: object | None) -> RouterT:
+        built = self._factory(config_snapshot)
+        if inspect.isawaitable(built):
+            return await built
+        return built
+
+    async def start(self, config_snapshot: object | None = None) -> int:
+        """Build the initial generation and make it available for leases."""
+        async with self._operation_lock:
+            async with self._state_lock:
+                if self._closed or self._closing:
+                    raise RuntimeError("RouterOwner is closed")
+                if self._active is not None:
+                    return self._active.generation_id
+            build_task = asyncio.create_task(self._build(config_snapshot))
+            router: RouterT | None = None
+            installed = False
+            try:
+                router, cancelled = await _await_task_ignoring_cancellation(build_task)
+                if cancelled:
+                    raise asyncio.CancelledError
+                async with self._state_lock:
+                    generation = self._new_generation(router, config_snapshot)
+                    self._active = generation
+                    installed = True
+                    return generation.generation_id
+            finally:
+                if router is not None and not installed:
+                    await _close_uninstalled_router(router)
+
+    def _new_generation(
+        self,
+        router: RouterT,
+        config_snapshot: object | None,
+    ) -> _RouterGeneration[RouterT]:
+        generation = _RouterGeneration(
+            self._next_generation_id,
+            router,
+            config_snapshot,
+        )
+        self._next_generation_id += 1
+        self._generations[generation.generation_id] = generation
+        return generation
+
+    async def _acquire_active(self) -> RouterLease[RouterT]:
+        async with self._state_lock:
+            if self._closed or self._closing:
+                raise RuntimeError("RouterOwner is closed")
+            generation = self._active
+            if generation is None:
+                raise RuntimeError("RouterOwner has not been started")
+            if generation.retired:
+                raise RuntimeError("Active Router generation is retired")
+            generation.references += 1
+            return RouterLease(self, generation)
+
+    async def acquire(self) -> RouterLease[RouterT]:
+        """Acquire the active generation, rebuilding stale provider configuration once."""
+        lease = await self._acquire_active()
+        needs_reload = getattr(lease.router, "needs_provider_config_reload", None)
+        if not callable(needs_reload) or not needs_reload():
+            return lease
+        stale_generation_id = lease.generation_id
+        await lease.release()
+
+        async with self._operation_lock:
+            current = await self._acquire_active()
+            try:
+                current_needs_reload = getattr(
+                    current.router,
+                    "needs_provider_config_reload",
+                    None,
+                )
+                if (
+                    current.generation_id == stale_generation_id
+                    and callable(current_needs_reload)
+                    and current_needs_reload()
+                ):
+                    await self._rebuild_locked(current.config_snapshot)
+            finally:
+                await current.release()
+        return await self._acquire_active()
+
+    async def rebuild(
+        self,
+        config_snapshot: object | None = None,
+        *,
+        before_swap: Callable[[], object | None] | None = None,
+    ) -> int:
+        """Build a replacement before atomically retiring the active generation."""
+        async with self._operation_lock:
+            return await self._rebuild_locked(config_snapshot, before_swap=before_swap)
+
+    async def _rebuild_locked(
+        self,
+        config_snapshot: object | None,
+        *,
+        before_swap: Callable[[], object | None] | None = None,
+    ) -> int:
+        """Rebuild while the caller owns the operation lock."""
+        async with self._state_lock:
+            if self._closed or self._closing:
+                raise RuntimeError("RouterOwner is closed")
+            build_snapshot = (
+                self._active.config_snapshot
+                if config_snapshot is None and self._active is not None
+                else config_snapshot
+            )
+        build_task = asyncio.create_task(self._build(build_snapshot))
+        router: RouterT | None = None
+        installed = False
+        try:
+            router, cancelled = await _await_task_ignoring_cancellation(build_task)
+            if cancelled:
+                raise asyncio.CancelledError
+
+            to_close: _RouterGeneration[RouterT] | None = None
+            await self._state_lock.acquire()
+            try:
+                generation_snapshot = build_snapshot
+                if before_swap is not None:
+                    committed_snapshot = before_swap()
+                    if inspect.isawaitable(committed_snapshot):
+                        raise TypeError("before_swap callback must be synchronous")
+                    if committed_snapshot is not None:
+                        generation_snapshot = committed_snapshot
+                previous = self._active
+                generation = self._new_generation(router, generation_snapshot)
+                self._active = generation
+                installed = True
+                if previous is not None:
+                    previous.retired = True
+                    if previous.references == 0 and not previous.closing:
+                        previous.closing = True
+                        to_close = previous
+            finally:
+                self._state_lock.release()
+            if to_close is not None:
+                self._schedule_generation_close(to_close)
+            return generation.generation_id
+        finally:
+            if router is not None and not installed:
+                await _close_uninstalled_router(router)
+
+    async def _release(self, generation: _RouterGeneration[RouterT]) -> None:
+        to_close = False
+        async with self._state_lock:
+            if generation.references <= 0:
+                return
+            generation.references -= 1
+            if generation.retired and generation.references == 0 and not generation.closing:
+                generation.closing = True
+                to_close = True
+        if to_close:
+            await self._close_generation(generation)
+
+    async def _close_generation(self, generation: _RouterGeneration[RouterT]) -> None:
+        try:
+            await _close_router_resources(generation.router)
+        except Exception:
+            logger.warning(
+                "Failed to close Router generation %s",
+                generation.generation_id,
+                exc_info=True,
+            )
+        finally:
+            async with self._state_lock:
+                generation.closed = True
+                self._generations.pop(generation.generation_id, None)
+                generation.event().set()
+
+    def _schedule_generation_close(self, generation: _RouterGeneration[RouterT]) -> None:
+        """Own a post-swap close task without extending the rebuild commit path."""
+        task = asyncio.create_task(self._close_generation(generation))
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
+
+    async def _shutdown(self) -> None:
+        """Retire every generation and wait for its resources to close."""
+        async with self._operation_lock:
+            async with self._state_lock:
+                if self._closed:
+                    return
+                self._closing = True
+                active = self._active
+                self._active = None
+                if active is not None:
+                    active.retired = True
+                generations = list(self._generations.values())
+                close_now: list[_RouterGeneration[RouterT]] = []
+                for generation in generations:
+                    if generation.references == 0 and not generation.closing:
+                        generation.closing = True
+                        close_now.append(generation)
+
+            for generation in close_now:
+                await self._close_generation(generation)
+            await asyncio.gather(*(generation.event().wait() for generation in generations))
+            async with self._state_lock:
+                self._closed = True
+                self._closing = False
+
+    async def close(self) -> None:
+        """Finish one owner-owned shutdown before propagating caller cancellation."""
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(self._shutdown())
+        _, cancelled = await _await_task_ignoring_cancellation(self._close_task)
+        if cancelled:
+            raise asyncio.CancelledError
 
 
 class _PrimedStream(AsyncIterator[ChunkT]):
@@ -128,6 +466,15 @@ def get_router() -> "Router":
     Returns:
         The global Router instance
     """
+    try:
+        from router_maestro.runtime.request_context import get_current_request_context
+
+        context = get_current_request_context()
+    except ImportError:
+        context = None
+    if context is not None:
+        return cast(Router, context.router)
+
     global _router_instance
     if _router_instance is None:
         _router_instance = Router()
@@ -150,7 +497,17 @@ def reset_router() -> None:
 class Router:
     """Router for model requests with priority and fallback support."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        config_snapshot: object | None = None,
+        *,
+        managed_generation: bool = False,
+    ) -> None:
+        self._config_snapshot = config_snapshot
+        self._managed_generation = managed_generation
+        self._close_lock = asyncio.Lock()
+        self._closed_provider_ids: set[int] = set()
+        self._closed = False
         self.providers: dict[str, BaseProvider] = {}
         # Model cache: maps model_id -> (provider_name, ModelInfo)
         self._models_cache: dict[str, tuple[str, ModelInfo]] = {}
@@ -161,13 +518,14 @@ class Router:
         self._fuzzy_cache: dict[str, str | None] = {}
         # Providers config cache
         self._providers_ttl: TTLCache[bool] = TTLCache(CACHE_TTL_SECONDS)
+        snapshot_config = getattr(config_snapshot, "config", config_snapshot)
+        if isinstance(snapshot_config, PrioritiesConfig):
+            self._priorities_cache.set(deepcopy(snapshot_config))
         self._load_providers()
 
     def _load_providers(self) -> None:
         """Load providers from configuration."""
         custom_providers_config = load_providers_config()
-        auth_manager = AuthManager()
-
         old_providers = self.providers
         self.providers = {}
 
@@ -177,7 +535,7 @@ class Router:
 
         # Load custom providers from providers.json
         for provider_name, provider_config in custom_providers_config.providers.items():
-            provider = self._create_custom_provider(provider_name, provider_config, auth_manager)
+            provider = self._create_custom_provider(provider_name, provider_config)
             if provider is not None:
                 self.providers[provider_name] = provider
 
@@ -201,30 +559,25 @@ class Router:
         self,
         provider_name: str,
         provider_config,
-        auth_manager: AuthManager,
     ) -> BaseProvider | None:
-        provider_type = provider_config.type
-        if provider_type != "openai-compatible":
-            logger.warning(
-                "Unknown provider type '%s' for %s; skipping", provider_type, provider_name
-            )
-            return None
+        from router_maestro.auth.repository import CredentialRepository
+        from router_maestro.providers.custom_factory import create_custom_provider
 
-        cred = auth_manager.get_credential(provider_name)
-        if not isinstance(cred, ApiKeyCredential):
-            logger.debug("Skipping custom provider %s (no API key)", provider_name)
-            return None
-
-        provider = OpenAICompatibleProvider(
-            name=provider_name,
-            base_url=provider_config.baseURL,
-            api_key=cred.key,
-            models={
-                model_id: model_config.name
-                for model_id, model_config in provider_config.models.items()
-            },
+        provider = create_custom_provider(
+            provider_name,
+            provider_config,
+            credential_repository=CredentialRepository(),
         )
-        logger.debug("Loaded custom provider: %s", provider_name)
+        if provider is None and provider_config.type != "openai-compatible":
+            logger.warning(
+                "Unknown provider type '%s' for %s; skipping",
+                provider_config.type,
+                provider_name,
+            )
+        elif provider is None:
+            logger.debug("Skipping custom provider %s (no API key)", provider_name)
+        else:
+            logger.debug("Loaded custom provider: %s", provider_name)
         return provider
 
     def _get_priorities_config(self) -> PrioritiesConfig:
@@ -233,12 +586,19 @@ class Router:
         if cached is not None:
             return cached
 
+        if getattr(self, "_managed_generation", False):
+            frozen = self._priorities_cache.peek()
+            if frozen is not None:
+                return frozen
+
         config = load_priorities_config()
         self._priorities_cache.set(config)
         return config
 
     def _ensure_providers_fresh(self) -> None:
         """Ensure providers config is fresh, reload if expired."""
+        if getattr(self, "_managed_generation", False):
+            return
         if not self._providers_ttl.is_valid:
             logger.debug("Providers config expired, reloading")
             self._load_providers()
@@ -246,6 +606,36 @@ class Router:
             self._models_cache.clear()
             self._fuzzy_cache.clear()
             self._models_cache_ttl.clear()
+
+    def needs_provider_config_reload(self) -> bool:
+        """Return whether this immutable managed generation needs replacement."""
+        return self._managed_generation and not self._providers_ttl.is_valid
+
+    async def close(self) -> None:
+        """Close every provider resource owned by this Router exactly once."""
+        async with self._close_lock:
+            if self._closed:
+                return
+            seen = set(self._closed_provider_ids)
+            for provider in self.providers.values():
+                if id(provider) in seen:
+                    continue
+                seen.add(id(provider))
+                close = getattr(provider, "close", None)
+                if not callable(close):
+                    continue
+                try:
+                    result = close()
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception:
+                    logger.warning(
+                        "Failed to close provider %s",
+                        getattr(provider, "name", type(provider).__name__),
+                        exc_info=True,
+                    )
+                self._closed_provider_ids.add(id(provider))
+            self._closed = True
 
     def _parse_model_key(self, model_key: str) -> tuple[str, str]:
         """Parse a model key into provider and model.

--- a/src/router_maestro/runtime/__init__.py
+++ b/src/router_maestro/runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Per-request runtime ownership."""
+
+from router_maestro.runtime.request_context import (
+    RequestContext,
+    RequestContextMiddleware,
+    current_request_context,
+    get_current_request_context,
+)
+
+__all__ = [
+    "RequestContext",
+    "RequestContextMiddleware",
+    "current_request_context",
+    "get_current_request_context",
+]

--- a/src/router_maestro/runtime/request_context.py
+++ b/src/router_maestro/runtime/request_context.py
@@ -1,0 +1,350 @@
+"""One immutable configuration and Router lease for an inference request."""
+
+from __future__ import annotations
+
+import asyncio
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from starlette.requests import ClientDisconnect
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.providers.base import (
+    ResponseStatus,
+    TerminalOutcome,
+    TransportTermination,
+    client_cancelled_outcome,
+    exception_outcome,
+    unexpected_eof_outcome,
+)
+from router_maestro.utils.audit import AuditTrace, get_trace_dir, is_tracing_enabled
+
+if TYPE_CHECKING:
+    from router_maestro.pipeline.request_pipeline import RequestPipeline
+
+
+class RuntimeConfigSnapshot(Protocol):
+    """Task 15 snapshot surface consumed by request ownership."""
+
+    revision: str
+
+    @property
+    def config(self) -> PrioritiesConfig: ...
+
+
+class RuntimeConfigRepository(Protocol):
+    def read(self) -> RuntimeConfigSnapshot: ...
+
+
+class RouterLease(Protocol):
+    generation_id: int
+    router: Any
+    config_snapshot: object | None
+
+    async def release(self) -> None: ...
+
+
+class RouterOwner(Protocol):
+    async def acquire(self) -> RouterLease: ...
+
+
+_current_request_context: ContextVar[RequestContext | None] = ContextVar(
+    "router_maestro_request_context",
+    default=None,
+)
+
+
+def get_current_request_context() -> RequestContext | None:
+    """Return the bound inference context, if this task has one."""
+    return _current_request_context.get()
+
+
+def current_request_context() -> RequestContext:
+    """Return the bound inference context or raise outside request execution."""
+    context = get_current_request_context()
+    if context is None:
+        raise LookupError("No Router-Maestro request context is active")
+    return context
+
+
+def _completed_outcome() -> TerminalOutcome:
+    return TerminalOutcome(
+        transport=TransportTermination.EXPLICIT_TERMINAL,
+        response_status=ResponseStatus.COMPLETED,
+    )
+
+
+def _http_outcome(status: int | None) -> TerminalOutcome:
+    if status is not None and status >= 400:
+        return TerminalOutcome(
+            transport=TransportTermination.EXPLICIT_TERMINAL,
+            response_status=ResponseStatus.FAILED,
+        )
+    return _completed_outcome()
+
+
+async def _await_cleanup(task: asyncio.Task[None]) -> None:
+    """Defer caller cancellation until a resource cleanup task reaches its terminal state."""
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    task.result()
+    if cancelled:
+        raise asyncio.CancelledError
+
+
+@dataclass(slots=True)
+class RequestContext:
+    """Own request-scoped configuration, Router resources, pipeline, and audit."""
+
+    request_id: str
+    config_snapshot: RuntimeConfigSnapshot
+    config: PrioritiesConfig
+    lease: RouterLease
+    revision: str = field(init=False)
+    generation_id: int = field(init=False)
+    router: Any = field(init=False)
+    pipeline: RequestPipeline | None = None
+    audit: AuditTrace | None = None
+    stream_committed: bool = False
+    outcome: TerminalOutcome | None = None
+    status_code: int | None = None
+    _finalized: bool = False
+    _finalize_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+    _inbound_recorded: bool = False
+    _request_method: str = ""
+    _request_path: str = ""
+    _request_headers: dict[str, str] = field(default_factory=dict, repr=False)
+    _request_body: bytearray = field(default_factory=bytearray, repr=False)
+
+    def __post_init__(self) -> None:
+        self.revision = self.config_snapshot.revision
+        self.generation_id = self.lease.generation_id
+        self.router = self.lease.router
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        request_id: str,
+        config_snapshot: RuntimeConfigSnapshot,
+        lease: RouterLease,
+    ) -> RequestContext:
+        """Capture the snapshot config once and construct its optional audit trace."""
+        config = config_snapshot.config
+        audit = None
+        if is_tracing_enabled(config.audit.enabled):
+            audit = AuditTrace(request_id, get_trace_dir(config.audit.trace_dir))
+        return cls(
+            request_id=request_id,
+            config_snapshot=config_snapshot,
+            config=config,
+            lease=lease,
+            audit=audit,
+        )
+
+    @property
+    def finalized(self) -> bool:
+        return self._finalized
+
+    def bind_request(self, scope: Scope) -> None:
+        """Capture immutable inbound metadata before route execution."""
+        self._request_method = scope.get("method", "")
+        self._request_path = scope.get("path", "")
+        self._request_headers = {
+            name.decode("latin-1"): value.decode("latin-1")
+            for name, value in scope.get("headers", ())
+        }
+
+    def append_request_body(self, body: bytes, *, complete: bool) -> None:
+        self._request_body.extend(body)
+        if complete:
+            self.record_inbound()
+
+    def record_inbound(self) -> None:
+        if self._inbound_recorded or self.audit is None:
+            return
+        self._inbound_recorded = True
+        self.audit.record_inbound(
+            self._request_method,
+            self._request_path,
+            self._request_headers,
+            bytes(self._request_body),
+        )
+
+    def request_header(self, name: str) -> str | None:
+        lowered = name.lower()
+        for header_name, value in self._request_headers.items():
+            if header_name.lower() == lowered:
+                return value
+        return None
+
+    async def finalize(
+        self,
+        *,
+        outcome: TerminalOutcome | None = None,
+        wire_status: int | None = None,
+        body_summary: str | None = None,
+    ) -> None:
+        """Flush audit and release the generation lease exactly once."""
+        async with self._finalize_lock:
+            if self._finalized:
+                return
+            if wire_status is not None:
+                self.status_code = wire_status
+            pipeline_outcome = self.pipeline.outcome if self.pipeline is not None else None
+            resolved_outcome = (
+                outcome or self.outcome or pipeline_outcome or _http_outcome(self.status_code)
+            )
+            self.outcome = resolved_outcome
+            status = self.status_code or 500
+
+            async def finish() -> None:
+                try:
+                    self.record_inbound()
+                    if self.pipeline is not None:
+                        if self.pipeline.outcome is None:
+                            self.pipeline.finish(
+                                wire_status=status,
+                                outcome=resolved_outcome,
+                                body_summary=body_summary,
+                            )
+                        if self.audit is not None:
+                            self.audit.record_outbound(
+                                status,
+                                body_summary=body_summary,
+                                outcome=resolved_outcome,
+                            )
+                    elif self.audit is not None:
+                        self.audit.record_outbound(
+                            status,
+                            body_summary=body_summary,
+                            outcome=resolved_outcome,
+                        )
+                    if self.audit is not None:
+                        await self.audit.flush_async()
+                finally:
+                    await self.lease.release()
+                    self._finalized = True
+
+            await _await_cleanup(asyncio.create_task(finish()))
+
+
+def is_inference_path(path: str) -> bool:
+    """Return whether a path executes or tokenizes an inference request."""
+    if path in {
+        "/api/openai/v1/chat/completions",
+        "/api/openai/v1/responses",
+        "/v1/messages",
+        "/v1/messages/count_tokens",
+        "/api/anthropic/v1/messages",
+        "/api/anthropic/v1/messages/count_tokens",
+        "/api/anthropic/beta/v1/messages",
+        "/api/anthropic/beta/v1/messages/count_tokens",
+    }:
+        return True
+    return path.startswith("/api/gemini/v1beta/models/") and path.endswith(
+        (":generateContent", ":streamGenerateContent", ":countTokens")
+    )
+
+
+class RequestContextMiddleware:
+    """Bind resource finalization to ASGI response-body completion."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not is_inference_path(scope.get("path", "")):
+            await self.app(scope, receive, send)
+            return
+
+        app = scope.get("app")
+        state = getattr(app, "state", None)
+        repository = cast(RuntimeConfigRepository, getattr(state, "runtime_config_repository"))
+        owner = cast(RouterOwner, getattr(state, "router_owner"))
+        snapshot = repository.read()
+        start = getattr(owner, "start", None)
+        if callable(start):
+            await start(snapshot)
+        lease = await owner.acquire()
+        request_id = scope.setdefault("state", {}).get("request_id", "")
+        lease_snapshot = getattr(lease, "config_snapshot", None)
+        context = RequestContext.create(
+            request_id=request_id,
+            config_snapshot=(
+                cast(RuntimeConfigSnapshot, lease_snapshot)
+                if lease_snapshot is not None
+                else snapshot
+            ),
+            lease=lease,
+        )
+        context.bind_request(scope)
+        scope["state"]["request_context"] = context
+        token: Token[RequestContext | None] = _current_request_context.set(context)
+        final_body_sent = False
+        client_disconnected = False
+
+        async def receive_with_context() -> Message:
+            nonlocal client_disconnected
+            message = await receive()
+            if message["type"] == "http.request":
+                context.append_request_body(
+                    message.get("body", b""),
+                    complete=not message.get("more_body", False),
+                )
+            elif message["type"] == "http.disconnect":
+                client_disconnected = True
+            return message
+
+        async def send_with_context(message: Message) -> None:
+            nonlocal final_body_sent
+            if message["type"] == "http.response.start":
+                context.status_code = message["status"]
+                context.stream_committed = True
+            await send(message)
+            if message["type"] == "http.response.body" and not message.get("more_body", False):
+                final_body_sent = True
+                await context.finalize(
+                    outcome=client_cancelled_outcome() if client_disconnected else None,
+                    wire_status=context.status_code,
+                )
+
+        try:
+            await self.app(scope, receive_with_context, send_with_context)
+            if not final_body_sent:
+                await context.finalize(
+                    outcome=(
+                        client_cancelled_outcome()
+                        if client_disconnected
+                        else unexpected_eof_outcome()
+                    ),
+                    wire_status=context.status_code,
+                    body_summary="ASGI application returned before the final response body",
+                )
+        except asyncio.CancelledError:
+            await context.finalize(
+                outcome=client_cancelled_outcome(),
+                wire_status=context.status_code,
+            )
+            raise
+        except (ClientDisconnect, OSError):
+            await context.finalize(
+                outcome=client_cancelled_outcome(),
+                wire_status=context.status_code,
+            )
+            raise
+        except Exception as error:
+            await context.finalize(
+                outcome=exception_outcome(str(error)),
+                wire_status=context.status_code,
+                body_summary=str(error),
+            )
+            raise
+        finally:
+            _current_request_context.reset(token)

--- a/src/router_maestro/server/app.py
+++ b/src/router_maestro/server/app.py
@@ -16,8 +16,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from router_maestro import __version__
+from router_maestro.config.repository import RuntimeConfigRepository
 from router_maestro.providers import ProviderError
-from router_maestro.routing import get_router
+from router_maestro.routing.router import RouterOwner
+from router_maestro.runtime import RequestContextMiddleware
 from router_maestro.server.middleware import (
     REQUEST_ID_HEADER,
     ObservabilityMiddleware,
@@ -55,31 +57,34 @@ async def lifespan(app: FastAPI):
     setup_logging(level=log_level)
     logger.info("Router-Maestro server starting up")
 
-    # Pre-warm model cache if any providers are authenticated
-    router = get_router()
-    authenticated_providers = [
-        name for name, provider in router.providers.items() if provider.is_authenticated()
-    ]
-    if authenticated_providers:
-        logger.info(
-            "Pre-warming model cache for authenticated providers: %s", authenticated_providers
-        )
+    repository: RuntimeConfigRepository = app.state.runtime_config_repository
+    owner: RouterOwner = app.state.router_owner
+    try:
+        snapshot = repository.read()
+        await owner.start(snapshot)
+        lease = await owner.acquire()
         try:
-            models = await router.list_models()
-            logger.info("Model cache pre-warmed with %d models", len(models))
-        except Exception as e:
-            logger.warning("Failed to pre-warm model cache: %s", e)
+            router = lease.router
+            authenticated_providers = [
+                name for name, provider in router.providers.items() if provider.is_authenticated()
+            ]
+            if authenticated_providers:
+                logger.info(
+                    "Pre-warming model cache for authenticated providers: %s",
+                    authenticated_providers,
+                )
+                try:
+                    models = await router.list_models()
+                    logger.info("Model cache pre-warmed with %d models", len(models))
+                except Exception as e:
+                    logger.warning("Failed to pre-warm model cache: %s", e)
+        finally:
+            await lease.release()
 
-    yield
-    # Shutdown — close provider HTTP clients
-    router = get_router()
-    for provider in router.providers.values():
-        if hasattr(provider, "close"):
-            try:
-                await provider.close()
-            except Exception:
-                pass
-    logger.info("Router-Maestro server shutting down")
+        yield
+    finally:
+        await owner.close()
+        logger.info("Router-Maestro server shutting down")
 
 
 def get_metrics_token() -> str | None:
@@ -175,6 +180,8 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
     app.state.http_metrics = create_http_metrics()
+    app.state.runtime_config_repository = RuntimeConfigRepository()
+    app.state.router_owner = RouterOwner()
     app.add_exception_handler(RequestValidationError, protocol_validation_exception_handler)
     app.add_exception_handler(StarletteHTTPException, protocol_http_exception_handler)
     app.add_exception_handler(ProviderError, protocol_provider_exception_handler)
@@ -188,6 +195,7 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_middleware(RequestContextMiddleware)
     app.add_middleware(ObservabilityMiddleware)
 
     # Include routers with API key verification

--- a/src/router_maestro/server/routes/_outcomes.py
+++ b/src/router_maestro/server/routes/_outcomes.py
@@ -1,0 +1,19 @@
+"""Request-context outcome recording for non-stream protocol routes."""
+
+from router_maestro.providers import ChatResponse, TerminalOutcome, resolve_terminal_outcome
+from router_maestro.runtime import get_current_request_context
+
+
+def record_terminal_outcome(outcome: TerminalOutcome) -> None:
+    """Record provider semantics without conflating them with the HTTP status."""
+    context = get_current_request_context()
+    if context is not None:
+        context.outcome = outcome
+
+
+def record_chat_response_outcome(response: ChatResponse) -> TerminalOutcome | None:
+    """Resolve canonical or legacy Chat terminal data and record it when present."""
+    outcome = resolve_terminal_outcome(response.terminal_outcome, response.finish_reason)
+    if outcome is not None:
+        record_terminal_outcome(outcome)
+    return outcome

--- a/src/router_maestro/server/routes/admin.py
+++ b/src/router_maestro/server/routes/admin.py
@@ -1,11 +1,19 @@
 """Admin API routes for remote management."""
 
+import asyncio
 import logging
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 
-from router_maestro.auth import AuthManager, AuthType
+from router_maestro.auth import (
+    ApiKeyCredential,
+    AuthManager,
+    AuthType,
+    Credential,
+    CredentialRepository,
+    provider_auth_definitions,
+)
 from router_maestro.auth.github_oauth import (
     GitHubOAuthError,
     get_copilot_token,
@@ -18,11 +26,13 @@ from router_maestro.config.repository import (
     RuntimeConfigRepository,
     RuntimeConfigSnapshot,
 )
-from router_maestro.routing import get_router, reset_router
+from router_maestro.config.settings import load_providers_config
 from router_maestro.routing.model_ref import catalog_model_public_id
 from router_maestro.server.oauth_sessions import oauth_sessions
 from router_maestro.server.schemas.admin import (
     AuthListResponse,
+    AuthProviderDefinitionInfo,
+    AuthProviderDefinitionsResponse,
     AuthProviderInfo,
     LoginRequest,
     ModelInfo,
@@ -54,6 +64,75 @@ def _runtime_config_response(snapshot: RuntimeConfigSnapshot) -> PrioritiesRespo
 
 def _set_revision_etag(response: Response, revision: str) -> None:
     response.headers["ETag"] = f'"{revision}"'
+
+
+async def _wait_for_task_ignoring_cancellation(task: asyncio.Task) -> bool:
+    """Wait for a task to finish and report whether its caller was cancelled."""
+    cancelled = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            cancelled = True
+    return cancelled
+
+
+async def _compensate_cancelled_credential_write(
+    *,
+    provider: str,
+    previous: Credential | None,
+    replacement: Credential,
+    credential_repository: CredentialRepository,
+) -> None:
+    """Conditionally undo a cancelled write without letting more cancellation interrupt it."""
+    compensation_task = asyncio.create_task(
+        asyncio.to_thread(
+            credential_repository.compare_and_swap_provider,
+            provider,
+            expected=replacement,
+            replacement=previous,
+        )
+    )
+    await _wait_for_task_ignoring_cancellation(compensation_task)
+    try:
+        restored = compensation_task.result()
+        if not restored:
+            logger.info(
+                "Credential compensation skipped for %s because it changed concurrently",
+                provider,
+            )
+    except Exception:
+        logger.exception("Failed to compensate cancelled credential mutation for %s", provider)
+
+
+async def _rebuild_after_credential_mutation(
+    *,
+    provider: str,
+    previous: Credential | None,
+    replacement: Credential | None,
+    credential_repository: CredentialRepository,
+    runtime_config_repository: RuntimeConfigRepository,
+    router_owner,
+) -> None:
+    """Rebuild for one credential mutation, compensating only our own write on failure."""
+    try:
+        snapshot = runtime_config_repository.read()
+        await router_owner.rebuild(config_snapshot=snapshot)
+    except BaseException:
+        try:
+            restored = credential_repository.compare_and_swap_provider(
+                provider,
+                expected=replacement,
+                replacement=previous,
+            )
+            if not restored:
+                logger.info(
+                    "Credential compensation skipped for %s because it changed concurrently",
+                    provider,
+                )
+        except Exception:
+            logger.exception("Failed to compensate credential mutation for %s", provider)
+        raise
 
 
 # ============================================================================
@@ -90,17 +169,39 @@ async def list_auth() -> AuthListResponse:
     return AuthListResponse(providers=providers)
 
 
+@router.get("/auth/providers", response_model=AuthProviderDefinitionsResponse)
+def list_auth_providers() -> AuthProviderDefinitionsResponse:
+    """List non-secret authentication definitions configured on this server."""
+    definitions = provider_auth_definitions(load_providers_config())
+    return AuthProviderDefinitionsResponse(
+        providers=[
+            AuthProviderDefinitionInfo(
+                provider=definition.provider,
+                display_name=definition.display_name,
+                auth_type=definition.auth_type,
+                credential_required=definition.credential_required,
+                source=definition.source,
+                api_key_env=definition.api_key_env,
+            )
+            for definition in definitions
+        ]
+    )
+
+
 @router.post("/auth/login")
 async def login(
     request: LoginRequest,
     background_tasks: BackgroundTasks,
+    router_owner=Depends(get_router_owner),
+    runtime_config_repository: RuntimeConfigRepository = Depends(get_runtime_config_repository),
 ) -> OAuthInitResponse | dict:
     """Initiate login for a provider.
 
     For OAuth providers (github-copilot): Returns session info for device flow polling.
     For API key providers: Saves the key and returns success.
     """
-    manager = AuthManager()
+    credential_repository = CredentialRepository()
+    manager = AuthManager(credential_repository)
 
     if request.provider == "github-copilot":
         # OAuth device flow
@@ -126,6 +227,9 @@ async def login(
             session.session_id,
             device_code.device_code,
             device_code.interval,
+            router_owner,
+            credential_repository,
+            runtime_config_repository,
         )
 
         return OAuthInitResponse(
@@ -137,9 +241,17 @@ async def login(
 
     elif request.api_key:
         # API key auth
+        previous = credential_repository.get_provider(request.provider)
+        replacement = ApiKeyCredential(key=request.api_key)
         manager.login_api_key(request.provider, request.api_key)
-        # Reset router to pick up new authentication
-        reset_router()
+        await _rebuild_after_credential_mutation(
+            provider=request.provider,
+            previous=previous,
+            replacement=replacement,
+            credential_repository=credential_repository,
+            runtime_config_repository=runtime_config_repository,
+            router_owner=router_owner,
+        )
         return {"success": True, "provider": request.provider}
 
     else:
@@ -153,10 +265,11 @@ async def _poll_oauth_completion(
     session_id: str,
     device_code: str,
     interval: int,
+    router_owner,
+    credential_repository: CredentialRepository,
+    runtime_config_repository: RuntimeConfigRepository,
 ) -> None:
     """Background task to poll for OAuth completion and save credentials."""
-    manager = AuthManager()
-
     async with httpx.AsyncClient() as client:
         try:
             # Poll for access token
@@ -171,16 +284,42 @@ async def _poll_oauth_completion(
             copilot_token = await get_copilot_token(client, access_token.access_token)
 
             # Save credentials
-            manager.storage.set(
-                "github-copilot",
-                OAuthCredential(
-                    refresh=access_token.access_token,
-                    access=copilot_token.token,
-                    expires=copilot_token.expires_at,
-                    api_endpoint=copilot_token.api_endpoint,
-                ),
+            credential = OAuthCredential(
+                refresh=access_token.access_token,
+                access=copilot_token.token,
+                expires=copilot_token.expires_at,
+                api_endpoint=copilot_token.api_endpoint,
             )
-            manager.save()
+            previous = await asyncio.to_thread(
+                credential_repository.get_provider,
+                "github-copilot",
+            )
+            update_task = asyncio.create_task(
+                asyncio.to_thread(
+                    credential_repository.update_provider,
+                    "github-copilot",
+                    credential,
+                )
+            )
+            cancelled = await _wait_for_task_ignoring_cancellation(update_task)
+            if cancelled:
+                await _compensate_cancelled_credential_write(
+                    provider="github-copilot",
+                    previous=previous,
+                    replacement=credential,
+                    credential_repository=credential_repository,
+                )
+                raise asyncio.CancelledError
+            update_task.result()
+
+            await _rebuild_after_credential_mutation(
+                provider="github-copilot",
+                previous=previous,
+                replacement=credential,
+                credential_repository=credential_repository,
+                runtime_config_repository=runtime_config_repository,
+                router_owner=router_owner,
+            )
 
             # Update session status
             await oauth_sessions.update_session_status(
@@ -189,9 +328,6 @@ async def _poll_oauth_completion(
                 access_token=copilot_token.token,
                 refresh_token=access_token.access_token,
             )
-
-            # Reset router to pick up new authentication
-            reset_router()
 
         except GitHubOAuthError as e:
             await oauth_sessions.update_session_status(
@@ -221,13 +357,25 @@ async def get_oauth_status(session_id: str) -> OAuthStatusResponse:
 
 
 @router.delete("/auth/{provider}")
-async def logout(provider: str) -> dict:
+async def logout(
+    provider: str,
+    router_owner=Depends(get_router_owner),
+    runtime_config_repository: RuntimeConfigRepository = Depends(get_runtime_config_repository),
+) -> dict:
     """Log out from a provider."""
-    manager = AuthManager()
+    credential_repository = CredentialRepository()
+    manager = AuthManager(credential_repository)
+    previous = credential_repository.get_provider(provider)
 
     if manager.logout(provider):
-        # Reset router to reflect authentication change
-        reset_router()
+        await _rebuild_after_credential_mutation(
+            provider=provider,
+            previous=previous,
+            replacement=None,
+            credential_repository=credential_repository,
+            runtime_config_repository=runtime_config_repository,
+            router_owner=router_owner,
+        )
         return {"success": True, "provider": provider}
     else:
         raise HTTPException(status_code=404, detail=f"Not authenticated with {provider}")
@@ -239,47 +387,54 @@ async def logout(provider: str) -> dict:
 
 
 @router.get("/models", response_model=ModelsResponse)
-async def list_models() -> ModelsResponse:
+async def list_models(router_owner=Depends(get_router_owner)) -> ModelsResponse:
     """List all available models from authenticated providers."""
-    router_instance = get_router()
+    lease = await router_owner.acquire()
 
     try:
-        models = await router_instance.list_models()
+        models = await lease.router.list_models()
+        model_list = [
+            ModelInfo(
+                provider=model.provider,
+                id=catalog_model_public_id(
+                    model.provider,
+                    model.id,
+                    id_is_qualified=model.id_is_qualified,
+                ),
+                name=model.name,
+                max_prompt_tokens=model.max_prompt_tokens,
+                max_output_tokens=model.max_output_tokens,
+                max_context_window_tokens=model.max_context_window_tokens,
+            )
+            for model in models
+        ]
+        return ModelsResponse(models=model_list)
     except Exception:
         logger.error("Failed to list models", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to list models")
-
-    model_list = [
-        ModelInfo(
-            provider=model.provider,
-            id=catalog_model_public_id(
-                model.provider,
-                model.id,
-                id_is_qualified=model.id_is_qualified,
-            ),
-            name=model.name,
-            max_prompt_tokens=model.max_prompt_tokens,
-            max_output_tokens=model.max_output_tokens,
-            max_context_window_tokens=model.max_context_window_tokens,
-        )
-        for model in models
-    ]
-
-    return ModelsResponse(models=model_list)
+    finally:
+        await lease.release()
 
 
 @router.post("/models/refresh")
-async def refresh_models() -> dict:
+async def refresh_models(
+    router_owner=Depends(get_router_owner),
+    runtime_config_repository: RuntimeConfigRepository = Depends(get_runtime_config_repository),
+) -> dict:
     """Force refresh the models cache."""
-    router_instance = get_router()
-    router_instance.invalidate_cache()
-    # Trigger re-population
+    lease = None
     try:
-        models = await router_instance.list_models()
+        snapshot = runtime_config_repository.read()
+        await router_owner.rebuild(config_snapshot=snapshot)
+        lease = await router_owner.acquire()
+        models = await lease.router.list_models()
         return {"success": True, "models_count": len(models)}
     except Exception:
         logger.error("Failed to refresh models", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to refresh models")
+    finally:
+        if lease is not None:
+            await lease.release()
 
 
 # ============================================================================
@@ -308,10 +463,32 @@ async def update_priorities(
 ) -> PrioritiesResponse:
     """Replace runtime configuration using content-revision compare-and-swap."""
     replacement = request.model_dump(exclude={"revision"})
+    persisted_snapshot: RuntimeConfigSnapshot | None = None
+
     try:
-        snapshot = repository.compare_and_swap(
-            expected_revision=request.revision,
-            replacement=repository.read().config.model_validate(replacement),
+        current = repository.read()
+        if current.revision != request.revision:
+            raise RuntimeConfigConflictError(
+                expected_revision=request.revision,
+                current_revision=current.revision,
+            )
+        replacement_config = current.config.model_validate(replacement)
+        candidate = repository.prepare(replacement_config)
+        if candidate.revision == current.revision:
+            _set_revision_etag(response, current.revision)
+            return _runtime_config_response(current)
+
+        def commit_candidate() -> RuntimeConfigSnapshot:
+            nonlocal persisted_snapshot
+            persisted_snapshot = repository.compare_and_swap(
+                expected_revision=request.revision,
+                replacement=replacement_config,
+            )
+            return persisted_snapshot
+
+        await router_owner.rebuild(
+            config_snapshot=candidate,
+            before_swap=commit_candidate,
         )
     except RuntimeConfigConflictError as error:
         raise HTTPException(
@@ -324,7 +501,7 @@ async def update_priorities(
             headers={"ETag": f'"{error.current_revision}"'},
         ) from error
 
-    if snapshot.revision != request.revision:
-        await router_owner.rebuild(config_snapshot=snapshot)
-    _set_revision_etag(response, snapshot.revision)
-    return _runtime_config_response(snapshot)
+    if persisted_snapshot is None:
+        raise RuntimeError("Router owner did not commit the runtime configuration candidate")
+    _set_revision_etag(response, persisted_snapshot.revision)
+    return _runtime_config_response(persisted_snapshot)

--- a/src/router_maestro/server/routes/admin.py
+++ b/src/router_maestro/server/routes/admin.py
@@ -3,7 +3,7 @@
 import logging
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 
 from router_maestro.auth import AuthManager, AuthType
 from router_maestro.auth.github_oauth import (
@@ -13,9 +13,10 @@ from router_maestro.auth.github_oauth import (
     request_device_code,
 )
 from router_maestro.auth.storage import OAuthCredential
-from router_maestro.config import (
-    load_priorities_config,
-    save_priorities_config,
+from router_maestro.config.repository import (
+    RuntimeConfigConflictError,
+    RuntimeConfigRepository,
+    RuntimeConfigSnapshot,
 )
 from router_maestro.routing import get_router, reset_router
 from router_maestro.routing.model_ref import catalog_model_public_id
@@ -35,6 +36,24 @@ from router_maestro.server.schemas.admin import (
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
 logger = logging.getLogger("router_maestro.server.routes.admin")
+
+
+def get_runtime_config_repository(request: Request) -> RuntimeConfigRepository:
+    """Return the application-owned runtime configuration repository."""
+    return request.app.state.runtime_config_repository
+
+
+def get_router_owner(request: Request):
+    """Return the application-owned Router generation owner."""
+    return request.app.state.router_owner
+
+
+def _runtime_config_response(snapshot: RuntimeConfigSnapshot) -> PrioritiesResponse:
+    return PrioritiesResponse(**snapshot.config.model_dump(mode="json"), revision=snapshot.revision)
+
+
+def _set_revision_etag(response: Response, revision: str) -> None:
+    response.headers["ETag"] = f'"{revision}"'
 
 
 # ============================================================================
@@ -269,34 +288,43 @@ async def refresh_models() -> dict:
 
 
 @router.get("/priorities", response_model=PrioritiesResponse)
-async def get_priorities() -> PrioritiesResponse:
+async def get_priorities(
+    response: Response,
+    repository: RuntimeConfigRepository = Depends(get_runtime_config_repository),
+) -> PrioritiesResponse:
     """Get current priority configuration."""
-    config = load_priorities_config()
-
-    return PrioritiesResponse(
-        priorities=config.priorities,
-        fallback=config.fallback.model_dump(),
-    )
+    snapshot = repository.read()
+    _set_revision_etag(response, snapshot.revision)
+    return _runtime_config_response(snapshot)
 
 
+@router.patch("/priorities", response_model=PrioritiesResponse)
 @router.put("/priorities", response_model=PrioritiesResponse)
-async def update_priorities(request: PrioritiesUpdateRequest) -> PrioritiesResponse:
-    """Update priority configuration."""
-    config = load_priorities_config()
+async def update_priorities(
+    request: PrioritiesUpdateRequest,
+    response: Response,
+    repository: RuntimeConfigRepository = Depends(get_runtime_config_repository),
+    router_owner=Depends(get_router_owner),
+) -> PrioritiesResponse:
+    """Replace runtime configuration using content-revision compare-and-swap."""
+    replacement = request.model_dump(exclude={"revision"})
+    try:
+        snapshot = repository.compare_and_swap(
+            expected_revision=request.revision,
+            replacement=repository.read().config.model_validate(replacement),
+        )
+    except RuntimeConfigConflictError as error:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "config_revision_conflict",
+                "message": "Runtime configuration changed; refresh and retry",
+                "current_revision": error.current_revision,
+            },
+            headers={"ETag": f'"{error.current_revision}"'},
+        ) from error
 
-    # Update priorities
-    config.priorities = request.priorities
-
-    # Update fallback if provided
-    if request.fallback is not None:
-        from router_maestro.config import FallbackConfig
-
-        config.fallback = FallbackConfig.model_validate(request.fallback)
-
-    save_priorities_config(config)
-    reset_router()
-
-    return PrioritiesResponse(
-        priorities=config.priorities,
-        fallback=config.fallback.model_dump(),
-    )
+    if snapshot.revision != request.revision:
+        await router_owner.rebuild(config_snapshot=snapshot)
+    _set_revision_etag(response, snapshot.revision)
+    return _runtime_config_response(snapshot)

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -37,6 +37,7 @@ from router_maestro.server.protocols.anthropic_reducer import (
     build_anthropic_response,
 )
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
+from router_maestro.server.routes._outcomes import record_chat_response_outcome
 from router_maestro.server.schemas.anthropic import (
     AnthropicCountTokensRequest,
     AnthropicMessagesRequest,
@@ -120,9 +121,15 @@ async def _apply_thinking_budget(
             thinking_type=chat_request.thinking_type,
         )
 
-    from router_maestro.config import load_priorities_config
+    from router_maestro.runtime import get_current_request_context
 
-    priorities = load_priorities_config()
+    context = get_current_request_context()
+    if context is not None:
+        priorities = context.config
+    else:
+        from router_maestro.config import load_priorities_config
+
+        priorities = load_priorities_config()
     thinking_config = priorities.thinking
 
     translated_model = chat_request.model
@@ -428,6 +435,7 @@ async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIReques
             response_id=f"msg_{uuid.uuid4().hex[:24]}",
             model=response_model,
         )
+        record_chat_response_outcome(response)
 
         logger.info(
             "Upstream response from %s: content_len=%s, tool_calls=%s, finish_reason=%s",

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -17,7 +17,18 @@ from fastapi import Request as FastAPIRequest
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
-from router_maestro.providers import ProviderError, ProviderFailureKind, RequestOptionError
+from router_maestro.providers import (
+    ProviderError,
+    ProviderFailureKind,
+    RequestOptionError,
+    ResponseStatus,
+    TerminalError,
+    TerminalOutcome,
+    TransportTermination,
+    client_cancelled_outcome,
+    exception_outcome,
+    unexpected_eof_outcome,
+)
 from router_maestro.providers.copilot import CopilotProvider
 from router_maestro.routing import get_router
 from router_maestro.routing.capabilities import CapabilitySupport, Operation, RequestFeatures
@@ -121,6 +132,10 @@ class _NativeUpstreamStatusError(ProviderError):
             model=model,
         )
         self.response = response
+
+
+class _NativeUnexpectedEOFError(ProviderError):
+    """Native Anthropic transport ended cleanly before a terminal event."""
 
 
 def _raise_for_native_status(response, candidate: RouteCandidate) -> None:
@@ -494,9 +509,15 @@ def _apply_thinking_budget_native(
         ):
             return body
 
-    from router_maestro.config import load_priorities_config
+    from router_maestro.runtime import get_current_request_context
 
-    priorities = load_priorities_config()
+    context = get_current_request_context()
+    if context is not None:
+        priorities = context.config
+    else:
+        from router_maestro.config import load_priorities_config
+
+        priorities = load_priorities_config()
     thinking_config = priorities.thinking
 
     client_budget = None
@@ -693,7 +714,12 @@ async def _stream_native_candidate(
         except ProviderError as error:
             if error.kind is not ProviderFailureKind.UPSTREAM_PROTOCOL or error.provider:
                 raise
-            raise ProviderError(
+            error_type = (
+                _NativeUnexpectedEOFError
+                if isinstance(error, _NativeUnexpectedEOFError)
+                else ProviderError
+            )
+            raise error_type(
                 error.safe_message,
                 status_code=error.status_code,
                 retryable=error.retryable,
@@ -709,15 +735,195 @@ async def _stream_native_candidate(
 
 async def _encode_native_stream_errors(
     stream: AsyncIterator[str],
+    *,
+    pipeline=None,
 ) -> AsyncGenerator[str, None]:
-    """Encode a post-commit native provider failure in the active SSE response."""
+    """Apply raw stream guards and preserve native semantic terminal state."""
+    terminal_outcome: TerminalOutcome | None = None
+    response_status = ResponseStatus.COMPLETED
+    raw_leak_guard = None
+    if pipeline is not None and pipeline.leak_guard is not None:
+        from router_maestro.pipeline.leak_guard import RawFrameLeakGuard
+
+        raw_leak_guard = RawFrameLeakGuard(inner=pipeline.leak_guard)
     try:
         async for frame in stream:
+            event_type, data = _parse_native_frame(frame)
+            if pipeline is not None:
+                abort_reason = _feed_native_frame_guards(
+                    pipeline,
+                    raw_leak_guard,
+                    event_type,
+                    data,
+                )
+                if abort_reason is not None:
+                    terminal_outcome = exception_outcome(abort_reason, code="overloaded")
+                    pipeline.finish(
+                        wire_status=200,
+                        outcome=terminal_outcome,
+                        body_summary=abort_reason,
+                    )
+                    yield _native_overload_event()
+                    return
+            if event_type == "message_delta" and isinstance(data, dict):
+                delta = data.get("delta")
+                if isinstance(delta, dict):
+                    stop_reason = delta.get("stop_reason")
+                    if stop_reason in {"max_tokens", "model_context_window_exceeded"}:
+                        response_status = ResponseStatus.INCOMPLETE
+                    elif stop_reason is not None:
+                        response_status = ResponseStatus.COMPLETED
+            frame_outcome = _native_frame_outcome(
+                event_type,
+                data,
+                response_status=response_status,
+            )
+            if frame_outcome is not None:
+                terminal_outcome = frame_outcome
             yield frame
-    except ProviderError as error:
+            if terminal_outcome is not None:
+                if pipeline is not None:
+                    pipeline.finish(wire_status=200, outcome=terminal_outcome)
+                return
+        terminal_outcome = unexpected_eof_outcome()
+        if pipeline is not None:
+            pipeline.finish(
+                wire_status=200,
+                outcome=terminal_outcome,
+                body_summary=terminal_outcome.error.message,
+            )
+        yield _sse_error_event(
+            ProviderError(
+                terminal_outcome.error.message,
+                status_code=502,
+                retryable=True,
+                kind=ProviderFailureKind.UPSTREAM_PROTOCOL,
+            )
+        )
+    except _NativeUnexpectedEOFError as error:
+        terminal_outcome = unexpected_eof_outcome()
+        if pipeline is not None:
+            pipeline.finish(
+                wire_status=200,
+                outcome=terminal_outcome,
+                body_summary=terminal_outcome.error.message,
+            )
         yield _sse_error_event(error)
+    except ProviderError as error:
+        terminal_outcome = exception_outcome(error.safe_message, code="provider_error")
+        if pipeline is not None:
+            pipeline.finish(
+                wire_status=200,
+                outcome=terminal_outcome,
+                body_summary=error.safe_message,
+            )
+        yield _sse_error_event(error)
+    except asyncio.CancelledError:
+        if pipeline is not None:
+            pipeline.finish(wire_status=200, outcome=client_cancelled_outcome())
+        raise
+    except Exception:
+        terminal_outcome = exception_outcome("Internal server error", code="server_error")
+        if pipeline is not None:
+            pipeline.finish(
+                wire_status=200,
+                outcome=terminal_outcome,
+                body_summary="Internal server error",
+            )
+        logger.error("Unexpected error in beta anthropic stream", exc_info=True)
+        yield _sse_error_event("Internal server error")
     finally:
         await close_async_iterator(stream)
+
+
+def _parse_native_frame(frame: str) -> tuple[str | None, dict | None]:
+    """Return the event discriminator and JSON object from one encoded frame."""
+    event_type: str | None = None
+    data: dict | None = None
+    for line in frame.splitlines():
+        if line.startswith("event: "):
+            event_type = line.removeprefix("event: ")
+        elif line.startswith("data: "):
+            try:
+                parsed = json.loads(line.removeprefix("data: "))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                data = parsed
+    return event_type, data
+
+
+def _feed_native_frame_guards(
+    pipeline,
+    raw_leak_guard,
+    event_type: str | None,
+    data: dict | None,
+) -> str | None:
+    """Project native content deltas onto the shared guard input contract."""
+    if event_type != "content_block_delta" or data is None:
+        return None
+    delta = data.get("delta")
+    if not isinstance(delta, dict):
+        return None
+    from router_maestro.providers.base import ChatStreamChunk
+
+    delta_type = delta.get("type")
+    if delta_type == "text_delta":
+        chunk = ChatStreamChunk(content=delta.get("text", ""))
+    elif delta_type == "thinking_delta":
+        if raw_leak_guard is not None:
+            leak_reason = raw_leak_guard.feed_frame(event_type, json.dumps(data))
+            if leak_reason is not None:
+                return leak_reason
+        chunk = ChatStreamChunk(content="", thinking=delta.get("thinking", ""))
+    elif delta_type == "input_json_delta":
+        chunk = ChatStreamChunk(
+            content="",
+            tool_calls=[{"function": {"arguments": delta.get("partial_json", "")}}],
+        )
+    else:
+        return None
+    return pipeline.feed_stream(chunk)
+
+
+def _native_frame_outcome(
+    event_type: str | None,
+    data: dict | None,
+    *,
+    response_status: ResponseStatus,
+) -> TerminalOutcome | None:
+    """Map a native Anthropic terminal event onto the shared semantic outcome."""
+    if event_type == "error":
+        error = data.get("error") if isinstance(data, dict) else None
+        error_type = error.get("type") if isinstance(error, dict) else "api_error"
+        message = error.get("message") if isinstance(error, dict) else "Upstream response failed"
+        return TerminalOutcome(
+            transport=TransportTermination.EXPLICIT_TERMINAL,
+            response_status=ResponseStatus.FAILED,
+            error=TerminalError(code=str(error_type), message=str(message)),
+        )
+    if event_type != "message_stop":
+        return None
+    return TerminalOutcome(
+        transport=TransportTermination.EXPLICIT_TERMINAL,
+        response_status=response_status,
+        incomplete_details=(
+            {"reason": "max_output_tokens"}
+            if response_status is ResponseStatus.INCOMPLETE
+            else None
+        ),
+    )
+
+
+def _native_overload_event() -> str:
+    return _sse_error_event(
+        ProviderError(
+            "Overloaded: please retry this request",
+            status_code=529,
+            retryable=True,
+            kind=ProviderFailureKind.RATE_LIMIT,
+        )
+    )
 
 
 def _qualify_native_stream_frame(frame: str, qualified_model: str) -> str:
@@ -880,6 +1086,21 @@ async def beta_messages(raw_request: FastAPIRequest):
         await copilot_provider.ensure_token()
 
     if stream:
+        from router_maestro.pipeline import RequestPipeline
+
+        tool_names = {
+            tool.get("name", "")
+            for tool in body.get("tools", [])
+            if isinstance(tool, dict) and tool.get("name")
+        } or None
+        from router_maestro.runtime import get_current_request_context
+
+        context = get_current_request_context()
+        pipeline = RequestPipeline.create(
+            request_id=(context.request_id if context is not None else f"beta-{actual_model}"),
+            model=model,
+            tool_names=tool_names,
+        )
         if native_resolution.plan is not None:
             try:
                 selected_stream, _used_provider = await Router.execute_plan_stream(
@@ -895,11 +1116,18 @@ async def beta_messages(raw_request: FastAPIRequest):
                 )
                 return protocol_error_response(e, "anthropic")
             return sse_streaming_response(
-                _encode_native_stream_errors(selected_stream),
+                _encode_native_stream_errors(selected_stream, pipeline=pipeline),
                 keepalive_frame=ANTHROPIC_PING_FRAME,
             )
         return sse_streaming_response(
-            _stream_passthrough(copilot_provider, body),
+            _encode_native_stream_errors(
+                _stream_passthrough(
+                    copilot_provider,
+                    body,
+                    raise_provider_errors=True,
+                ),
+                pipeline=pipeline,
+            ),
             keepalive_frame=ANTHROPIC_PING_FRAME,
         )
 
@@ -1074,15 +1302,6 @@ async def _stream_passthrough(
     On a signature validation error (400), strips history thinking blocks
     and retries once before surfacing the error.
     """
-    # Build leak guard with tool names from the payload
-    from router_maestro.pipeline.leak_guard import RawFrameLeakGuard
-
-    tool_names: set[str] | None = None
-    tools = payload.get("tools")
-    if tools:
-        tool_names = {t.get("name", "") for t in tools if t.get("name")} or None
-    leak_guard = RawFrameLeakGuard(allowed_tool_names=tool_names)
-
     try:
         async with provider._stream_with_auth_retry(
             COPILOT_MESSAGES_PATH,
@@ -1121,7 +1340,7 @@ async def _stream_passthrough(
                 return
             else:
                 # Success — stream events
-                async for frame in _iter_sse_frames(response, leak_guard=leak_guard):
+                async for frame in _iter_sse_frames(response):
                     yield frame
                 return
 
@@ -1144,9 +1363,11 @@ async def _stream_passthrough(
                 yield _sse_error_event(msg)
                 return
 
-            async for frame in _iter_sse_frames(response, leak_guard=leak_guard):
+            async for frame in _iter_sse_frames(response):
                 yield frame
 
+    except _NativeUnexpectedEOFError:
+        raise
     except ProviderError as e:
         if raise_provider_errors:
             raise
@@ -1206,7 +1427,7 @@ async def _iter_sse_frames(response, *, leak_guard=None) -> AsyncGenerator[str, 
     if current_event is not None or data_buffer:
         _raise_native_stream_protocol_error(ValueError("truncated upstream SSE frame"))
     if not terminal_received:
-        _raise_native_stream_protocol_error(
+        _raise_native_stream_unexpected_eof(
             ValueError("upstream SSE ended before a terminal event")
         )
 
@@ -1214,6 +1435,18 @@ async def _iter_sse_frames(response, *, leak_guard=None) -> AsyncGenerator[str, 
 def _raise_native_stream_protocol_error(cause: BaseException) -> None:
     """Raise a safe retryable failure for malformed native Anthropic SSE."""
     raise ProviderError(
+        "Native Anthropic upstream returned a malformed stream",
+        status_code=502,
+        retryable=True,
+        kind=ProviderFailureKind.UPSTREAM_PROTOCOL,
+        upstream_status_code=200,
+        cause=cause,
+    ) from cause
+
+
+def _raise_native_stream_unexpected_eof(cause: BaseException) -> None:
+    """Raise the typed signal for clean EOF before a native terminal event."""
+    raise _NativeUnexpectedEOFError(
         "Native Anthropic upstream returned a malformed stream",
         status_code=502,
         retryable=True,

--- a/src/router_maestro/server/routes/chat.py
+++ b/src/router_maestro/server/routes/chat.py
@@ -27,6 +27,7 @@ from router_maestro.routing import Router, get_router
 from router_maestro.routing.model_ref import qualify_model_id
 from router_maestro.server.protocols import client_error_response, unrepresented_option_error
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
+from router_maestro.server.routes._outcomes import record_chat_response_outcome
 from router_maestro.server.schemas import (
     ChatCompletionChoice,
     ChatCompletionChunk,
@@ -239,7 +240,7 @@ async def chat_completions(request: ChatCompletionRequest):
         if response.tool_calls:
             response_tool_calls = [ChatMessageToolCall(**tc) for tc in response.tool_calls]
 
-        return ChatCompletionResponse(
+        downstream_response = ChatCompletionResponse(
             id=f"chatcmpl-{uuid.uuid4().hex[:8]}",
             created=int(time.time()),
             model=(
@@ -261,6 +262,8 @@ async def chat_completions(request: ChatCompletionRequest):
             ],
             usage=usage,
         )
+        record_chat_response_outcome(response)
+        return downstream_response
     except ProviderError as e:
         logger.error("Chat completion request failed: %s", e)
         if isinstance(e, RequestOptionError):

--- a/src/router_maestro/server/routes/gemini.py
+++ b/src/router_maestro/server/routes/gemini.py
@@ -24,6 +24,7 @@ from router_maestro.routing import get_router
 from router_maestro.routing.model_ref import qualify_model_id
 from router_maestro.server.protocols import client_error_response, unrepresented_option_error
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
+from router_maestro.server.routes._outcomes import record_chat_response_outcome
 from router_maestro.server.schemas.gemini import (
     GeminiCandidate,
     GeminiContent,
@@ -116,7 +117,7 @@ async def generate_content(
     try:
         response, provider_name = await model_router.chat_completion(chat_request)
         estimated_tokens = _estimate_input_tokens(request)
-        return translate_openai_to_gemini(
+        downstream_response = translate_openai_to_gemini(
             response,
             (
                 response.selected_model.qualified_id
@@ -125,6 +126,8 @@ async def generate_content(
             ),
             input_tokens=estimated_tokens,
         ).model_dump(by_alias=True, exclude_none=True)
+        record_chat_response_outcome(response)
+        return downstream_response
     except ProviderError as e:
         logger.error("Gemini generateContent request failed: %s", e)
         if isinstance(e, RequestOptionError):

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -28,6 +28,7 @@ from router_maestro.server.protocols import (
     unrepresented_option_error,
 )
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
+from router_maestro.server.routes._outcomes import record_terminal_outcome
 from router_maestro.server.schemas import (
     ResponsesReasoningConfig,
     ResponsesRequest,
@@ -311,7 +312,9 @@ async def create_response(request: ResponsesRequest):
             if payload["usage"] is not None
             else None
         )
-        return ResponsesResponse.model_construct(**{**payload, "usage": usage})
+        downstream_response = ResponsesResponse.model_construct(**{**payload, "usage": usage})
+        record_terminal_outcome(snapshot.outcome)
+        return downstream_response
     except ProviderError as e:
         elapsed_ms = (time.time() - start_time) * 1000
         logger.error(

--- a/src/router_maestro/server/schemas/admin.py
+++ b/src/router_maestro/server/schemas/admin.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, Field
 
+from router_maestro.config.priorities import PrioritiesConfig
+
 
 class AuthProviderInfo(BaseModel):
     """Information about an authenticated provider."""
@@ -59,15 +61,20 @@ class ModelsResponse(BaseModel):
     models: list[ModelInfo] = Field(default_factory=list)
 
 
-class PrioritiesResponse(BaseModel):
-    """Response for getting priorities."""
-
-    priorities: list[str] = Field(default_factory=list, description="Model priorities in order")
-    fallback: dict = Field(default_factory=dict, description="Fallback configuration")
+REVISION_PATTERN = r"^[0-9a-f]{64}$"
 
 
-class PrioritiesUpdateRequest(BaseModel):
-    """Request to update priorities."""
+class RuntimeConfigResponse(PrioritiesConfig):
+    """Complete runtime configuration at one content revision."""
 
-    priorities: list[str] = Field(..., description="New priority list")
-    fallback: dict | None = Field(default=None, description="Optional fallback config update")
+    revision: str = Field(pattern=REVISION_PATTERN)
+
+
+class RuntimeConfigPatchRequest(PrioritiesConfig):
+    """Complete replacement runtime configuration with its expected revision."""
+
+    revision: str = Field(pattern=REVISION_PATTERN)
+
+
+PrioritiesResponse = RuntimeConfigResponse
+PrioritiesUpdateRequest = RuntimeConfigPatchRequest

--- a/src/router_maestro/server/schemas/admin.py
+++ b/src/router_maestro/server/schemas/admin.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, Field
 
+from router_maestro.auth.discovery import ProviderAuthSource
+from router_maestro.auth.storage import AuthType
 from router_maestro.config.priorities import PrioritiesConfig
 
 
@@ -17,6 +19,23 @@ class AuthListResponse(BaseModel):
     """Response for listing authenticated providers."""
 
     providers: list[AuthProviderInfo] = Field(default_factory=list)
+
+
+class AuthProviderDefinitionInfo(BaseModel):
+    """Non-secret provider authentication metadata exposed by this server."""
+
+    provider: str
+    display_name: str
+    auth_type: AuthType
+    credential_required: bool
+    source: ProviderAuthSource
+    api_key_env: str | None = None
+
+
+class AuthProviderDefinitionsResponse(BaseModel):
+    """Provider login definitions configured for this server."""
+
+    providers: list[AuthProviderDefinitionInfo] = Field(default_factory=list)
 
 
 class LoginRequest(BaseModel):

--- a/src/router_maestro/utils/audit.py
+++ b/src/router_maestro/utils/audit.py
@@ -17,9 +17,11 @@ Activation:
 Trace directory defaults to ~/.local/share/router-maestro/traces/
 """
 
+import asyncio
 import json
 import os
 import time
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +34,20 @@ if TYPE_CHECKING:
 logger = get_logger("utils.audit")
 
 _SENSITIVE_HEADERS = frozenset({"authorization", "x-api-key", "x-goog-api-key"})
+_SENSITIVE_FIELD_KEYS = frozenset(
+    {
+        "apikey",
+        "accesstoken",
+        "idtoken",
+        "clientsecret",
+        "refreshtoken",
+        "authorization",
+        "password",
+        "secret",
+        "token",
+        "privatekey",
+    }
+)
 
 
 def is_tracing_enabled(audit_config_enabled: bool = False) -> bool:
@@ -67,6 +83,31 @@ def _safe_json(obj: Any) -> Any:
     return str(obj)
 
 
+def _redact_payload(obj: Any) -> Any:
+    """Return a detached value with credential-like payload fields removed."""
+    value = _safe_json(obj)
+    if isinstance(value, dict):
+        return {
+            key: (
+                "***"
+                if "".join(character for character in str(key).casefold() if character.isalnum())
+                in _SENSITIVE_FIELD_KEYS
+                else _redact_payload(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_payload(item) for item in value]
+    return value
+
+
+def _write_records(trace_dir: Path, records: dict[str, Any]) -> None:
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    for name, data in records.items():
+        path = trace_dir / f"{name}.json"
+        path.write_text(json.dumps(data, indent=2, default=str))
+
+
 class AuditTrace:
     """Collects per-request trace data and writes to disk on flush."""
 
@@ -75,6 +116,14 @@ class AuditTrace:
         self._dir = trace_dir / request_id
         self._records: dict[str, Any] = {}
         self._start_time = time.time()
+
+    def _append_record(self, base_name: str, record: dict[str, Any]) -> None:
+        index = 1
+        name = base_name
+        while name in self._records:
+            index += 1
+            name = f"{base_name}_{index}"
+        self._records[name] = record
 
     def record_inbound(
         self,
@@ -89,7 +138,7 @@ class AuditTrace:
             "method": method,
             "path": path,
             "headers": _redact_headers(headers),
-            "body": _safe_json(body),
+            "body": _redact_payload(body),
         }
 
     def record_upstream(
@@ -99,14 +148,17 @@ class AuditTrace:
         headers: dict[str, str],
         body: Any,
     ) -> None:
-        self._records["upstream"] = {
-            "timestamp": time.time(),
-            "request_id": self._request_id,
-            "method": method,
-            "url": url,
-            "headers": _redact_headers(headers),
-            "body": _safe_json(body),
-        }
+        self._append_record(
+            "upstream",
+            {
+                "timestamp": time.time(),
+                "request_id": self._request_id,
+                "method": method,
+                "url": url,
+                "headers": _redact_headers(headers),
+                "body": _redact_payload(body),
+            },
+        )
 
     def record_upstream_response(
         self,
@@ -120,13 +172,13 @@ class AuditTrace:
             "timestamp": time.time(),
             "request_id": self._request_id,
             "status": status,
-            "headers": dict(headers),
+            "headers": _redact_headers(headers),
         }
         if stream_summary:
             record["stream_summary"] = stream_summary
         elif body is not None:
-            record["body"] = _safe_json(body)
-        self._records["upstream_resp"] = record
+            record["body"] = _redact_payload(body)
+        self._append_record("upstream_resp", record)
 
     def record_outbound(
         self,
@@ -139,7 +191,7 @@ class AuditTrace:
             "timestamp": time.time(),
             "request_id": self._request_id,
             "status": status,
-            "headers": headers or {},
+            "headers": _redact_headers(headers or {}),
             "body_summary": body_summary,
             "duration_ms": round((time.time() - self._start_time) * 1000, 1),
         }
@@ -161,10 +213,19 @@ class AuditTrace:
             return
 
         try:
-            self._dir.mkdir(parents=True, exist_ok=True)
-            for name, data in self._records.items():
-                path = self._dir / f"{name}.json"
-                path.write_text(json.dumps(data, indent=2, default=str))
+            records = _redact_payload(deepcopy(self._records))
+            _write_records(self._dir, records)
             logger.debug("Audit trace written: %s (%d files)", self._dir, len(self._records))
         except OSError as e:
             logger.warning("Failed to write audit trace: %s", e)
+
+    async def flush_async(self) -> None:
+        """Write a redacted snapshot without blocking the event loop."""
+        if not self._records:
+            return
+        records = _redact_payload(deepcopy(self._records))
+        try:
+            await asyncio.to_thread(_write_records, self._dir, records)
+            logger.debug("Audit trace written: %s (%d files)", self._dir, len(records))
+        except OSError as error:
+            logger.warning("Failed to write audit trace: %s", error)

--- a/src/router_maestro/utils/cache.py
+++ b/src/router_maestro/utils/cache.py
@@ -21,7 +21,7 @@ class TTLCache(Generic[T]):
     @property
     def is_valid(self) -> bool:
         """Check if the cached value is present and not expired."""
-        return self._value is not None and (time.time() - self._timestamp) < self._ttl
+        return self._value is not None and (time.monotonic() - self._timestamp) < self._ttl
 
     def get(self) -> T | None:
         """Return the cached value if valid, otherwise None."""
@@ -32,7 +32,11 @@ class TTLCache(Generic[T]):
     def set(self, value: T) -> None:
         """Store a value with the current timestamp."""
         self._value = value
-        self._timestamp = time.time()
+        self._timestamp = time.monotonic()
+
+    def peek(self) -> T | None:
+        """Return the stored value regardless of TTL freshness."""
+        return self._value
 
     def clear(self) -> None:
         """Clear the cached value and timestamp."""

--- a/src/router_maestro/utils/responses_bridge.py
+++ b/src/router_maestro/utils/responses_bridge.py
@@ -453,6 +453,7 @@ def responses_response_to_chat_response(
         thinking_signature=getattr(resp, "thinking_signature", None),
         thinking_id=getattr(resp, "thinking_id", None),
         refusal=resp.refusal,
+        terminal_outcome=outcome,
     )
 
 

--- a/src/router_maestro/utils/token_config.py
+++ b/src/router_maestro/utils/token_config.py
@@ -22,6 +22,13 @@ import httpx
 logger = logging.getLogger("router_maestro.utils.token_config")
 
 
+def _request_audit():
+    from router_maestro.runtime import get_current_request_context
+
+    context = get_current_request_context()
+    return context.audit if context is not None else None
+
+
 @dataclass(frozen=True)
 class TokenCountingConfig:
     """Parameterises the token counting constants by provider.
@@ -160,9 +167,18 @@ async def count_tokens_via_anthropic_api(
         "anthropic-version": "2023-06-01",
         "content-type": "application/json",
     }
+    audit = _request_audit()
+    if audit is not None:
+        audit.record_upstream("POST", url, headers, payload)
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(url, json=payload, headers=headers)
+        if audit is not None:
+            audit.record_upstream_response(
+                response.status_code,
+                dict(response.headers),
+                response.content,
+            )
         response.raise_for_status()
         data = response.json()
 

--- a/tests/test_admin_client_runtime_config.py
+++ b/tests/test_admin_client_runtime_config.py
@@ -1,0 +1,70 @@
+"""CLI admin client contract for runtime-config compare-and-swap."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from router_maestro.cli.client import AdminClient, AdminConfigConflictError
+
+
+@pytest.mark.asyncio
+async def test_admin_client_patch_sends_complete_config_and_revision():
+    captured = {}
+
+    async def patch_request(url, **kwargs):
+        captured.update(url=url, **kwargs)
+        return httpx.Response(
+            200,
+            json={**kwargs["json"], "revision": "b" * 64},
+            request=httpx.Request("PATCH", url),
+        )
+
+    client = AdminClient("http://router.test", "secret")
+    config = {
+        "priorities": ["provider/model"],
+        "fallback": {"strategy": "priority", "maxRetries": 2},
+        "model_overrides": {},
+        "thinking": {"default_budget": 16000, "auto_enable": False, "model_budgets": {}},
+        "guards": {
+            "leak_guard": {"enabled": True},
+            "runaway_guard": {"enabled": True, "max_bytes": 10000000, "max_deltas": 50000},
+        },
+        "beta_strip": ["beta-*"],
+        "audit": {"enabled": False, "trace_dir": None},
+    }
+
+    with patch("router_maestro.cli.client.httpx.AsyncClient") as async_client:
+        async_client.return_value.__aenter__.return_value.patch = AsyncMock(
+            side_effect=patch_request
+        )
+        result = await client.patch_runtime_config(config=config, revision="a" * 64)
+
+    assert captured["url"] == "http://router.test/api/admin/priorities"
+    assert captured["json"] == {**config, "revision": "a" * 64}
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert result["revision"] == "b" * 64
+
+
+@pytest.mark.asyncio
+async def test_admin_client_maps_revision_conflict():
+    request = httpx.Request("PATCH", "http://router.test/api/admin/priorities")
+    response = httpx.Response(
+        409,
+        json={
+            "detail": {
+                "code": "config_revision_conflict",
+                "current_revision": "c" * 64,
+            }
+        },
+        headers={"ETag": f'"{"c" * 64}"'},
+        request=request,
+    )
+    client = AdminClient("http://router.test", "secret")
+
+    with patch("router_maestro.cli.client.httpx.AsyncClient") as async_client:
+        async_client.return_value.__aenter__.return_value.patch = AsyncMock(return_value=response)
+        with pytest.raises(AdminConfigConflictError) as exc_info:
+            await client.patch_runtime_config(config={}, revision="a" * 64)
+
+    assert exc_info.value.current_revision == "c" * 64

--- a/tests/test_admin_client_runtime_config.py
+++ b/tests/test_admin_client_runtime_config.py
@@ -68,3 +68,38 @@ async def test_admin_client_maps_revision_conflict():
             await client.patch_runtime_config(config={}, revision="a" * 64)
 
     assert exc_info.value.current_revision == "c" * 64
+
+
+@pytest.mark.asyncio
+async def test_admin_client_lists_typed_auth_provider_definitions():
+    captured = {}
+
+    async def get_request(url, **kwargs):
+        captured.update(url=url, **kwargs)
+        return httpx.Response(
+            200,
+            json={
+                "providers": [
+                    {
+                        "provider": "remote-custom",
+                        "display_name": "Remote Custom",
+                        "auth_type": "api",
+                        "credential_required": True,
+                        "source": "custom",
+                        "api_key_env": "REMOTE_CUSTOM_API_KEY",
+                    }
+                ]
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    client = AdminClient("http://router.test", "secret")
+    with patch("router_maestro.cli.client.httpx.AsyncClient") as async_client:
+        async_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=get_request)
+        definitions = await client.list_auth_providers()
+
+    assert captured["url"] == "http://router.test/api/admin/auth/providers"
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+    assert len(definitions) == 1
+    assert definitions[0].provider == "remote-custom"
+    assert definitions[0].credential_required is True

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -3,9 +3,10 @@
 from dataclasses import dataclass
 
 import pytest
+from starlette.responses import Response
 
 from router_maestro.auth.storage import OAuthCredential
-from router_maestro.config import PrioritiesConfig
+from router_maestro.config.repository import RuntimeConfigRepository
 from router_maestro.providers import ModelInfo as ProviderModelInfo
 from router_maestro.server.routes import admin
 from router_maestro.server.schemas.admin import PrioritiesUpdateRequest
@@ -86,21 +87,35 @@ async def test_oauth_completion_preserves_copilot_api_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_update_priorities_invalidates_router_cache_after_save(monkeypatch):
-    saved_configs: list[PrioritiesConfig] = []
-    reset_calls: list[None] = []
+async def test_update_priorities_rebuilds_router_after_cas(tmp_path):
+    repository = RuntimeConfigRepository(tmp_path / "priorities.json")
+    initial = repository.read()
 
-    monkeypatch.setattr(admin, "load_priorities_config", lambda: PrioritiesConfig())
-    monkeypatch.setattr(admin, "save_priorities_config", saved_configs.append)
-    monkeypatch.setattr(admin, "reset_router", lambda: reset_calls.append(None))
+    class _Owner:
+        snapshots = []
+
+        async def rebuild(self, *, config_snapshot=None):
+            self.snapshots.append(config_snapshot)
+            return 2
+
+    owner = _Owner()
+    wire_response = Response()
+    request = PrioritiesUpdateRequest(
+        **initial.config.model_dump(mode="json"),
+        revision=initial.revision,
+    )
+    request.priorities = ["github-copilot/gpt-4o"]
 
     response = await admin.update_priorities(
-        PrioritiesUpdateRequest(priorities=["github-copilot/gpt-4o"])
+        request,
+        wire_response,
+        repository,
+        owner,
     )
 
     assert response.priorities == ["github-copilot/gpt-4o"]
-    assert saved_configs[0].priorities == ["github-copilot/gpt-4o"]
-    assert reset_calls == [None]
+    assert repository.read().config.priorities == ["github-copilot/gpt-4o"]
+    assert [snapshot.revision for snapshot in owner.snapshots] == [response.revision]
 
 
 @pytest.mark.asyncio

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,15 +1,22 @@
 """Tests for admin route side effects."""
 
+import asyncio
+import threading
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
+from fastapi import BackgroundTasks
 from starlette.responses import Response
 
-from router_maestro.auth.storage import OAuthCredential
+from router_maestro.auth.discovery import ProviderAuthSource
+from router_maestro.auth.repository import CredentialRepository
+from router_maestro.auth.storage import ApiKeyCredential, AuthType, Credential, OAuthCredential
+from router_maestro.config.providers import CustomProviderConfig, ProvidersConfig
 from router_maestro.config.repository import RuntimeConfigRepository
 from router_maestro.providers import ModelInfo as ProviderModelInfo
 from router_maestro.server.routes import admin
-from router_maestro.server.schemas.admin import PrioritiesUpdateRequest
+from router_maestro.server.schemas.admin import LoginRequest, PrioritiesUpdateRequest
 
 
 @dataclass
@@ -24,24 +31,27 @@ class _CopilotToken:
     api_endpoint: str | None
 
 
-class _StorageSpy:
+class _CredentialRepositorySpy:
     def __init__(self):
-        self.saved: dict[str, OAuthCredential] = {}
+        self.saved: dict[str, Credential] = {}
 
-    def set(self, provider: str, credential: OAuthCredential) -> None:
+    def update_provider(self, provider: str, credential: Credential) -> None:
         self.saved[provider] = credential
 
+    def remove_provider(self, provider: str) -> bool:
+        return self.saved.pop(provider, None) is not None
 
-class _AuthManagerSpy:
-    instances: list["_AuthManagerSpy"] = []
+    def get_provider(self, provider: str):
+        return self.saved.get(provider)
 
-    def __init__(self):
-        self.storage = _StorageSpy()
-        self.save_called = False
-        _AuthManagerSpy.instances.append(self)
-
-    def save(self) -> None:
-        self.save_called = True
+    def compare_and_swap_provider(self, provider: str, *, expected, replacement) -> bool:
+        if self.saved.get(provider) != expected:
+            return False
+        if replacement is None:
+            self.saved.pop(provider, None)
+        else:
+            self.saved[provider] = replacement
+        return True
 
 
 class _OAuthSessionsSpy:
@@ -67,23 +77,466 @@ async def _fake_get_copilot_token(client, access_token):
 @pytest.mark.asyncio
 async def test_oauth_completion_preserves_copilot_api_endpoint(monkeypatch):
     sessions = _OAuthSessionsSpy()
-    reset_calls: list[None] = []
-    _AuthManagerSpy.instances.clear()
+    repository = _CredentialRepositorySpy()
 
-    monkeypatch.setattr(admin, "AuthManager", _AuthManagerSpy)
+    class _Owner:
+        snapshots = []
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            self.snapshots.append(config_snapshot)
+
+    owner = _Owner()
+    runtime_snapshot = SimpleNamespace(revision="runtime-revision")
+    runtime_repository = SimpleNamespace(read=lambda: runtime_snapshot)
+
     monkeypatch.setattr(admin, "oauth_sessions", sessions)
-    monkeypatch.setattr(admin, "reset_router", lambda: reset_calls.append(None))
     monkeypatch.setattr(admin, "poll_access_token", _fake_poll_access_token)
     monkeypatch.setattr(admin, "get_copilot_token", _fake_get_copilot_token)
 
-    await admin._poll_oauth_completion("sess-1", "device-code", 1)
+    await admin._poll_oauth_completion(
+        "sess-1",
+        "device-code",
+        1,
+        owner,
+        repository,
+        runtime_repository,
+    )
 
-    manager = _AuthManagerSpy.instances[0]
-    credential = manager.storage.saved["github-copilot"]
+    credential = repository.saved["github-copilot"]
     assert credential.api_endpoint == "https://api.enterprise.githubcopilot.com"
-    assert manager.save_called is True
-    assert reset_calls == [None]
+    assert owner.snapshots == [runtime_snapshot]
     assert sessions.updates[0]["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_oauth_completion_compensates_late_credential_write(
+    monkeypatch,
+    tmp_path,
+):
+    sessions = _OAuthSessionsSpy()
+    repository = CredentialRepository(tmp_path / "auth.json")
+    original = OAuthCredential(refresh="old-refresh", access="old-access", expires=100)
+    repository.update_provider("github-copilot", original)
+    update_started = threading.Event()
+    allow_update = threading.Event()
+    update_finished = threading.Event()
+    original_update = repository.update_provider
+
+    def blocking_update(provider, credential):
+        update_started.set()
+        if not allow_update.wait(timeout=5):
+            raise TimeoutError("test did not release credential update")
+        try:
+            original_update(provider, credential)
+        finally:
+            update_finished.set()
+
+    class _Owner:
+        rebuild_calls = 0
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            self.rebuild_calls += 1
+
+    owner = _Owner()
+    monkeypatch.setattr(repository, "update_provider", blocking_update)
+    monkeypatch.setattr(admin, "oauth_sessions", sessions)
+    monkeypatch.setattr(admin, "poll_access_token", _fake_poll_access_token)
+    monkeypatch.setattr(admin, "get_copilot_token", _fake_get_copilot_token)
+
+    poll_task = asyncio.create_task(
+        admin._poll_oauth_completion(
+            "sess-cancelled",
+            "device-code",
+            1,
+            owner,
+            repository,
+            SimpleNamespace(read=lambda: SimpleNamespace(revision="runtime-revision")),
+        )
+    )
+    assert await asyncio.to_thread(update_started.wait, 1)
+
+    poll_task.cancel()
+    await asyncio.sleep(0)
+    allow_update.set()
+    assert await asyncio.to_thread(update_finished.wait, 1)
+
+    with pytest.raises(asyncio.CancelledError):
+        await poll_task
+
+    assert repository.get_provider("github-copilot") == original
+    assert owner.rebuild_calls == 0
+    assert sessions.updates == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_oauth_compensation_ignores_repeated_cancellation_and_concurrent_write(
+    monkeypatch,
+    tmp_path,
+):
+    sessions = _OAuthSessionsSpy()
+    repository = CredentialRepository(tmp_path / "auth.json")
+    original = OAuthCredential(refresh="old-refresh", access="old-access", expires=100)
+    concurrent = OAuthCredential(
+        refresh="concurrent-refresh",
+        access="concurrent-access",
+        expires=200,
+    )
+    repository.update_provider("github-copilot", original)
+    update_started = threading.Event()
+    allow_update = threading.Event()
+    update_finished = threading.Event()
+    allow_update_return = threading.Event()
+    compensation_started = threading.Event()
+    allow_compensation = threading.Event()
+    compensation_finished = threading.Event()
+    original_update = repository.update_provider
+    original_compare_and_swap = repository.compare_and_swap_provider
+
+    def blocking_update(provider, credential):
+        update_started.set()
+        if not allow_update.wait(timeout=5):
+            raise TimeoutError("test did not release credential update")
+        original_update(provider, credential)
+        update_finished.set()
+        if not allow_update_return.wait(timeout=5):
+            raise TimeoutError("test did not release credential update return")
+
+    def blocking_compare_and_swap(provider, *, expected, replacement):
+        compensation_started.set()
+        if not allow_compensation.wait(timeout=5):
+            raise TimeoutError("test did not release credential compensation")
+        try:
+            return original_compare_and_swap(
+                provider,
+                expected=expected,
+                replacement=replacement,
+            )
+        finally:
+            compensation_finished.set()
+
+    class _Owner:
+        rebuild_calls = 0
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            self.rebuild_calls += 1
+
+    owner = _Owner()
+    monkeypatch.setattr(repository, "update_provider", blocking_update)
+    monkeypatch.setattr(repository, "compare_and_swap_provider", blocking_compare_and_swap)
+    monkeypatch.setattr(admin, "oauth_sessions", sessions)
+    monkeypatch.setattr(admin, "poll_access_token", _fake_poll_access_token)
+    monkeypatch.setattr(admin, "get_copilot_token", _fake_get_copilot_token)
+
+    poll_task = asyncio.create_task(
+        admin._poll_oauth_completion(
+            "sess-repeated-cancel",
+            "device-code",
+            1,
+            owner,
+            repository,
+            SimpleNamespace(read=lambda: SimpleNamespace(revision="runtime-revision")),
+        )
+    )
+    assert await asyncio.to_thread(update_started.wait, 1)
+
+    poll_task.cancel()
+    await asyncio.sleep(0)
+    allow_update.set()
+    assert await asyncio.to_thread(update_finished.wait, 1)
+    await asyncio.to_thread(
+        CredentialRepository.update_provider,
+        repository,
+        "github-copilot",
+        concurrent,
+    )
+    allow_update_return.set()
+    assert await asyncio.to_thread(compensation_started.wait, 1)
+
+    poll_task.cancel()
+    await asyncio.sleep(0)
+    poll_task.cancel()
+    await asyncio.sleep(0)
+    assert not poll_task.done()
+
+    allow_compensation.set()
+    assert await asyncio.to_thread(compensation_finished.wait, 1)
+    with pytest.raises(asyncio.CancelledError):
+        await poll_task
+
+    assert repository.get_provider("github-copilot") == concurrent
+    assert owner.rebuild_calls == 0
+    assert sessions.updates == []
+
+
+@pytest.mark.asyncio
+async def test_oauth_login_background_task_receives_current_router_owner(monkeypatch):
+    owner = object()
+    runtime_repository = object()
+    background_tasks = BackgroundTasks()
+    device_code = SimpleNamespace(
+        device_code="device-code",
+        user_code="user-code",
+        verification_uri="https://github.example/device",
+        expires_in=900,
+        interval=5,
+    )
+    session = SimpleNamespace(session_id="session-id")
+
+    async def fake_request_device_code(_client):
+        return device_code
+
+    async def fake_create_session(**_kwargs):
+        return session
+
+    monkeypatch.setattr(admin, "request_device_code", fake_request_device_code)
+    monkeypatch.setattr(admin.oauth_sessions, "create_session", fake_create_session)
+
+    await admin.login(
+        LoginRequest(provider="github-copilot"),
+        background_tasks,
+        owner,
+        runtime_repository,
+    )
+
+    assert len(background_tasks.tasks) == 1
+    assert background_tasks.tasks[0].func is admin._poll_oauth_completion
+    assert background_tasks.tasks[0].args[3] is owner
+    assert background_tasks.tasks[0].args[5] is runtime_repository
+
+
+@pytest.mark.asyncio
+async def test_api_key_login_and_logout_rebuild_router(monkeypatch):
+    class _Owner:
+        snapshots = []
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            self.snapshots.append(config_snapshot)
+
+    owner = _Owner()
+    credential_repository = _CredentialRepositorySpy()
+    runtime_snapshot = SimpleNamespace(revision="runtime-revision")
+    runtime_repository = SimpleNamespace(read=lambda: runtime_snapshot)
+    monkeypatch.setattr(admin, "CredentialRepository", lambda: credential_repository)
+
+    login_result = await admin.login(
+        LoginRequest(provider="openai", api_key="secret"),
+        BackgroundTasks(),
+        owner,
+        runtime_repository,
+    )
+    logout_result = await admin.logout("openai", owner, runtime_repository)
+
+    assert login_result == {"success": True, "provider": "openai"}
+    assert logout_result == {"success": True, "provider": "openai"}
+    assert owner.snapshots == [runtime_snapshot, runtime_snapshot]
+    assert credential_repository.saved == {}
+
+
+@pytest.mark.asyncio
+async def test_api_key_login_compensates_only_its_credential_when_rebuild_fails(
+    monkeypatch,
+    tmp_path,
+):
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("openai", ApiKeyCredential(key="old-key"))
+
+    class _Owner:
+        snapshots = []
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            self.snapshots.append(config_snapshot)
+            raise RuntimeError("router build failed")
+
+    runtime_snapshot = RuntimeConfigRepository(tmp_path / "priorities.json").read()
+    manager_type = admin.AuthManager
+    monkeypatch.setattr(admin, "CredentialRepository", lambda: repository)
+    monkeypatch.setattr(admin, "AuthManager", lambda *_args: manager_type(repository))
+
+    with pytest.raises(RuntimeError, match="router build failed"):
+        await admin.login(
+            LoginRequest(provider="openai", api_key="new-key"),
+            BackgroundTasks(),
+            _Owner(),
+            SimpleNamespace(read=lambda: runtime_snapshot),
+        )
+
+    assert repository.get_provider("openai") == ApiKeyCredential(key="old-key")
+
+
+@pytest.mark.asyncio
+async def test_api_key_login_compensation_never_overwrites_concurrent_credential(
+    monkeypatch,
+    tmp_path,
+):
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("openai", ApiKeyCredential(key="old-key"))
+
+    class _Owner:
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            repository.update_provider("openai", ApiKeyCredential(key="concurrent-key"))
+            raise RuntimeError("router build failed")
+
+    runtime_snapshot = RuntimeConfigRepository(tmp_path / "priorities.json").read()
+    manager_type = admin.AuthManager
+    monkeypatch.setattr(admin, "CredentialRepository", lambda: repository)
+    monkeypatch.setattr(admin, "AuthManager", lambda *_args: manager_type(repository))
+
+    with pytest.raises(RuntimeError, match="router build failed"):
+        await admin.login(
+            LoginRequest(provider="openai", api_key="new-key"),
+            BackgroundTasks(),
+            _Owner(),
+            SimpleNamespace(read=lambda: runtime_snapshot),
+        )
+
+    assert repository.get_provider("openai") == ApiKeyCredential(key="concurrent-key")
+
+
+@pytest.mark.asyncio
+async def test_logout_restores_removed_credential_when_rebuild_fails(monkeypatch, tmp_path):
+    repository = CredentialRepository(tmp_path / "auth.json")
+    original = ApiKeyCredential(key="old-key")
+    repository.update_provider("openai", original)
+
+    class _Owner:
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            raise RuntimeError("router build failed")
+
+    runtime_snapshot = RuntimeConfigRepository(tmp_path / "priorities.json").read()
+    manager_type = admin.AuthManager
+    monkeypatch.setattr(admin, "CredentialRepository", lambda: repository)
+    monkeypatch.setattr(admin, "AuthManager", lambda *_args: manager_type(repository))
+
+    with pytest.raises(RuntimeError, match="router build failed"):
+        await admin.logout(
+            "openai",
+            _Owner(),
+            SimpleNamespace(read=lambda: runtime_snapshot),
+        )
+
+    assert repository.get_provider("openai") == original
+
+
+@pytest.mark.asyncio
+async def test_logout_compensation_never_overwrites_concurrent_credential(monkeypatch, tmp_path):
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("openai", ApiKeyCredential(key="old-key"))
+
+    class _Owner:
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            repository.update_provider("openai", ApiKeyCredential(key="concurrent-key"))
+            raise RuntimeError("router build failed")
+
+    runtime_snapshot = RuntimeConfigRepository(tmp_path / "priorities.json").read()
+    manager_type = admin.AuthManager
+    monkeypatch.setattr(admin, "CredentialRepository", lambda: repository)
+    monkeypatch.setattr(admin, "AuthManager", lambda *_args: manager_type(repository))
+
+    with pytest.raises(RuntimeError, match="router build failed"):
+        await admin.logout(
+            "openai",
+            _Owner(),
+            SimpleNamespace(read=lambda: runtime_snapshot),
+        )
+
+    assert repository.get_provider("openai") == ApiKeyCredential(key="concurrent-key")
+
+
+@pytest.mark.asyncio
+async def test_oauth_completion_restores_previous_credential_when_rebuild_fails(
+    monkeypatch,
+    tmp_path,
+):
+    sessions = _OAuthSessionsSpy()
+    repository = CredentialRepository(tmp_path / "auth.json")
+    original = OAuthCredential(refresh="old-refresh", access="old-access", expires=100)
+    repository.update_provider("github-copilot", original)
+
+    class _Owner:
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            raise RuntimeError("router build failed")
+
+    runtime_snapshot = RuntimeConfigRepository(tmp_path / "priorities.json").read()
+    monkeypatch.setattr(admin, "oauth_sessions", sessions)
+    monkeypatch.setattr(admin, "poll_access_token", _fake_poll_access_token)
+    monkeypatch.setattr(admin, "get_copilot_token", _fake_get_copilot_token)
+
+    await admin._poll_oauth_completion(
+        "sess-failed",
+        "device-code",
+        1,
+        _Owner(),
+        repository,
+        SimpleNamespace(read=lambda: runtime_snapshot),
+    )
+
+    assert repository.get_provider("github-copilot") == original
+    assert sessions.updates[-1]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_oauth_compensation_never_overwrites_concurrent_credential(monkeypatch, tmp_path):
+    sessions = _OAuthSessionsSpy()
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider(
+        "github-copilot",
+        OAuthCredential(refresh="old-refresh", access="old-access", expires=100),
+    )
+    concurrent = OAuthCredential(
+        refresh="concurrent-refresh",
+        access="concurrent-access",
+        expires=200,
+    )
+
+    class _Owner:
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            repository.update_provider("github-copilot", concurrent)
+            raise RuntimeError("router build failed")
+
+    runtime_snapshot = RuntimeConfigRepository(tmp_path / "priorities.json").read()
+    monkeypatch.setattr(admin, "oauth_sessions", sessions)
+    monkeypatch.setattr(admin, "poll_access_token", _fake_poll_access_token)
+    monkeypatch.setattr(admin, "get_copilot_token", _fake_get_copilot_token)
+
+    await admin._poll_oauth_completion(
+        "sess-concurrent",
+        "device-code",
+        1,
+        _Owner(),
+        repository,
+        SimpleNamespace(read=lambda: runtime_snapshot),
+    )
+
+    assert repository.get_provider("github-copilot") == concurrent
+    assert sessions.updates[-1]["status"] == "error"
+
+
+def test_auth_provider_discovery_uses_server_provider_configuration(monkeypatch):
+    monkeypatch.setattr(
+        admin,
+        "load_providers_config",
+        lambda: ProvidersConfig(
+            providers={
+                "ollama": CustomProviderConfig(
+                    baseURL="http://localhost:11434/v1",
+                    options={"allow_unauthenticated": True},
+                )
+            }
+        ),
+    )
+
+    response = admin.list_auth_providers()
+
+    assert [provider.provider for provider in response.providers] == [
+        "github-copilot",
+        "openai",
+        "anthropic",
+        "ollama",
+    ]
+    assert response.providers[-1].auth_type is AuthType.API_KEY
+    assert response.providers[-1].source is ProviderAuthSource.CUSTOM
+    assert response.providers[-1].credential_required is False
+    assert response.providers[-1].api_key_env == "OLLAMA_API_KEY"
 
 
 @pytest.mark.asyncio
@@ -93,9 +546,12 @@ async def test_update_priorities_rebuilds_router_after_cas(tmp_path):
 
     class _Owner:
         snapshots = []
+        installed_snapshots = []
 
-        async def rebuild(self, *, config_snapshot=None):
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
             self.snapshots.append(config_snapshot)
+            installed_snapshot = before_swap() if before_swap is not None else config_snapshot
+            self.installed_snapshots.append(installed_snapshot)
             return 2
 
     owner = _Owner()
@@ -116,6 +572,7 @@ async def test_update_priorities_rebuilds_router_after_cas(tmp_path):
     assert response.priorities == ["github-copilot/gpt-4o"]
     assert repository.read().config.priorities == ["github-copilot/gpt-4o"]
     assert [snapshot.revision for snapshot in owner.snapshots] == [response.revision]
+    assert [snapshot.revision for snapshot in owner.installed_snapshots] == [response.revision]
 
 
 @pytest.mark.asyncio
@@ -127,12 +584,88 @@ async def test_admin_models_returns_unique_provider_qualified_public_ids(monkeyp
                 ProviderModelInfo(id="shared-model", name="Shared", provider="second"),
             ]
 
-    monkeypatch.setattr(admin, "get_router", lambda: _ModelRouter())
+    class _Lease:
+        router = _ModelRouter()
+        released = False
 
-    response = await admin.list_models()
+        async def release(self):
+            self.released = True
+
+    class _Owner:
+        lease = _Lease()
+
+        async def acquire(self):
+            return self.lease
+
+    owner = _Owner()
+
+    response = await admin.list_models(owner)
 
     assert [model.id for model in response.models] == [
         "first/shared-model",
         "second/shared-model",
     ]
     assert [model.provider for model in response.models] == ["first", "second"]
+    assert owner.lease.released is True
+
+
+@pytest.mark.asyncio
+async def test_admin_model_refresh_rebuilds_generation_and_releases_lease_after_failure():
+    events = []
+
+    class _ModelRouter:
+        async def list_models(self):
+            events.append("list")
+            raise RuntimeError("catalog unavailable")
+
+    class _Lease:
+        router = _ModelRouter()
+        released = False
+
+        async def release(self):
+            self.released = True
+
+    class _Owner:
+        lease = _Lease()
+        snapshots = []
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            events.append("rebuild")
+            self.snapshots.append(config_snapshot)
+
+        async def acquire(self):
+            events.append("acquire")
+            return self.lease
+
+    owner = _Owner()
+    runtime_snapshot = SimpleNamespace(revision="runtime-revision")
+
+    with pytest.raises(Exception) as exc_info:
+        await admin.refresh_models(owner, SimpleNamespace(read=lambda: runtime_snapshot))
+
+    assert getattr(exc_info.value, "status_code", None) == 500
+    assert events == ["rebuild", "acquire", "list"]
+    assert owner.snapshots == [runtime_snapshot]
+    assert owner.lease.released is True
+
+
+@pytest.mark.asyncio
+async def test_admin_model_refresh_does_not_acquire_when_rebuild_fails():
+    class _Owner:
+        acquired = False
+
+        async def rebuild(self, config_snapshot=None, *, before_swap=None):
+            raise RuntimeError("router build failed")
+
+        async def acquire(self):
+            self.acquired = True
+            raise AssertionError("old generation must not be queried after rebuild failure")
+
+    owner = _Owner()
+    runtime_snapshot = SimpleNamespace(revision="runtime-revision")
+
+    with pytest.raises(Exception) as exc_info:
+        await admin.refresh_models(owner, SimpleNamespace(read=lambda: runtime_snapshot))
+
+    assert getattr(exc_info.value, "status_code", None) == 500
+    assert owner.acquired is False

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -1,5 +1,6 @@
 """Tests for the Anthropic beta passthrough route."""
 
+import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -13,7 +14,13 @@ from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from router_maestro.config import PrioritiesConfig, ThinkingBudgetConfig
-from router_maestro.providers.base import ModelInfo, ProviderError, ProviderFailureKind
+from router_maestro.providers.base import (
+    ModelInfo,
+    ProviderError,
+    ProviderFailureKind,
+    ResponseStatus,
+    TransportTermination,
+)
 from router_maestro.providers.copilot import CopilotProvider
 from router_maestro.routing.capabilities import (
     CapabilitySupport,
@@ -28,6 +35,7 @@ from router_maestro.server.routes.anthropic import ANTHROPIC_PING_FRAME
 from router_maestro.server.routes.anthropic_beta import (
     _apply_thinking_budget_native,
     _clean_stream_frame,
+    _encode_native_stream_errors,
     _is_native_eligible,
     _is_signature_error,
     _iter_sse_frames,
@@ -957,6 +965,62 @@ def _native_provider() -> MagicMock:
     return provider
 
 
+def _guard_config(
+    *,
+    leak_enabled: bool,
+    runaway_enabled: bool,
+    max_bytes: int = 100_000,
+) -> PrioritiesConfig:
+    return PrioritiesConfig.model_validate(
+        {
+            "guards": {
+                "leak_guard": {"enabled": leak_enabled},
+                "runaway_guard": {
+                    "enabled": runaway_enabled,
+                    "max_bytes": max_bytes,
+                    "max_deltas": 1_000,
+                },
+            }
+        }
+    )
+
+
+class _CapturedGuardContext:
+    """Small RequestContext surface used to prove pipeline snapshot binding."""
+
+    def __init__(self, configs: list[PrioritiesConfig], router=None) -> None:
+        self.request_id = "req-beta-guard"
+        self._configs = configs
+        self.router = router or MagicMock(_models_cache={})
+        self.pipeline = None
+        self.audit = None
+
+    @property
+    def config(self) -> PrioritiesConfig:
+        return self._configs[0]
+
+
+class _GuardSnapshot:
+    def __init__(self, config: PrioritiesConfig) -> None:
+        self.revision = "guard-revision"
+        self._config = config
+
+    @property
+    def config(self) -> PrioritiesConfig:
+        return self._config.model_copy(deep=True)
+
+
+class _GuardLease:
+    def __init__(self, config: PrioritiesConfig) -> None:
+        self.generation_id = 1
+        self.router = MagicMock(_models_cache={})
+        self.config_snapshot = _GuardSnapshot(config)
+        self.release_count = 0
+
+    async def release(self) -> None:
+        self.release_count += 1
+
+
 def _real_native_router(provider, models: list[ModelInfo], priorities: list[str]):
     from router_maestro.routing.router import CACHE_TTL_SECONDS, Router
     from router_maestro.utils.cache import TTLCache
@@ -1053,6 +1117,738 @@ class TestBetaMessagesEndpoint:
             fallbacks=(),
             explicit=True,
         )
+
+    @pytest.mark.parametrize("path", ["legacy", "planned"])
+    @pytest.mark.parametrize("guard", ["leak", "runaway"])
+    @pytest.mark.parametrize("initially_enabled", [False, True])
+    def test_native_stream_guards_use_frozen_enable_flags_on_both_paths(
+        self,
+        client,
+        path,
+        guard,
+        initially_enabled,
+    ):
+        leak_enabled = guard == "leak" and initially_enabled
+        runaway_enabled = guard == "runaway" and initially_enabled
+        configs = [
+            _guard_config(
+                leak_enabled=leak_enabled,
+                runaway_enabled=runaway_enabled,
+            )
+        ]
+        provider = _native_provider()
+        plan = self._native_plan(
+            provider,
+            CapabilitySupport.SUPPORTED,
+            model="guarded-model",
+        )
+        resolution = _NativeModelResolution(
+            _ResolvedModel("github-copilot", "guarded-model", provider),
+            CapabilitySupport.SUPPORTED,
+            plan if path == "planned" else None,
+        )
+        context = _CapturedGuardContext(configs)
+        delta = (
+            {"type": "text_delta", "text": "<tick>control</tick>"}
+            if guard == "leak"
+            else {"type": "text_delta", "text": "x" * 100_001}
+        )
+
+        async def selected_stream():
+            yield f"event: message_start\ndata: {json.dumps(_VALID_MESSAGE_START)}\n\n"
+            # Simulate a live config replacement after the request pipeline has
+            # captured its initial snapshot. The active stream must not change.
+            configs[0] = _guard_config(
+                leak_enabled=guard == "leak" and not initially_enabled,
+                runaway_enabled=guard == "runaway" and not initially_enabled,
+            )
+            payload = {"type": "content_block_delta", "index": 0, "delta": delta}
+            yield f"event: content_block_delta\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        patches = [
+            patch(
+                "router_maestro.server.routes.anthropic_beta._resolve_native_model",
+                new_callable=AsyncMock,
+                return_value=resolution,
+            ),
+            patch(
+                "router_maestro.runtime.request_context.get_current_request_context",
+                return_value=context,
+            ),
+        ]
+        if path == "planned":
+            patches.append(
+                patch(
+                    "router_maestro.server.routes.anthropic_beta.Router.execute_plan_stream",
+                    new_callable=AsyncMock,
+                    return_value=(selected_stream(), "github-copilot"),
+                )
+            )
+        else:
+            patches.append(
+                patch(
+                    "router_maestro.server.routes.anthropic_beta._stream_passthrough",
+                    return_value=selected_stream(),
+                )
+            )
+
+        with patches[0], patches[1], patches[2]:
+            downstream = client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "guarded-model",
+                    "max_tokens": 100,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        event_types = [
+            line.removeprefix("event: ")
+            for line in downstream.text.splitlines()
+            if line.startswith("event: ")
+        ]
+        assert context.pipeline is not None
+        assert context.pipeline.outcome is not None
+        assert (context.pipeline.leak_guard is not None) is leak_enabled
+        if initially_enabled:
+            assert event_types == ["message_start", "error"]
+            assert context.pipeline.outcome.transport is TransportTermination.EXCEPTION
+            assert context.pipeline.outcome.response_status is ResponseStatus.FAILED
+            assert context.pipeline.outcome.error.code == "overloaded"
+        else:
+            assert event_types == ["message_start", "content_block_delta", "message_stop"]
+            assert context.pipeline.outcome.transport is TransportTermination.EXPLICIT_TERMINAL
+            assert context.pipeline.outcome.response_status is ResponseStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_native_stream_with_both_guards_disabled_never_invokes_raw_leak_guard(self):
+        from router_maestro.pipeline import RequestPipeline
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=False)
+        context = _CapturedGuardContext([config])
+        with patch(
+            "router_maestro.runtime.request_context.get_current_request_context",
+            return_value=context,
+        ):
+            pipeline = RequestPipeline.create(
+                request_id="req-no-native-guards",
+                model="guarded-model",
+            )
+
+        async def stream():
+            payload = {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "text_delta",
+                    "text": "<tick>control</tick>" + "x" * 100_001,
+                },
+            }
+            yield f"event: content_block_delta\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        with patch(
+            "router_maestro.pipeline.leak_guard.RawFrameLeakGuard",
+            side_effect=AssertionError("disabled leak guard must not be constructed"),
+        ):
+            frames = [
+                frame
+                async for frame in _encode_native_stream_errors(
+                    stream(),
+                    pipeline=pipeline,
+                )
+            ]
+
+        assert [
+            line.removeprefix("event: ")
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("event: ")
+        ] == ["content_block_delta", "message_stop"]
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.response_status is ResponseStatus.COMPLETED
+
+    @pytest.mark.parametrize(
+        "delta",
+        [
+            pytest.param(
+                {"type": "thinking_delta", "thinking": "x" * 100_001},
+                id="thinking-delta",
+            ),
+            pytest.param(
+                {"type": "input_json_delta", "partial_json": "x" * 100_001},
+                id="tool-input-delta",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_runaway_guard_counts_non_text_raw_deltas(self, delta):
+        from router_maestro.pipeline import RequestPipeline
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=True)
+        context = _CapturedGuardContext([config])
+        with patch(
+            "router_maestro.runtime.request_context.get_current_request_context",
+            return_value=context,
+        ):
+            pipeline = RequestPipeline.create(
+                request_id="req-raw-delta",
+                model="guarded-model",
+            )
+
+        async def stream():
+            payload = {"type": "content_block_delta", "index": 0, "delta": delta}
+            yield f"event: content_block_delta\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert [
+            line.removeprefix("event: ")
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("event: ")
+        ] == ["error"]
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.error.code == "overloaded"
+
+    @pytest.mark.asyncio
+    async def test_native_leak_guard_scans_raw_thinking_delta(self):
+        from router_maestro.pipeline import RequestPipeline
+
+        config = _guard_config(leak_enabled=True, runaway_enabled=False)
+        context = _CapturedGuardContext([config])
+        with patch(
+            "router_maestro.runtime.request_context.get_current_request_context",
+            return_value=context,
+        ):
+            pipeline = RequestPipeline.create(
+                request_id="req-raw-thinking-leak",
+                model="guarded-model",
+            )
+
+        async def stream():
+            payload = {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "thinking_delta",
+                    "thinking": "<tick>private control</tick>",
+                },
+            }
+            yield f"event: content_block_delta\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert [
+            line.removeprefix("event: ")
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("event: ")
+        ] == ["error"]
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.error.code == "overloaded"
+
+    @pytest.mark.parametrize(
+        ("terminal", "expected_transport", "expected_status", "expected_code"),
+        [
+            pytest.param(
+                "error",
+                TransportTermination.EXPLICIT_TERMINAL,
+                ResponseStatus.FAILED,
+                "overloaded_error",
+                id="upstream-error",
+            ),
+            pytest.param(
+                "incomplete",
+                TransportTermination.EXPLICIT_TERMINAL,
+                ResponseStatus.INCOMPLETE,
+                None,
+                id="incomplete",
+            ),
+            pytest.param(
+                "unexpected-eof",
+                TransportTermination.UNEXPECTED_EOF,
+                ResponseStatus.UNKNOWN,
+                "unexpected_eof",
+                id="unexpected-eof",
+            ),
+            pytest.param(
+                "provider-error",
+                TransportTermination.EXCEPTION,
+                ResponseStatus.FAILED,
+                "provider_error",
+                id="postcommit-provider-error",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_stream_records_non_success_semantic_outcome(
+        self,
+        terminal,
+        expected_transport,
+        expected_status,
+        expected_code,
+    ):
+        from router_maestro.pipeline import RequestPipeline
+
+        pipeline = RequestPipeline(
+            request_id="req-native-terminal",
+            guards=[],
+            leak_guard=None,
+            audit=None,
+            config=PrioritiesConfig(),
+        )
+
+        async def stream():
+            yield f"event: message_start\ndata: {json.dumps(_VALID_MESSAGE_START)}\n\n"
+            if terminal == "error":
+                error = {
+                    "type": "error",
+                    "error": {"type": "overloaded_error", "message": "retry"},
+                }
+                yield f"event: error\ndata: {json.dumps(error)}\n\n"
+            elif terminal == "incomplete":
+                delta = {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "max_tokens", "stop_sequence": None},
+                    "usage": {"output_tokens": 3},
+                }
+                yield f"event: message_delta\ndata: {json.dumps(delta)}\n\n"
+                yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+            elif terminal == "provider-error":
+                raise ProviderError(
+                    "safe postcommit failure",
+                    status_code=502,
+                    kind=ProviderFailureKind.TRANSPORT,
+                )
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert frames
+        if terminal == "error":
+            assert sum(frame.count("event: error") for frame in frames) == 1
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.transport is expected_transport
+        assert pipeline.outcome.response_status is expected_status
+        assert (pipeline.outcome.error.code if pipeline.outcome.error else None) == expected_code
+
+    @pytest.mark.asyncio
+    async def test_native_stream_records_cancelled_semantic_outcome(self):
+        from router_maestro.pipeline import RequestPipeline
+
+        pipeline = RequestPipeline(
+            request_id="req-native-cancel",
+            guards=[],
+            leak_guard=None,
+            audit=None,
+            config=PrioritiesConfig(),
+        )
+
+        async def stream():
+            yield f"event: message_start\ndata: {json.dumps(_VALID_MESSAGE_START)}\n\n"
+            raise asyncio.CancelledError
+
+        encoded = _encode_native_stream_errors(stream(), pipeline=pipeline)
+        await anext(encoded)
+        with pytest.raises(asyncio.CancelledError):
+            await anext(encoded)
+
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.transport is TransportTermination.CLIENT_CANCELLED
+        assert pipeline.outcome.response_status is ResponseStatus.CANCELLED
+
+    @pytest.mark.parametrize(
+        ("terminal", "expected_transport", "expected_status"),
+        [
+            pytest.param(
+                "error",
+                TransportTermination.EXPLICIT_TERMINAL,
+                ResponseStatus.FAILED,
+                id="upstream-error",
+            ),
+            pytest.param(
+                "incomplete",
+                TransportTermination.EXPLICIT_TERMINAL,
+                ResponseStatus.INCOMPLETE,
+                id="incomplete",
+            ),
+            pytest.param(
+                "unexpected-eof",
+                TransportTermination.UNEXPECTED_EOF,
+                ResponseStatus.UNKNOWN,
+                id="unexpected-eof",
+            ),
+            pytest.param(
+                "provider-error",
+                TransportTermination.EXCEPTION,
+                ResponseStatus.FAILED,
+                id="postcommit-provider-error",
+            ),
+        ],
+    )
+    def test_native_stream_terminal_reaches_request_context(
+        self,
+        app,
+        terminal,
+        expected_transport,
+        expected_status,
+    ):
+        from router_maestro.runtime import RequestContextMiddleware
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=False)
+        snapshot = _GuardSnapshot(config)
+        lease = _GuardLease(config)
+        captured_contexts = []
+
+        class Repository:
+            def read(self):
+                return snapshot
+
+        class Owner:
+            async def start(self, _snapshot):
+                return None
+
+            async def acquire(self):
+                return lease
+
+        app.state.runtime_config_repository = Repository()
+        app.state.router_owner = Owner()
+        app.add_middleware(RequestContextMiddleware)
+
+        async def selected_stream():
+            from router_maestro.runtime import current_request_context
+
+            captured_contexts.append(current_request_context())
+            yield f"event: message_start\ndata: {json.dumps(_VALID_MESSAGE_START)}\n\n"
+            if terminal == "error":
+                error = {
+                    "type": "error",
+                    "error": {"type": "overloaded_error", "message": "retry"},
+                }
+                yield f"event: error\ndata: {json.dumps(error)}\n\n"
+            elif terminal == "incomplete":
+                delta = {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "max_tokens", "stop_sequence": None},
+                    "usage": {"output_tokens": 3},
+                }
+                yield f"event: message_delta\ndata: {json.dumps(delta)}\n\n"
+                yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+            elif terminal == "provider-error":
+                raise ProviderError(
+                    "safe postcommit failure",
+                    status_code=502,
+                    kind=ProviderFailureKind.TRANSPORT,
+                )
+
+        provider = _native_provider()
+        resolution = _NativeModelResolution(
+            _ResolvedModel("github-copilot", "context-model", provider),
+            CapabilitySupport.SUPPORTED,
+            self._native_plan(
+                provider,
+                CapabilitySupport.SUPPORTED,
+                model="context-model",
+            ),
+        )
+        with (
+            patch(
+                "router_maestro.server.routes.anthropic_beta._resolve_native_model",
+                new_callable=AsyncMock,
+                return_value=resolution,
+            ),
+            patch(
+                "router_maestro.server.routes.anthropic_beta.Router.execute_plan_stream",
+                new_callable=AsyncMock,
+                return_value=(selected_stream(), "github-copilot"),
+            ),
+            TestClient(app) as context_client,
+        ):
+            downstream = context_client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "context-model",
+                    "max_tokens": 100,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert downstream.status_code == 200
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].outcome is not None
+        assert captured_contexts[0].outcome.transport is expected_transport
+        assert captured_contexts[0].outcome.response_status is expected_status
+        assert captured_contexts[0].pipeline is not None
+        assert captured_contexts[0].pipeline.outcome == captured_contexts[0].outcome
+        assert lease.release_count == 1
+
+    @pytest.mark.parametrize("path", ["planned", "legacy"])
+    @pytest.mark.parametrize(
+        ("terminal", "expected_transport", "expected_status", "expected_code"),
+        [
+            pytest.param(
+                "clean-eof",
+                TransportTermination.UNEXPECTED_EOF,
+                ResponseStatus.UNKNOWN,
+                "unexpected_eof",
+                id="clean-eof",
+            ),
+            pytest.param(
+                "provider-error",
+                TransportTermination.EXCEPTION,
+                ResponseStatus.FAILED,
+                "provider_error",
+                id="provider-error",
+            ),
+            pytest.param(
+                "native-error",
+                TransportTermination.EXPLICIT_TERMINAL,
+                ResponseStatus.FAILED,
+                "overloaded_error",
+                id="native-error",
+            ),
+        ],
+    )
+    def test_native_transport_terminal_reaches_canonical_context(
+        self,
+        app,
+        path,
+        terminal,
+        expected_transport,
+        expected_status,
+        expected_code,
+    ):
+        from router_maestro.runtime import RequestContextMiddleware, current_request_context
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=False)
+        snapshot = _GuardSnapshot(config)
+        lease = _GuardLease(config)
+        captured_contexts = []
+
+        class Repository:
+            def read(self):
+                return snapshot
+
+        class Owner:
+            async def start(self, _snapshot):
+                return None
+
+            async def acquire(self):
+                return lease
+
+        class StreamResponse:
+            status_code = 200
+
+            async def aiter_lines(self):
+                captured_contexts.append(current_request_context())
+                lines = [
+                    "event: message_start",
+                    f"data: {json.dumps(_VALID_MESSAGE_START)}",
+                    "",
+                ]
+                if terminal == "native-error":
+                    error = {
+                        "type": "error",
+                        "error": {"type": "overloaded_error", "message": "retry"},
+                    }
+                    lines.extend(("event: error", f"data: {json.dumps(error)}", ""))
+                else:
+                    lines.extend(
+                        (
+                            "event: content_block_start",
+                            'data: {"type":"content_block_start","index":0,'
+                            '"content_block":{"type":"text","text":""}}',
+                            "",
+                            "event: content_block_delta",
+                            'data: {"type":"content_block_delta","index":0,'
+                            '"delta":{"type":"text_delta","text":"partial"}}',
+                            "",
+                        )
+                    )
+                for line in lines:
+                    yield line
+                if terminal == "provider-error":
+                    raise ProviderError(
+                        "safe upstream transport failure",
+                        status_code=502,
+                        kind=ProviderFailureKind.TRANSPORT,
+                    )
+
+        @asynccontextmanager
+        async def stream_context():
+            yield StreamResponse()
+
+        provider = _native_provider()
+        provider._stream_with_auth_retry = MagicMock(return_value=stream_context())
+        plan = self._native_plan(
+            provider,
+            CapabilitySupport.SUPPORTED,
+            model="clean-eof-context",
+        )
+        resolution = _NativeModelResolution(
+            _ResolvedModel("github-copilot", "clean-eof-context", provider),
+            CapabilitySupport.SUPPORTED,
+            plan if path == "planned" else None,
+        )
+        app.state.runtime_config_repository = Repository()
+        app.state.router_owner = Owner()
+        app.add_middleware(RequestContextMiddleware)
+
+        with (
+            patch(
+                "router_maestro.server.routes.anthropic_beta._resolve_native_model",
+                new_callable=AsyncMock,
+                return_value=resolution,
+            ),
+            TestClient(app) as context_client,
+        ):
+            downstream = context_client.post(
+                "/api/anthropic/beta/v1/messages",
+                json={
+                    "model": "clean-eof-context",
+                    "max_tokens": 100,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert downstream.status_code == 200
+        assert downstream.text.count("event: error") == 1
+        assert len(captured_contexts) == 1
+        context = captured_contexts[0]
+        assert context.outcome is not None
+        assert context.outcome.transport is expected_transport
+        assert context.outcome.response_status is expected_status
+        assert context.outcome.error.code == expected_code
+        assert context.pipeline is not None
+        assert context.pipeline.outcome == context.outcome
+        assert context.pipeline.wire_status == 200
+        assert lease.release_count == 1
+
+    @pytest.mark.asyncio
+    async def test_native_stream_disconnect_reaches_request_context_as_cancelled(self, app):
+        from router_maestro.runtime import RequestContextMiddleware
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=False)
+        snapshot = _GuardSnapshot(config)
+        lease = _GuardLease(config)
+        captured_contexts = []
+
+        class Repository:
+            def read(self):
+                return snapshot
+
+        class Owner:
+            async def start(self, _snapshot):
+                return None
+
+            async def acquire(self):
+                return lease
+
+        app.state.runtime_config_repository = Repository()
+        app.state.router_owner = Owner()
+        app.add_middleware(RequestContextMiddleware)
+
+        async def selected_stream():
+            from router_maestro.runtime import current_request_context
+
+            captured_contexts.append(current_request_context())
+            yield f"event: message_start\ndata: {json.dumps(_VALID_MESSAGE_START)}\n\n"
+            await asyncio.Event().wait()
+
+        provider = _native_provider()
+        resolution = _NativeModelResolution(
+            _ResolvedModel("github-copilot", "context-model", provider),
+            CapabilitySupport.SUPPORTED,
+            self._native_plan(
+                provider,
+                CapabilitySupport.SUPPORTED,
+                model="context-model",
+            ),
+        )
+        with (
+            patch(
+                "router_maestro.server.routes.anthropic_beta._resolve_native_model",
+                new_callable=AsyncMock,
+                return_value=resolution,
+            ),
+            patch(
+                "router_maestro.server.routes.anthropic_beta.Router.execute_plan_stream",
+                new_callable=AsyncMock,
+                return_value=(selected_stream(), "github-copilot"),
+            ),
+        ):
+            scope = {
+                "type": "http",
+                "asgi": {"spec_version": "2.3"},
+                "http_version": "1.1",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/api/anthropic/beta/v1/messages",
+                "raw_path": b"/api/anthropic/beta/v1/messages",
+                "query_string": b"",
+                "headers": [(b"content-type", b"application/json")],
+                "client": ("test", 1),
+                "server": ("test", 80),
+                "state": {"request_id": "req-beta-cancel"},
+                "app": app,
+            }
+            request_body = json.dumps(
+                {
+                    "model": "context-model",
+                    "max_tokens": 100,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                }
+            ).encode()
+            received_request = False
+
+            async def receive():
+                nonlocal received_request
+                if not received_request:
+                    received_request = True
+                    return {
+                        "type": "http.request",
+                        "body": request_body,
+                        "more_body": False,
+                    }
+                return {"type": "http.disconnect"}
+
+            async def send(_message):
+                return None
+
+            await app(scope, receive, send)
+
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0].outcome is not None
+        assert captured_contexts[0].outcome.transport is TransportTermination.CLIENT_CANCELLED
+        assert captured_contexts[0].outcome.response_status is ResponseStatus.CANCELLED
+        assert captured_contexts[0].pipeline is not None
+        assert captured_contexts[0].pipeline.outcome == captured_contexts[0].outcome
+        assert lease.release_count == 1
 
     @pytest.mark.parametrize("transport", ["native", "translated"])
     @pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
@@ -4869,10 +5665,12 @@ class TestBetaMessagesEndpoint:
         forwarded = mock_stream.call_args.args[1]
         assert forwarded["thinking"] == {"type": "adaptive"}
         assert forwarded["output_config"] == {"effort": "xhigh"}
-        mock_sse_response.assert_called_once_with(
-            stream_marker,
-            keepalive_frame=ANTHROPIC_PING_FRAME,
-        )
+        mock_sse_response.assert_called_once()
+        guarded_stream = mock_sse_response.call_args.args[0]
+        assert guarded_stream.__name__ == "_encode_native_stream_errors"
+        assert mock_sse_response.call_args.kwargs == {
+            "keepalive_frame": ANTHROPIC_PING_FRAME,
+        }
 
     @patch("router_maestro.server.routes.anthropic_beta.sse_streaming_response")
     @patch("router_maestro.server.routes.anthropic_beta._stream_passthrough")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,5 +1,6 @@
 """Tests for per-request audit tracing."""
 
+import asyncio
 import json
 
 from router_maestro.providers.base import unexpected_eof_outcome
@@ -51,6 +52,31 @@ class TestAuditTrace:
         assert inbound["headers"]["x-api-key"] == "***"
         assert inbound["headers"]["X-Request-Id"] == "abc"
 
+    def test_common_nested_credential_field_spellings_are_redacted(self, tmp_path):
+        trace = AuditTrace("req-payload-secrets", tmp_path)
+        secrets = {
+            "accessToken": "access-camel",
+            "access_token": "access-snake",
+            "id_token": "id-secret",
+            "client_secret": "client-snake",
+            "client-secret": "client-kebab",
+            "private_key": "private-secret",
+            "nested": {"refreshToken": "refresh-camel"},
+            "ordinary_text": "the word token is safe in normal content",
+        }
+        trace.record_inbound("POST", "/v1/messages", {}, secrets)
+        trace.flush()
+
+        body = json.loads((tmp_path / "req-payload-secrets" / "inbound.json").read_text())["body"]
+        assert body["accessToken"] == "***"
+        assert body["access_token"] == "***"
+        assert body["id_token"] == "***"
+        assert body["client_secret"] == "***"
+        assert body["client-secret"] == "***"
+        assert body["private_key"] == "***"
+        assert body["nested"]["refreshToken"] == "***"
+        assert body["ordinary_text"] == "the word token is safe in normal content"
+
     def test_no_records_no_write(self, tmp_path):
         trace = AuditTrace("req-empty", tmp_path)
         trace.flush()
@@ -64,6 +90,24 @@ class TestAuditTrace:
         resp = json.loads((tmp_path / "req-stream" / "upstream_resp.json").read_text())
         assert resp["stream_summary"] == "42 chunks, 5000 bytes"
         assert "body" not in resp
+
+    def test_upstream_attempts_are_append_only(self, tmp_path):
+        trace = AuditTrace("req-retry", tmp_path)
+        trace.record_upstream("POST", "https://one.invalid", {}, {"attempt": 1})
+        trace.record_upstream("POST", "https://two.invalid", {}, {"attempt": 2})
+        trace.record_upstream_response(503, {}, {"attempt": 1})
+        trace.record_upstream_response(200, {}, {"attempt": 2})
+        trace.flush()
+
+        trace_dir = tmp_path / "req-retry"
+        assert json.loads((trace_dir / "upstream.json").read_text())["url"] == (
+            "https://one.invalid"
+        )
+        assert json.loads((trace_dir / "upstream_2.json").read_text())["url"] == (
+            "https://two.invalid"
+        )
+        assert json.loads((trace_dir / "upstream_resp.json").read_text())["status"] == 503
+        assert json.loads((trace_dir / "upstream_resp_2.json").read_text())["status"] == 200
 
     def test_outbound_separates_wire_status_from_terminal_outcome(self, tmp_path):
         trace = AuditTrace("req-eof", tmp_path)
@@ -93,3 +137,28 @@ class TestTracingEnabled:
     def test_disabled(self, monkeypatch):
         monkeypatch.delenv("ROUTER_MAESTRO_TRACE", raising=False)
         assert is_tracing_enabled(audit_config_enabled=False) is False
+
+
+def test_async_flush_redacts_before_scheduling_thread(monkeypatch, tmp_path):
+    trace = AuditTrace("req-thread", tmp_path)
+    trace.record_upstream(
+        "POST",
+        "https://example.invalid",
+        {"Authorization": "Bearer secret"},
+        {"api_key": "payload-secret", "nested": {"token": "nested-secret"}},
+    )
+    captured = []
+
+    async def fake_to_thread(function, *args, **kwargs):
+        captured.append((function, args, kwargs))
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    asyncio.run(trace.flush_async())
+
+    function, args, kwargs = captured[0]
+    serialized = json.dumps(args, default=str) + json.dumps(kwargs, default=str)
+    assert function.__name__ == "_write_records"
+    assert "Bearer secret" not in serialized
+    assert "payload-secret" not in serialized
+    assert "nested-secret" not in serialized

--- a/tests/test_auth_concurrency.py
+++ b/tests/test_auth_concurrency.py
@@ -1,0 +1,206 @@
+"""Concurrency contracts for provider credential persistence."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from router_maestro.auth.manager import AuthManager
+from router_maestro.auth.repository import CredentialRepository
+from router_maestro.auth.storage import ApiKeyCredential, AuthStorage, OAuthCredential
+from router_maestro.providers.copilot_support.auth_session import CopilotAuthSession
+
+
+def _oauth(access: str = "copilot-old") -> OAuthCredential:
+    return OAuthCredential(
+        refresh="github-refresh",
+        access=access,
+        expires=0,
+        api_endpoint="https://api.githubcopilot.com",
+    )
+
+
+def test_update_provider_reads_latest_before_patching(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    first = CredentialRepository(path)
+    second = CredentialRepository(path)
+    first.update_provider("github-copilot", _oauth())
+
+    stale = first.read()
+    second.update_provider("openai", ApiKeyCredential(key="openai-key"))
+    stale.set("github-copilot", _oauth("copilot-new"))
+    first.update_provider("github-copilot", stale.get("github-copilot"))
+
+    stored = first.read()
+    assert stored.get("openai") == ApiKeyCredential(key="openai-key")
+    assert stored.get("github-copilot") == _oauth("copilot-new")
+
+
+def test_repository_instances_serialize_concurrent_provider_updates(tmp_path) -> None:
+    path = tmp_path / "nested" / ".." / "auth.json"
+    repositories = [CredentialRepository(path), CredentialRepository(path.resolve())]
+    barrier = threading.Barrier(3)
+
+    def update(index: int) -> None:
+        barrier.wait()
+        repositories[index].update_provider(
+            ("openai", "anthropic")[index],
+            ApiKeyCredential(key=f"key-{index}"),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(update, index) for index in range(2)]
+        barrier.wait()
+        for future in futures:
+            future.result()
+
+    stored = CredentialRepository(path).read()
+    assert stored.get("openai") == ApiKeyCredential(key="key-0")
+    assert stored.get("anthropic") == ApiKeyCredential(key="key-1")
+
+
+def test_remove_provider_preserves_unrelated_credentials(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("openai", ApiKeyCredential(key="openai-key"))
+    repository.update_provider("anthropic", ApiKeyCredential(key="anthropic-key"))
+
+    assert repository.remove_provider("openai") is True
+
+    stored = repository.read()
+    assert stored.get("openai") is None
+    assert stored.get("anthropic") == ApiKeyCredential(key="anthropic-key")
+
+
+def test_remove_missing_provider_does_not_rewrite_file(tmp_path, monkeypatch) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("openai", ApiKeyCredential(key="openai-key"))
+    original_save = AuthStorage.save
+    save_calls: list[object] = []
+
+    def recording_save(storage: AuthStorage, path) -> None:
+        save_calls.append(path)
+        original_save(storage, path)
+
+    monkeypatch.setattr(AuthStorage, "save", recording_save)
+
+    assert repository.remove_provider("missing") is False
+    assert save_calls == []
+
+
+def test_repository_reads_and_credentials_are_defensive_copies(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("openai", ApiKeyCredential(key="original"))
+
+    snapshot = repository.read()
+    snapshot.set("anthropic", ApiKeyCredential(key="in-memory-only"))
+    credential = repository.get_provider("openai")
+    assert isinstance(credential, ApiKeyCredential)
+    credential.key = "mutated"
+
+    assert repository.get_provider("anthropic") is None
+    assert repository.get_provider("openai") == ApiKeyCredential(key="original")
+
+
+def test_manager_observes_credentials_written_after_construction(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    manager = AuthManager(CredentialRepository(path))
+
+    CredentialRepository(path).update_provider("openai", ApiKeyCredential(key="latest"))
+
+    assert manager.get_credential("openai") == ApiKeyCredential(key="latest")
+    assert manager.list_authenticated() == ["openai"]
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "fchmod"),
+    reason="POSIX permission bits are not applicable on this platform",
+)
+def test_atomic_provider_update_preserves_owner_only_permissions(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    repository = CredentialRepository(path)
+
+    repository.update_provider("openai", ApiKeyCredential(key="secret"))
+
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.asyncio
+async def test_copilot_refresh_preserves_concurrent_provider_login(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("github-copilot", _oauth())
+    session = CopilotAuthSession(repository)
+
+    async def mint(_client, _refresh):
+        repository.update_provider("openai", ApiKeyCredential(key="openai-key"))
+        return SimpleNamespace(
+            token="copilot-new",
+            expires_at=2**31,
+            api_endpoint="https://api.githubcopilot.com",
+        )
+
+    await session.ensure_token(mint=mint)
+
+    stored = repository.read()
+    assert stored.get("openai") == ApiKeyCredential(key="openai-key")
+    assert stored.get("github-copilot") == _oauth("copilot-new").model_copy(
+        update={"expires": 2**31}
+    )
+
+
+@pytest.mark.asyncio
+async def test_copilot_persists_refreshed_credential_off_event_loop(tmp_path) -> None:
+    class RecordingRepository(CredentialRepository):
+        def __init__(self, path) -> None:
+            super().__init__(path)
+            self.update_threads: list[int] = []
+
+        def update_provider(self, provider, credential) -> None:
+            self.update_threads.append(threading.get_ident())
+            super().update_provider(provider, credential)
+
+    repository = RecordingRepository(tmp_path / "auth.json")
+    repository.update_provider("github-copilot", _oauth())
+    repository.update_threads.clear()
+    session = CopilotAuthSession(repository)
+    event_loop_thread = threading.get_ident()
+
+    async def mint(_client, _refresh):
+        await asyncio.sleep(0)
+        return SimpleNamespace(
+            token="copilot-new",
+            expires_at=2**31,
+            api_endpoint=None,
+        )
+
+    await session.ensure_token(mint=mint)
+
+    assert len(repository.update_threads) == 1
+    assert repository.update_threads[0] != event_loop_thread
+
+
+@pytest.mark.asyncio
+async def test_copilot_refresh_persists_to_injected_manager_repository(tmp_path) -> None:
+    original_repository = CredentialRepository(tmp_path / "original-auth.json")
+    injected_repository = CredentialRepository(tmp_path / "injected-auth.json")
+    injected_repository.update_provider("github-copilot", _oauth())
+    session = CopilotAuthSession(original_repository)
+    session.auth_manager = AuthManager(injected_repository)
+
+    async def mint(_client, _refresh):
+        return SimpleNamespace(
+            token="copilot-new",
+            expires_at=2**31,
+            api_endpoint=None,
+        )
+
+    await session.ensure_token(mint=mint)
+
+    assert injected_repository.get_provider("github-copilot") == _oauth("copilot-new").model_copy(
+        update={"expires": 2**31}
+    )
+    assert original_repository.get_provider("github-copilot") is None

--- a/tests/test_cli_runtime_config_mutations.py
+++ b/tests/test_cli_runtime_config_mutations.py
@@ -1,0 +1,130 @@
+"""CLI runtime-config mutations must use one compare-and-swap snapshot."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+import typer
+from rich.console import Console
+
+from router_maestro.cli import model as model_cli
+from router_maestro.cli.client import AdminConfigConflictError
+
+
+def _runtime_config() -> dict:
+    return {
+        "revision": "a" * 64,
+        "priorities": ["first/model", "second/model"],
+        "fallback": {"strategy": "priority", "maxRetries": 2},
+        "model_overrides": {"sentinel/model": {"max_output_tokens": 1234}},
+        "thinking": {
+            "default_budget": 4321,
+            "auto_enable": True,
+            "model_budgets": {"sentinel/model": 2345},
+        },
+        "guards": {
+            "leak_guard": {"enabled": False},
+            "runaway_guard": {
+                "enabled": False,
+                "max_bytes": 7654321,
+                "max_deltas": 23456,
+            },
+        },
+        "beta_strip": ["sentinel-beta-*"],
+        "audit": {"enabled": True, "trace_dir": "/sentinel/traces"},
+    }
+
+
+class _RuntimeConfigClient:
+    def __init__(self, *, conflict: bool = False) -> None:
+        self.source = _runtime_config()
+        self.conflict = conflict
+        self.get_calls = 0
+        self.patch_calls: list[tuple[dict, str]] = []
+
+    async def get_runtime_config(self) -> dict:
+        self.get_calls += 1
+        return deepcopy(self.source)
+
+    async def get_priorities(self) -> dict:
+        raise AssertionError("mutations must read the complete versioned runtime config")
+
+    async def set_priorities(self, *args, **kwargs) -> bool:
+        raise AssertionError("set_priorities performs a second GET and must not be used")
+
+    async def patch_runtime_config(self, *, config: dict, revision: str) -> dict:
+        self.patch_calls.append((deepcopy(config), revision))
+        if self.conflict:
+            raise AdminConfigConflictError("b" * 64)
+        return {**config, "revision": "c" * 64}
+
+
+def _assert_single_snapshot_patch(client: _RuntimeConfigClient) -> dict:
+    assert client.get_calls == 1
+    assert len(client.patch_calls) == 1
+    patched, revision = client.patch_calls[0]
+    assert revision == "a" * 64
+    assert "revision" not in patched
+    for field in ("model_overrides", "thinking", "guards", "beta_strip", "audit"):
+        assert patched[field] == client.source[field]
+    return patched
+
+
+def test_priority_add_patches_the_same_complete_snapshot(monkeypatch) -> None:
+    client = _RuntimeConfigClient()
+    monkeypatch.setattr(model_cli, "get_admin_client", lambda: client)
+
+    model_cli.priority_add("new/model", position=1)
+
+    patched = _assert_single_snapshot_patch(client)
+    assert patched["priorities"] == ["new/model", "first/model", "second/model"]
+    assert patched["fallback"] == client.source["fallback"]
+
+
+def test_priority_remove_patches_the_same_complete_snapshot(monkeypatch) -> None:
+    client = _RuntimeConfigClient()
+    monkeypatch.setattr(model_cli, "get_admin_client", lambda: client)
+
+    model_cli.priority_remove("first/model")
+
+    patched = _assert_single_snapshot_patch(client)
+    assert patched["priorities"] == ["second/model"]
+    assert patched["fallback"] == client.source["fallback"]
+
+
+def test_priority_clear_patches_the_same_complete_snapshot(monkeypatch) -> None:
+    client = _RuntimeConfigClient()
+    monkeypatch.setattr(model_cli, "get_admin_client", lambda: client)
+
+    model_cli.priority_clear()
+
+    patched = _assert_single_snapshot_patch(client)
+    assert patched["priorities"] == []
+    assert patched["fallback"] == client.source["fallback"]
+
+
+def test_fallback_set_patches_the_same_complete_snapshot(monkeypatch) -> None:
+    client = _RuntimeConfigClient()
+    monkeypatch.setattr(model_cli, "get_admin_client", lambda: client)
+
+    model_cli.fallback_set(strategy="same-model", max_retries=7)
+
+    patched = _assert_single_snapshot_patch(client)
+    assert patched["priorities"] == client.source["priorities"]
+    assert patched["fallback"] == {"strategy": "same-model", "maxRetries": 7}
+
+
+def test_config_conflict_never_prints_mutation_success(monkeypatch) -> None:
+    client = _RuntimeConfigClient(conflict=True)
+    output = Console(record=True, width=120)
+    monkeypatch.setattr(model_cli, "get_admin_client", lambda: client)
+    monkeypatch.setattr(model_cli, "console", output)
+
+    with pytest.raises(typer.Exit):
+        model_cli.priority_add("new/model", position=None)
+
+    rendered = output.export_text()
+    assert "Runtime configuration changed; refresh and retry" in rendered
+    assert "Added 'new/model'" not in rendered
+    _assert_single_snapshot_patch(client)

--- a/tests/test_custom_provider_auth.py
+++ b/tests/test_custom_provider_auth.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from types import SimpleNamespace
 
 import pytest
+import typer
 from pydantic import ValidationError
 
 from router_maestro.auth.discovery import (
@@ -14,6 +16,7 @@ from router_maestro.auth.discovery import (
 )
 from router_maestro.auth.repository import CredentialRepository
 from router_maestro.auth.storage import ApiKeyCredential, AuthType, OAuthCredential
+from router_maestro.cli import auth as auth_cli
 from router_maestro.cli.auth import discover_auth_providers
 from router_maestro.cli.client import ServerNotRunningError
 from router_maestro.config.providers import (
@@ -40,6 +43,12 @@ def _config(**options) -> CustomProviderConfig:
 def test_custom_provider_options_reject_unknown_fields() -> None:
     with pytest.raises(ValidationError, match="unused"):
         CustomProviderOptions.model_validate({"unused": True})
+
+
+@pytest.mark.parametrize("provider", ["github-copilot", "GITHUB-COPILOT", "openai", "Anthropic"])
+def test_custom_provider_names_reject_reserved_builtins(provider: str) -> None:
+    with pytest.raises(ValidationError, match="reserved for a built-in provider"):
+        ProvidersConfig(providers={provider: _config()})
 
 
 @pytest.mark.parametrize("value", ["", "9INVALID", "HAS-DASH", "HAS SPACE"])
@@ -279,3 +288,58 @@ async def test_cli_remote_connection_failure_never_reads_local_config() -> None:
     assert exc_info.value is error
     assert client.calls == 1
     assert local_calls == []
+
+
+def test_cli_explicit_login_discovers_provider_from_server_first(monkeypatch) -> None:
+    class _Client:
+        def __init__(self) -> None:
+            self.discovery_calls = 0
+            self.logins = []
+
+        async def list_auth_providers(self):
+            self.discovery_calls += 1
+            return [
+                ProviderAuthDefinition(
+                    provider="remote-custom",
+                    display_name="Remote Custom",
+                    auth_type=AuthType.API_KEY,
+                    credential_required=True,
+                    source=ProviderAuthSource.CUSTOM,
+                    api_key_env="REMOTE_CUSTOM_API_KEY",
+                )
+            ]
+
+        async def login_api_key(self, provider: str, api_key: str) -> bool:
+            self.logins.append((provider, api_key))
+            return True
+
+    client = _Client()
+    monkeypatch.setattr(auth_cli, "get_admin_client", lambda: client)
+    monkeypatch.setattr(
+        auth_cli,
+        "load_contexts_config",
+        lambda: SimpleNamespace(current="remote"),
+        raising=False,
+    )
+    monkeypatch.setattr(auth_cli.Prompt, "ask", lambda *args, **kwargs: "remote-key")
+
+    auth_cli.login("remote-custom")
+
+    assert client.discovery_calls == 1
+    assert client.logins == [("remote-custom", "remote-key")]
+
+
+def test_cli_explicit_unknown_provider_still_queries_server(monkeypatch) -> None:
+    client = _DiscoveryClient([])
+    monkeypatch.setattr(auth_cli, "get_admin_client", lambda: client)
+    monkeypatch.setattr(
+        auth_cli,
+        "load_contexts_config",
+        lambda: SimpleNamespace(current="remote"),
+        raising=False,
+    )
+
+    with pytest.raises(typer.Exit):
+        auth_cli.login("not-configured")
+
+    assert client.calls == 1

--- a/tests/test_custom_provider_auth.py
+++ b/tests/test_custom_provider_auth.py
@@ -1,0 +1,281 @@
+"""Credential and discovery contracts for custom providers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from pydantic import ValidationError
+
+from router_maestro.auth.discovery import (
+    ProviderAuthDefinition,
+    ProviderAuthSource,
+    provider_auth_definitions,
+)
+from router_maestro.auth.repository import CredentialRepository
+from router_maestro.auth.storage import ApiKeyCredential, AuthType, OAuthCredential
+from router_maestro.cli.auth import discover_auth_providers
+from router_maestro.cli.client import ServerNotRunningError
+from router_maestro.config.providers import (
+    CustomProviderConfig,
+    CustomProviderOptions,
+    ProvidersConfig,
+)
+from router_maestro.providers.custom_factory import (
+    CustomCredentialSource,
+    create_custom_provider,
+    default_custom_api_key_env,
+    resolve_custom_provider_credential,
+)
+from router_maestro.providers.openai_compat import OpenAICompatibleProvider
+
+
+def _config(**options) -> CustomProviderConfig:
+    return CustomProviderConfig(
+        baseURL="http://localhost:11434/v1",
+        options=CustomProviderOptions(**options),
+    )
+
+
+def test_custom_provider_options_reject_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="unused"):
+        CustomProviderOptions.model_validate({"unused": True})
+
+
+@pytest.mark.parametrize("value", ["", "9INVALID", "HAS-DASH", "HAS SPACE"])
+def test_custom_provider_options_validate_explicit_environment_name(value: str) -> None:
+    with pytest.raises(ValidationError):
+        CustomProviderOptions(api_key_env=value)
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("ollama", "OLLAMA_API_KEY"),
+        ("my-provider", "MY_PROVIDER_API_KEY"),
+        ("my.provider-v2", "MY_PROVIDER_V2_API_KEY"),
+    ],
+)
+def test_default_environment_name_normalizes_provider(provider: str, expected: str) -> None:
+    assert default_custom_api_key_env(provider) == expected
+
+
+def test_environment_credential_overrides_repository(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("ollama", ApiKeyCredential(key="repository-key"))
+
+    resolved = resolve_custom_provider_credential(
+        "ollama",
+        _config(),
+        credential_repository=repository,
+        environ={"OLLAMA_API_KEY": "environment-key"},
+    )
+
+    assert resolved is not None
+    assert resolved.source is CustomCredentialSource.ENVIRONMENT
+    assert resolved.api_key == "environment-key"
+
+
+def test_explicit_environment_name_replaces_derived_name(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+
+    resolved = resolve_custom_provider_credential(
+        "ollama",
+        _config(api_key_env="LOCAL_LLM_TOKEN"),
+        credential_repository=repository,
+        environ={
+            "OLLAMA_API_KEY": "derived-key",
+            "LOCAL_LLM_TOKEN": "explicit-key",
+        },
+    )
+
+    assert resolved is not None
+    assert resolved.api_key == "explicit-key"
+
+
+def test_empty_environment_value_falls_back_to_repository(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider("ollama", ApiKeyCredential(key="repository-key"))
+
+    resolved = resolve_custom_provider_credential(
+        "ollama",
+        _config(),
+        credential_repository=repository,
+        environ={"OLLAMA_API_KEY": ""},
+    )
+
+    assert resolved is not None
+    assert resolved.source is CustomCredentialSource.REPOSITORY
+    assert resolved.api_key == "repository-key"
+
+
+def test_non_api_repository_credential_is_not_used_as_custom_key(tmp_path) -> None:
+    repository = CredentialRepository(tmp_path / "auth.json")
+    repository.update_provider(
+        "ollama",
+        OAuthCredential(refresh="refresh", access="access"),
+    )
+
+    assert (
+        resolve_custom_provider_credential(
+            "ollama",
+            _config(),
+            credential_repository=repository,
+            environ={},
+        )
+        is None
+    )
+
+
+def test_required_custom_provider_without_key_is_skipped(tmp_path) -> None:
+    provider = create_custom_provider(
+        "ollama",
+        _config(),
+        credential_repository=CredentialRepository(tmp_path / "auth.json"),
+        environ={},
+    )
+
+    assert provider is None
+
+
+def test_explicit_anonymous_provider_is_authenticated_without_authorization(tmp_path) -> None:
+    provider = create_custom_provider(
+        "ollama",
+        _config(allow_unauthenticated=True),
+        credential_repository=CredentialRepository(tmp_path / "auth.json"),
+        environ={},
+    )
+
+    assert provider is not None
+    assert provider.is_authenticated() is True
+    assert provider._get_headers() == {"Content-Type": "application/json"}
+
+
+def test_none_key_without_explicit_anonymous_permission_is_not_authenticated() -> None:
+    provider = OpenAICompatibleProvider(
+        name="ollama",
+        base_url="http://localhost:11434/v1",
+        api_key=None,
+    )
+
+    assert provider.is_authenticated() is False
+    assert "Authorization" not in provider._get_headers()
+
+
+def test_provider_auth_definitions_are_builtin_first_then_sorted_custom() -> None:
+    definitions = provider_auth_definitions(
+        ProvidersConfig(
+            providers={
+                "zeta-provider": _config(allow_unauthenticated=True),
+                "alpha-provider": _config(api_key_env="ALPHA_TOKEN"),
+            }
+        )
+    )
+
+    assert [definition.provider for definition in definitions] == [
+        "github-copilot",
+        "openai",
+        "anthropic",
+        "alpha-provider",
+        "zeta-provider",
+    ]
+    assert definitions[0] == ProviderAuthDefinition(
+        provider="github-copilot",
+        display_name="GitHub Copilot",
+        auth_type=AuthType.OAUTH,
+        credential_required=True,
+        source=ProviderAuthSource.BUILTIN,
+    )
+    assert definitions[3].api_key_env == "ALPHA_TOKEN"
+    assert definitions[3].credential_required is True
+    assert definitions[4].api_key_env == "ZETA_PROVIDER_API_KEY"
+    assert definitions[4].credential_required is False
+
+
+def test_builtin_auth_discovery_does_not_advertise_environment_credentials() -> None:
+    definitions = provider_auth_definitions(ProvidersConfig())
+
+    assert all(definition.api_key_env is None for definition in definitions)
+
+
+class _DiscoveryClient:
+    def __init__(self, result=None, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls = 0
+
+    async def list_auth_providers(self):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _counted_local_loader(
+    calls: list[None],
+    config: ProvidersConfig,
+) -> Callable[[], ProvidersConfig]:
+    def load() -> ProvidersConfig:
+        calls.append(None)
+        return config
+
+    return load
+
+
+@pytest.mark.asyncio
+async def test_cli_discovery_prefers_server_definitions_over_local_config() -> None:
+    server_definition = {
+        "provider": "remote-custom",
+        "display_name": "Remote Custom",
+        "auth_type": "api",
+        "credential_required": True,
+        "source": "custom",
+        "api_key_env": "REMOTE_CUSTOM_API_KEY",
+    }
+    client = _DiscoveryClient([server_definition])
+    local_calls: list[None] = []
+
+    definitions = await discover_auth_providers(
+        client,
+        context_name="local",
+        load_local_config=_counted_local_loader(local_calls, ProvidersConfig()),
+    )
+
+    assert definitions == (ProviderAuthDefinition.from_mapping(server_definition),)
+    assert client.calls == 1
+    assert local_calls == []
+
+
+@pytest.mark.asyncio
+async def test_cli_local_connection_failure_uses_typed_local_config() -> None:
+    client = _DiscoveryClient(error=ServerNotRunningError("http://localhost:8080"))
+    local_calls: list[None] = []
+    local_config = ProvidersConfig(providers={"ollama": _config()})
+
+    definitions = await discover_auth_providers(
+        client,
+        context_name="local",
+        load_local_config=_counted_local_loader(local_calls, local_config),
+    )
+
+    assert definitions == provider_auth_definitions(local_config)
+    assert client.calls == 1
+    assert local_calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_cli_remote_connection_failure_never_reads_local_config() -> None:
+    error = ServerNotRunningError("https://remote.example")
+    client = _DiscoveryClient(error=error)
+    local_calls: list[None] = []
+
+    with pytest.raises(ServerNotRunningError) as exc_info:
+        await discover_auth_providers(
+            client,
+            context_name="remote",
+            load_local_config=_counted_local_loader(local_calls, ProvidersConfig()),
+        )
+
+    assert exc_info.value is error
+    assert client.calls == 1
+    assert local_calls == []

--- a/tests/test_model_catalog_audit.py
+++ b/tests/test_model_catalog_audit.py
@@ -1,0 +1,128 @@
+"""Request-scoped audit coverage for provider model-catalog transports."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from router_maestro.providers.openai import OpenAIProvider
+from router_maestro.providers.openai_compat import OpenAICompatibleProvider
+from router_maestro.runtime import request_context as request_context_module
+
+
+class _AuditSpy:
+    def __init__(self) -> None:
+        self.upstream: list[tuple] = []
+        self.responses: list[tuple] = []
+
+    def record_upstream(self, *args) -> None:
+        self.upstream.append(args)
+
+    def record_upstream_response(self, *args) -> None:
+        self.responses.append(args)
+
+
+def _provider(kind: str):
+    if kind == "openai":
+        provider = OpenAIProvider(base_url="https://catalog.invalid/v1")
+        provider._get_headers = lambda: {  # type: ignore[method-assign]
+            "Authorization": "Bearer secret",
+            "Content-Type": "application/json",
+        }
+        return provider
+    return OpenAICompatibleProvider(
+        name="custom",
+        base_url="https://catalog.invalid/v1",
+        api_key="secret",
+    )
+
+
+def _client_patch(kind: str) -> str:
+    module = "openai" if kind == "openai" else "openai_compat"
+    return f"router_maestro.providers.{module}.httpx.AsyncClient"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["openai", "compatible"])
+async def test_model_catalog_success_is_recorded_in_request_audit(kind: str) -> None:
+    provider = _provider(kind)
+    audit = _AuditSpy()
+    response = httpx.Response(
+        200,
+        json={"data": [{"id": "gpt-audit"}]},
+        headers={"x-request-id": "catalog-1"},
+        request=httpx.Request("GET", "https://catalog.invalid/v1/models"),
+    )
+
+    with patch(_client_patch(kind)) as client_cls:
+        client = AsyncMock()
+        client.get.return_value = response
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client_cls.return_value = client
+        token = request_context_module._current_request_context.set(  # type: ignore[attr-defined]
+            type("Context", (), {"audit": audit})()
+        )
+        try:
+            await provider.list_models()
+        finally:
+            request_context_module._current_request_context.reset(token)  # type: ignore[attr-defined]
+
+    assert audit.upstream == [
+        (
+            "GET",
+            "https://catalog.invalid/v1/models",
+            provider._get_headers(),
+            None,
+        )
+    ]
+    assert audit.responses == [
+        (
+            200,
+            {
+                "x-request-id": "catalog-1",
+                "content-length": "29",
+                "content-type": "application/json",
+            },
+            b'{"data":[{"id":"gpt-audit"}]}',
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["openai", "compatible"])
+async def test_model_catalog_http_error_response_is_recorded(kind: str) -> None:
+    provider = _provider(kind)
+    audit = _AuditSpy()
+    response = httpx.Response(
+        503,
+        json={"error": "unavailable"},
+        request=httpx.Request("GET", "https://catalog.invalid/v1/models"),
+    )
+
+    with patch(_client_patch(kind)) as client_cls:
+        client = AsyncMock()
+        client.get.return_value = response
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client_cls.return_value = client
+        token = request_context_module._current_request_context.set(  # type: ignore[attr-defined]
+            type("Context", (), {"audit": audit})()
+        )
+        try:
+            models = await provider.list_models()
+        finally:
+            request_context_module._current_request_context.reset(token)  # type: ignore[attr-defined]
+
+    if kind == "openai":
+        assert models
+    else:
+        assert models == []
+    assert len(audit.upstream) == 1
+    assert audit.responses == [
+        (
+            503,
+            {"content-length": "23", "content-type": "application/json"},
+            b'{"error":"unavailable"}',
+        )
+    ]

--- a/tests/test_models_route.py
+++ b/tests/test_models_route.py
@@ -25,6 +25,22 @@ class _FakeRouter:
         ]
 
 
+class _RouterLease:
+    def __init__(self, router):
+        self.router = router
+
+    async def release(self):
+        return None
+
+
+class _RouterOwner:
+    def __init__(self, router):
+        self.router = router
+
+    async def acquire(self):
+        return _RouterLease(self.router)
+
+
 @pytest.mark.anyio
 async def test_openai_models_route_uses_routing_singleton(monkeypatch):
     """The models route should reuse the routing singleton instead of constructing Router."""
@@ -52,8 +68,7 @@ async def test_public_model_lists_encode_provider_namespaced_upstream_id(monkeyp
     openai_response = await list_models()
     with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
         anthropic_response = await list_anthropic_models()
-    with patch("router_maestro.server.routes.admin.get_router", return_value=model_router):
-        admin_response = await list_admin_models()
+    admin_response = await list_admin_models(_RouterOwner(model_router))
 
     expected = ["openrouter/openrouter/auto"]
     assert [model.id for model in openai_response.data] == expected
@@ -80,8 +95,7 @@ async def test_public_model_lists_do_not_double_prefix_qualified_catalog_ids(mon
     openai_response = await list_models()
     with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
         anthropic_response = await list_anthropic_models()
-    with patch("router_maestro.server.routes.admin.get_router", return_value=model_router):
-        admin_response = await list_admin_models()
+    admin_response = await list_admin_models(_RouterOwner(model_router))
 
     assert [model.id for model in openai_response.data] == ["github-copilot/claude-sonnet-4.6"]
     assert [model.id for model in anthropic_response.data] == ["github-copilot/claude-sonnet-4.6"]
@@ -137,8 +151,7 @@ async def test_public_model_lists_round_trip_to_same_provider_with_bare_upstream
     openai_response = await list_models()
     with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
         anthropic_response = await list_anthropic_models()
-    with patch("router_maestro.server.routes.admin.get_router", return_value=model_router):
-        admin_response = await list_admin_models()
+    admin_response = await list_admin_models(_RouterOwner(model_router))
 
     for public_ids in (
         [model.id for model in openai_response.data],

--- a/tests/test_nonstream_request_outcomes.py
+++ b/tests/test_nonstream_request_outcomes.py
@@ -1,0 +1,350 @@
+"""HTTP non-stream routes preserve provider semantics in RequestContext."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.providers import (
+    ChatResponse,
+    ResponseStatus,
+    TerminalError,
+    TerminalOutcome,
+    TransportTermination,
+)
+from router_maestro.providers import (
+    ResponsesResponse as InternalResponsesResponse,
+)
+from router_maestro.routing.capabilities import CapabilitySupport
+from router_maestro.routing.model_ref import ModelRef
+from router_maestro.runtime import RequestContext, RequestContextMiddleware, current_request_context
+from router_maestro.server.routes.anthropic import router as anthropic_router
+from router_maestro.server.routes.chat import router as chat_router
+from router_maestro.server.routes.gemini import router as gemini_router
+from router_maestro.server.routes.responses import router as responses_router
+from router_maestro.utils.responses_bridge import responses_response_to_chat_response
+
+
+class _Snapshot:
+    revision = "nonstream-outcome-revision"
+
+    def __init__(self) -> None:
+        self._config = PrioritiesConfig()
+
+    @property
+    def config(self) -> PrioritiesConfig:
+        return self._config.model_copy(deep=True)
+
+
+class _Lease:
+    generation_id = 1
+
+    def __init__(self, router, snapshot: _Snapshot) -> None:
+        self.router = router
+        self.config_snapshot = snapshot
+        self.release_count = 0
+
+    async def release(self) -> None:
+        self.release_count += 1
+
+
+class _Owner:
+    def __init__(self, lease: _Lease) -> None:
+        self.lease = lease
+
+    async def start(self, _snapshot: _Snapshot) -> None:
+        return None
+
+    async def acquire(self) -> _Lease:
+        return self.lease
+
+
+class _Repository:
+    def __init__(self, snapshot: _Snapshot) -> None:
+        self.snapshot = snapshot
+
+    def read(self) -> _Snapshot:
+        return self.snapshot
+
+
+class _CandidateCapabilities:
+    max_output_tokens = 8
+
+    def feature(self, _feature) -> CapabilitySupport:
+        return CapabilitySupport.UNSUPPORTED
+
+
+class _Backend:
+    def __init__(
+        self,
+        *,
+        chat_response: ChatResponse | None = None,
+        responses_response: InternalResponsesResponse | None = None,
+        bridge_response: InternalResponsesResponse | None = None,
+    ) -> None:
+        self.chat_response = chat_response
+        self.responses_response = responses_response
+        self.bridge_response = bridge_response
+        self.contexts: list[RequestContext] = []
+        self.candidate = SimpleNamespace(
+            model=ModelRef("test-provider", "test-model"),
+            capabilities=_CandidateCapabilities(),
+        )
+
+    async def plan_chat_completion(self, _request, *, stream: bool):
+        assert stream is False
+        return SimpleNamespace(primary=self.candidate, prevalidation_fallbacks=())
+
+    def prepare_planned_chat_completion(self, _plan, _request, **_kwargs):
+        return object()
+
+    async def chat_completion(self, _request, **_kwargs):
+        self.contexts.append(current_request_context())
+        if self.bridge_response is not None:
+            bridged = responses_response_to_chat_response(
+                self.bridge_response,
+                "test-model",
+                provider="test-provider",
+            )
+            return bridged, "test-provider"
+        assert self.chat_response is not None
+        return self.chat_response, "test-provider"
+
+    async def responses_completion(self, _request, **_kwargs):
+        self.contexts.append(current_request_context())
+        assert self.responses_response is not None
+        return self.responses_response, "test-provider"
+
+
+def _client(
+    route: APIRouter,
+    backend: _Backend,
+) -> tuple[TestClient, _Lease]:
+    snapshot = _Snapshot()
+    lease = _Lease(backend, snapshot)
+    app = FastAPI()
+    app.state.runtime_config_repository = _Repository(snapshot)
+    app.state.router_owner = _Owner(lease)
+    app.include_router(route)
+    app.add_middleware(RequestContextMiddleware)
+    return TestClient(app), lease
+
+
+def _incomplete_outcome() -> TerminalOutcome:
+    return TerminalOutcome(
+        transport=TransportTermination.EXPLICIT_TERMINAL,
+        response_status=ResponseStatus.INCOMPLETE,
+        finish_reason="length",
+        incomplete_details={"reason": "max_output_tokens", "vendor": "preserved"},
+    )
+
+
+def _assert_context(
+    backend: _Backend,
+    lease: _Lease,
+    expected: TerminalOutcome,
+) -> None:
+    assert len(backend.contexts) == 1
+    context = backend.contexts[0]
+    assert context.finalized is True
+    assert context.status_code == 200
+    assert context.outcome == expected
+    assert lease.release_count == 1
+
+
+def test_chat_nonstream_http_200_records_legacy_incomplete_outcome() -> None:
+    expected = TerminalOutcome(
+        transport=TransportTermination.EXPLICIT_TERMINAL,
+        response_status=ResponseStatus.INCOMPLETE,
+        finish_reason="length",
+    )
+    backend = _Backend(
+        chat_response=ChatResponse(
+            content="partial",
+            model="test-model",
+            finish_reason="length",
+        )
+    )
+    client, lease = _client(chat_router, backend)
+
+    response = client.post(
+        "/api/openai/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "length"
+    _assert_context(backend, lease, expected)
+
+
+def test_responses_nonstream_http_200_records_incomplete_outcome() -> None:
+    expected = _incomplete_outcome()
+    backend = _Backend(
+        responses_response=InternalResponsesResponse(
+            content="partial",
+            model="test-model",
+            terminal_outcome=expected,
+        )
+    )
+    client, lease = _client(responses_router, backend)
+
+    response = client.post(
+        "/api/openai/v1/responses",
+        json={"model": "test-model", "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "incomplete"
+    _assert_context(backend, lease, expected)
+
+
+def test_anthropic_nonstream_http_200_records_canonical_incomplete_outcome() -> None:
+    expected = _incomplete_outcome()
+    backend = _Backend(
+        chat_response=ChatResponse(
+            content="partial",
+            model="test-model",
+            finish_reason="length",
+            terminal_outcome=expected,
+        )
+    )
+    client, lease = _client(anthropic_router, backend)
+
+    response = client.post(
+        "/v1/messages",
+        json={
+            "model": "test-model",
+            "max_tokens": 8,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["stop_reason"] == "max_tokens"
+    _assert_context(backend, lease, expected)
+
+
+def test_gemini_nonstream_http_200_records_canonical_incomplete_outcome() -> None:
+    expected = _incomplete_outcome()
+    backend = _Backend(
+        chat_response=ChatResponse(
+            content="partial",
+            model="test-model",
+            finish_reason="length",
+            terminal_outcome=expected,
+        )
+    )
+    client, lease = _client(gemini_router, backend)
+
+    response = client.post(
+        "/api/gemini/v1beta/models/test-model:generateContent",
+        json={"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["candidates"][0]["finishReason"] == "MAX_TOKENS"
+    _assert_context(backend, lease, expected)
+
+
+@pytest.mark.parametrize("status", [ResponseStatus.FAILED, ResponseStatus.CANCELLED])
+def test_native_responses_nonstream_http_200_records_business_terminal_status(
+    status: ResponseStatus,
+) -> None:
+    expected = TerminalOutcome(
+        transport=TransportTermination.EXPLICIT_TERMINAL,
+        response_status=status,
+        error=(
+            TerminalError(code="upstream_failed", message="safe failure")
+            if status is ResponseStatus.FAILED
+            else None
+        ),
+    )
+    backend = _Backend(
+        responses_response=InternalResponsesResponse(
+            content="partial",
+            model="test-model",
+            terminal_outcome=expected,
+        )
+    )
+    client, lease = _client(responses_router, backend)
+
+    response = client.post(
+        "/api/openai/v1/responses",
+        json={"model": "test-model", "input": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == status.value
+    _assert_context(backend, lease, expected)
+
+
+@pytest.mark.parametrize("status", [ResponseStatus.FAILED, ResponseStatus.CANCELLED])
+@pytest.mark.parametrize(
+    ("route", "path", "payload", "error_key"),
+    [
+        (
+            chat_router,
+            "/api/openai/v1/chat/completions",
+            {"model": "test-model", "messages": [{"role": "user", "content": "hello"}]},
+            "error",
+        ),
+        (
+            anthropic_router,
+            "/v1/messages",
+            {
+                "model": "test-model",
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            "error",
+        ),
+        (
+            gemini_router,
+            "/api/gemini/v1beta/models/test-model:generateContent",
+            {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+            "error",
+        ),
+    ],
+    ids=["chat", "anthropic", "gemini"],
+)
+def test_responses_bridge_failure_keeps_protocol_error_semantics(
+    status: ResponseStatus,
+    route: APIRouter,
+    path: str,
+    payload: dict,
+    error_key: str,
+) -> None:
+    upstream = InternalResponsesResponse(
+        content="partial",
+        model="test-model",
+        terminal_outcome=TerminalOutcome(
+            transport=TransportTermination.EXPLICIT_TERMINAL,
+            response_status=status,
+            error=(
+                TerminalError(code="upstream_failed", message="safe failure")
+                if status is ResponseStatus.FAILED
+                else None
+            ),
+        ),
+    )
+    backend = _Backend(bridge_response=upstream)
+    client, lease = _client(route, backend)
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 502
+    assert error_key in response.json()
+    assert len(backend.contexts) == 1
+    context = backend.contexts[0]
+    assert context.finalized is True
+    assert context.status_code == 502
+    assert context.outcome is not None
+    assert context.outcome.response_status is ResponseStatus.FAILED
+    assert lease.release_count == 1

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -747,7 +747,7 @@ async def test_stale_copilot_catalog_keeps_planning_and_transport_consistent(
         )
     ]
     provider._models_ttl_cache.set(stale)
-    provider._models_ttl_cache._timestamp = 0
+    provider._models_ttl_cache._timestamp -= provider._models_ttl_cache._ttl + 1
 
     def failed_refresh(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, json={"error": "catalog unavailable"})

--- a/tests/test_provider_protocol_errors.py
+++ b/tests/test_provider_protocol_errors.py
@@ -506,7 +506,7 @@ async def test_copilot_padded_model_id_serves_and_renews_defensive_stale_snapsho
     provider = CopilotProvider()
     stale = [ModelInfo(id="known", name="Known", provider="github-copilot")]
     provider._models_ttl_cache.set(stale)
-    provider._models_ttl_cache._timestamp = 0
+    provider._models_ttl_cache._timestamp -= provider._models_ttl_cache._ttl + 1
     provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
     provider._send_with_auth_retry = AsyncMock(  # type: ignore[method-assign]
         return_value=_response_for_payload({"data": [{"id": " padded-model "}]})
@@ -531,7 +531,7 @@ async def test_copilot_malformed_supported_endpoints_serves_and_renews_stale_sna
     provider = CopilotProvider()
     stale = [ModelInfo(id="known", name="Known", provider="github-copilot")]
     provider._models_ttl_cache.set(stale)
-    provider._models_ttl_cache._timestamp = 0
+    provider._models_ttl_cache._timestamp -= provider._models_ttl_cache._ttl + 1
     provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
     provider._send_with_auth_retry = AsyncMock(  # type: ignore[method-assign]
         return_value=_response_for_payload(
@@ -555,7 +555,7 @@ async def test_copilot_malformed_strict_catalog_field_serves_and_renews_stale_sn
     provider = CopilotProvider()
     stale = [ModelInfo(id="known", name="Known", provider="github-copilot")]
     provider._models_ttl_cache.set(stale)
-    provider._models_ttl_cache._timestamp = 0
+    provider._models_ttl_cache._timestamp -= provider._models_ttl_cache._ttl + 1
     provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
     provider._send_with_auth_retry = AsyncMock(  # type: ignore[method-assign]
         return_value=_response_for_payload(

--- a/tests/test_request_lifecycle.py
+++ b/tests/test_request_lifecycle.py
@@ -1,0 +1,524 @@
+"""Pure-ASGI request ownership and finalization contracts."""
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from starlette.requests import ClientDisconnect
+from starlette.responses import StreamingResponse
+
+from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.providers.base import (
+    ResponseStatus,
+    TransportTermination,
+    client_cancelled_outcome,
+)
+from router_maestro.providers.copilot_support.transport import CopilotTransport
+from router_maestro.runtime.request_context import (
+    RequestContext,
+    RequestContextMiddleware,
+    current_request_context,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Snapshot:
+    revision: str
+    value: str
+
+    @property
+    def config(self) -> PrioritiesConfig:
+        return PrioritiesConfig(priorities=[self.value])
+
+
+class _Repository:
+    def __init__(self, snapshot: _Snapshot) -> None:
+        self.snapshot = snapshot
+        self.read_count = 0
+
+    def read(self) -> _Snapshot:
+        self.read_count += 1
+        return self.snapshot
+
+
+class _Lease:
+    def __init__(
+        self,
+        generation_id: int,
+        router: object,
+        config_snapshot: object | None = None,
+    ) -> None:
+        self.generation_id = generation_id
+        self.router = router
+        self.config_snapshot = config_snapshot
+        self.release_count = 0
+
+    async def release(self) -> None:
+        self.release_count += 1
+
+
+class _Owner:
+    def __init__(self, lease: _Lease) -> None:
+        self.lease = lease
+        self.acquire_count = 0
+
+    async def acquire(self) -> _Lease:
+        self.acquire_count += 1
+        return self.lease
+
+
+def _scope(repository: _Repository, owner: _Owner, path: str = "/v1/messages") -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [],
+        "state": {"request_id": "req-1"},
+        "app": SimpleNamespace(
+            state=SimpleNamespace(
+                runtime_config_repository=repository,
+                router_owner=owner,
+            )
+        ),
+    }
+
+
+async def _receive() -> dict[str, Any]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+async def _discard_send(_message: dict[str, Any]) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_endpoint_return_does_not_finalize_before_final_body() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(11, object())
+    owner = _Owner(lease)
+    endpoint_returned = asyncio.Event()
+    allow_final_body = asyncio.Event()
+    sent: list[dict[str, Any]] = []
+    captured: list[RequestContext] = []
+
+    async def app(scope, receive, send) -> None:
+        context = current_request_context()
+        captured.append(context)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"first", "more_body": True})
+        endpoint_returned.set()
+        await allow_final_body.wait()
+        await send({"type": "http.response.body", "body": b"last", "more_body": False})
+
+    middleware = RequestContextMiddleware(app)
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+
+    task = asyncio.create_task(middleware(_scope(repository, owner), _receive, send))
+    await endpoint_returned.wait()
+
+    assert lease.release_count == 0
+    assert captured[0].finalized is False
+
+    allow_final_body.set()
+    await task
+    assert lease.release_count == 1
+    assert captured[0].finalized is True
+    assert captured[0].stream_committed is True
+    assert captured[0].outcome is not None
+    assert captured[0].outcome.transport is TransportTermination.EXPLICIT_TERMINAL
+    assert captured[0].outcome.response_status is ResponseStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_exception_before_response_finalizes_and_releases_once() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    captured: list[RequestContext] = []
+
+    async def app(scope, receive, send) -> None:
+        captured.append(current_request_context())
+        raise RuntimeError("boom")
+
+    middleware = RequestContextMiddleware(app)
+    with pytest.raises(RuntimeError, match="boom"):
+        await middleware(_scope(repository, owner), _receive, _discard_send)
+
+    assert lease.release_count == 1
+    assert captured[0].outcome is not None
+    assert captured[0].outcome.transport is TransportTermination.EXCEPTION
+    await captured[0].finalize()
+    assert lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_request_records_cancel_and_releases_once() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    started = asyncio.Event()
+    captured: list[RequestContext] = []
+
+    async def app(scope, receive, send) -> None:
+        captured.append(current_request_context())
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(
+        RequestContextMiddleware(app)(
+            _scope(repository, owner),
+            _receive,
+            _discard_send,
+        )
+    )
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.release_count == 1
+    assert captured[0].outcome == client_cancelled_outcome()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_message_records_client_cancel_when_app_returns_normally() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    captured: list[RequestContext] = []
+
+    async def receive_disconnect() -> dict[str, Any]:
+        return {"type": "http.disconnect"}
+
+    async def app(scope, receive, send) -> None:
+        captured.append(current_request_context())
+        assert await receive() == {"type": "http.disconnect"}
+
+    await RequestContextMiddleware(app)(
+        _scope(repository, owner),
+        receive_disconnect,
+        _discard_send,
+    )
+
+    assert lease.release_count == 1
+    assert captured[0].outcome == client_cancelled_outcome()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_disconnect_listener_records_client_cancel() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    captured: list[RequestContext] = []
+
+    async def receive_disconnect() -> dict[str, Any]:
+        return {"type": "http.disconnect"}
+
+    async def stream():
+        await asyncio.Event().wait()
+        yield b"unreachable"
+
+    async def app(scope, receive, send) -> None:
+        captured.append(current_request_context())
+        await StreamingResponse(stream())(scope, receive, send)
+
+    scope = _scope(repository, owner)
+    scope["asgi"] = {"spec_version": "2.3"}
+    await RequestContextMiddleware(app)(scope, receive_disconnect, _discard_send)
+
+    assert lease.release_count == 1
+    assert captured[0].outcome == client_cancelled_outcome()
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_send_disconnect_records_client_cancel() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    captured: list[RequestContext] = []
+
+    async def stream():
+        yield b"chunk"
+
+    async def app(scope, receive, send) -> None:
+        captured.append(current_request_context())
+        await StreamingResponse(stream())(scope, receive, send)
+
+    async def disconnected_send(message: dict[str, Any]) -> None:
+        if message["type"] == "http.response.body":
+            raise OSError("client socket closed")
+
+    scope = _scope(repository, owner)
+    scope["asgi"] = {"spec_version": "2.4"}
+    with pytest.raises(ClientDisconnect):
+        await RequestContextMiddleware(app)(scope, _receive, disconnected_send)
+
+    assert lease.release_count == 1
+    assert captured[0].outcome == client_cancelled_outcome()
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_finalize_waits_for_release_before_propagating() -> None:
+    class BlockingLease(_Lease):
+        def __init__(self) -> None:
+            super().__init__(1, object())
+            self.release_started = asyncio.Event()
+            self.finish_release = asyncio.Event()
+
+        async def release(self) -> None:
+            self.release_started.set()
+            await self.finish_release.wait()
+            self.release_count += 1
+
+    snapshot = _Snapshot("rev", "config")
+    lease = BlockingLease()
+    context = RequestContext(
+        request_id="req",
+        config_snapshot=snapshot,
+        config=snapshot.config,
+        lease=lease,
+    )
+    finalize_task = asyncio.create_task(context.finalize(wire_status=200))
+    await lease.release_started.wait()
+
+    finalize_task.cancel()
+    await asyncio.sleep(0)
+    finalize_task.cancel()
+    await asyncio.sleep(0)
+    assert not finalize_task.done()
+    assert context.finalized is False
+
+    lease.finish_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await finalize_task
+    assert context.finalized is True
+    assert lease.release_count == 1
+    await context.finalize(wire_status=200)
+    assert lease.release_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unexpected_eof_finalizes_when_app_returns_without_final_body() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    captured: list[RequestContext] = []
+
+    async def app(scope, receive, send) -> None:
+        captured.append(current_request_context())
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"partial", "more_body": True})
+
+    await RequestContextMiddleware(app)(
+        _scope(repository, owner),
+        _receive,
+        _discard_send,
+    )
+
+    assert lease.release_count == 1
+    assert captured[0].outcome is not None
+    assert captured[0].outcome.transport is TransportTermination.UNEXPECTED_EOF
+
+
+@pytest.mark.asyncio
+async def test_request_captures_one_snapshot_and_generation_for_entire_body() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    router_a = object()
+    lease = _Lease(41, router_a)
+    owner = _Owner(lease)
+    captured: list[tuple[str, int, object, list[str]]] = []
+
+    async def app(scope, receive, send) -> None:
+        context = current_request_context()
+        captured.append(
+            (
+                context.revision,
+                context.generation_id,
+                context.router,
+                context.config.priorities,
+            )
+        )
+        repository.snapshot = _Snapshot("rev-b", "config-b")
+        owner.lease = _Lease(42, object())
+        captured.append(
+            (
+                context.revision,
+                context.generation_id,
+                context.router,
+                context.config.priorities,
+            )
+        )
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    await RequestContextMiddleware(app)(
+        _scope(repository, owner),
+        _receive,
+        _discard_send,
+    )
+
+    assert repository.read_count == 1
+    assert owner.acquire_count == 1
+    assert captured == [
+        ("rev-a", 41, router_a, ["config-a"]),
+        ("rev-a", 41, router_a, ["config-a"]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_uses_the_snapshot_owned_by_the_leased_generation() -> None:
+    repository = _Repository(_Snapshot("repo-new", "config-new"))
+    generation_snapshot = _Snapshot("generation-old", "config-old")
+    lease = _Lease(41, object(), generation_snapshot)
+    owner = _Owner(lease)
+    captured: list[tuple[str, list[str]]] = []
+
+    async def app(scope, receive, send) -> None:
+        context = current_request_context()
+        captured.append((context.revision, context.config.priorities))
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    await RequestContextMiddleware(app)(
+        _scope(repository, owner),
+        _receive,
+        _discard_send,
+    )
+
+    assert repository.read_count == 1
+    assert captured == [("generation-old", ["config-old"])]
+
+
+@pytest.mark.asyncio
+async def test_non_inference_path_does_not_capture_snapshot_or_lease() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+
+    async def app(scope, receive, send) -> None:
+        with pytest.raises(LookupError):
+            current_request_context()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    await RequestContextMiddleware(app)(
+        _scope(repository, owner, path="/health"),
+        _receive,
+        _discard_send,
+    )
+
+    assert repository.read_count == 0
+    assert owner.acquire_count == 0
+    assert lease.release_count == 0
+
+
+@pytest.mark.asyncio
+async def test_beta_header_strip_uses_captured_snapshot() -> None:
+    config = PrioritiesConfig(priorities=[])
+    config.beta_strip = ["remove-*", "exact"]
+
+    @dataclass(frozen=True, slots=True)
+    class Snapshot:
+        revision: str = "beta-revision"
+
+        @property
+        def config(self) -> PrioritiesConfig:
+            return config.model_copy(deep=True)
+
+    repository = _Repository(_Snapshot("ignored", "ignored"))
+    repository.snapshot = Snapshot()  # type: ignore[assignment]
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    observed: list[str | None] = []
+
+    async def app(scope, receive, send) -> None:
+        auth = SimpleNamespace(cached_token="token", provider_name="github-copilot")
+        observed.append(CopilotTransport(auth).headers().get("anthropic-beta"))
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    scope = _scope(repository, owner)
+    scope["headers"] = [
+        (b"anthropic-beta", b"keep,remove-one,exact"),
+    ]
+    await RequestContextMiddleware(app)(scope, _receive, _discard_send)
+
+    assert observed == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_outbound_audit_is_deferred_until_context_finalize() -> None:
+    from router_maestro.pipeline.request_pipeline import RequestPipeline
+    from router_maestro.providers.base import unexpected_eof_outcome
+
+    class AuditSpy:
+        def __init__(self) -> None:
+            self.outbound_count = 0
+            self.flush_count = 0
+
+        def record_outbound(self, *_args, **_kwargs) -> None:
+            self.outbound_count += 1
+
+        def record_inbound(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def flush_async(self) -> None:
+            self.flush_count += 1
+
+    audit = AuditSpy()
+    snapshot = _Snapshot("rev", "config")
+    lease = _Lease(1, object())
+    context = RequestContext(
+        request_id="req",
+        config_snapshot=snapshot,
+        config=snapshot.config,
+        lease=lease,
+        audit=audit,  # type: ignore[arg-type]
+    )
+    context.pipeline = RequestPipeline(
+        request_id="req",
+        guards=[],
+        leak_guard=None,
+        audit=audit,  # type: ignore[arg-type]
+        config=context.config,
+        defer_flush=True,
+    )
+    outcome = unexpected_eof_outcome()
+
+    context.pipeline.finish(wire_status=200, outcome=outcome)
+    assert audit.outbound_count == 0
+
+    await context.finalize(wire_status=200)
+    assert audit.outbound_count == 1
+    assert audit.flush_count == 1
+
+
+@pytest.mark.asyncio
+async def test_early_auth_response_still_finalizes_captured_inference_context() -> None:
+    repository = _Repository(_Snapshot("rev-a", "config-a"))
+    lease = _Lease(1, object())
+    owner = _Owner(lease)
+    auth_rejection_context: list[RequestContext] = []
+
+    async def auth_rejection(scope, receive, send) -> None:
+        auth_rejection_context.append(current_request_context())
+        await send({"type": "http.response.start", "status": 401, "headers": []})
+        await send({"type": "http.response.body", "body": b"no", "more_body": False})
+
+    await RequestContextMiddleware(auth_rejection)(
+        _scope(repository, owner),
+        _receive,
+        _discard_send,
+    )
+
+    assert repository.read_count == 1
+    assert owner.acquire_count == 1
+    assert lease.release_count == 1
+    context = auth_rejection_context[0]
+    assert context.outcome is not None
+    assert context.outcome.transport is TransportTermination.EXPLICIT_TERMINAL
+    assert context.outcome.response_status is ResponseStatus.FAILED

--- a/tests/test_responses_bridge.py
+++ b/tests/test_responses_bridge.py
@@ -706,6 +706,7 @@ class TestResponsesToChat:
         chat = responses_response_to_chat_response(resp, "gpt-5.4")
 
         assert chat.finish_reason == expected
+        assert chat.terminal_outcome == resp.terminal_outcome
 
     @pytest.mark.parametrize("status", [ResponseStatus.FAILED, ResponseStatus.CANCELLED])
     def test_canonical_failure_cannot_become_non_stream_chat_success(self, status):

--- a/tests/test_router_lifecycle.py
+++ b/tests/test_router_lifecycle.py
@@ -662,11 +662,21 @@ async def test_concurrent_cold_catalog_requests_share_one_refresh() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stale_catalog_is_served_while_one_refresh_runs() -> None:
+async def test_stale_catalog_is_served_while_one_refresh_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from router_maestro.utils import cache as cache_module
+
+    class FreshRunnerClock:
+        @staticmethod
+        def monotonic() -> float:
+            return 100.0
+
+    monkeypatch.setattr(cache_module, "time", FreshRunnerClock)
     catalog = CopilotCatalog()
     stale = [ModelInfo(id="stale", name="Stale", provider="github-copilot")]
     catalog.models_ttl_cache.set(stale)
-    catalog.models_ttl_cache._timestamp = 0
+    catalog.models_ttl_cache._timestamp -= catalog.models_ttl_cache._ttl + 1
     send_started = asyncio.Event()
     release_send = asyncio.Event()
     send_count = 0
@@ -686,7 +696,7 @@ async def test_stale_catalog_is_served_while_one_refresh_runs() -> None:
         derive_operations=_operations,
         raise_protocol_error=_protocol_error,
     )
-    await send_started.wait()
+    await asyncio.wait_for(send_started.wait(), timeout=1)
     second = await catalog.list_models(
         provider_name="github-copilot",
         ensure_token=_noop_token,
@@ -720,7 +730,7 @@ async def test_stale_catalog_refresh_runs_without_request_context() -> None:
     catalog = CopilotCatalog()
     stale = [ModelInfo(id="stale", name="Stale", provider="github-copilot")]
     catalog.models_ttl_cache.set(stale)
-    catalog.models_ttl_cache._timestamp = 0
+    catalog.models_ttl_cache._timestamp -= catalog.models_ttl_cache._ttl + 1
     refresh_contexts: list[RequestContext | None] = []
     refresh_finished = asyncio.Event()
 
@@ -785,7 +795,7 @@ async def test_catalog_aclose_cancels_and_awaits_active_refresh() -> None:
     catalog = CopilotCatalog()
     stale = [ModelInfo(id="stale", name="Stale", provider="github-copilot")]
     catalog.models_ttl_cache.set(stale)
-    catalog.models_ttl_cache._timestamp = 0
+    catalog.models_ttl_cache._timestamp -= catalog.models_ttl_cache._ttl + 1
     refresh_started = asyncio.Event()
     refresh_finished = asyncio.Event()
 

--- a/tests/test_router_lifecycle.py
+++ b/tests/test_router_lifecycle.py
@@ -1,0 +1,904 @@
+"""Router generation and model-catalog lifecycle contracts."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+from router_maestro.providers.base import (
+    BaseProvider,
+    ChatRequest,
+    ChatResponse,
+    ChatStreamChunk,
+    ModelInfo,
+)
+from router_maestro.providers.copilot import CopilotProvider
+from router_maestro.providers.copilot_support.catalog import CopilotCatalog
+from router_maestro.routing.router import Router, RouterOwner
+from router_maestro.runtime.request_context import RequestContext, get_current_request_context
+from router_maestro.server.app import lifespan
+
+
+class _ClosingProvider(BaseProvider):
+    name = "test"
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    async def chat_completion(self, request: ChatRequest) -> ChatResponse:
+        raise NotImplementedError
+
+    async def chat_completion_stream(self, request: ChatRequest) -> AsyncIterator[ChatStreamChunk]:
+        if False:
+            yield ChatStreamChunk()
+
+    async def list_models(self) -> list[ModelInfo]:
+        return []
+
+    def is_authenticated(self) -> bool:
+        return True
+
+    async def close(self) -> None:
+        self.close_count += 1
+
+
+@dataclass
+class _GenerationRouter:
+    label: str
+    provider: _ClosingProvider
+
+    @property
+    def providers(self) -> dict[str, BaseProvider]:
+        return {"test": self.provider}
+
+
+class _RouterFactory:
+    def __init__(self) -> None:
+        self.routers: list[_GenerationRouter] = []
+        self.fail_for: set[str] = set()
+
+    def __call__(self, snapshot: object | None = None) -> _GenerationRouter:
+        label = str(snapshot)
+        if label in self.fail_for:
+            raise RuntimeError(f"cannot build {label}")
+        router = _GenerationRouter(label, _ClosingProvider())
+        self.routers.append(router)
+        return router
+
+
+@pytest.mark.asyncio
+async def test_stream_lease_keeps_retired_generation_open_until_release() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("A")
+
+    lease_a = await owner.acquire()
+    generation_a = lease_a.generation_id
+    router_a = lease_a.router
+
+    generation_b = await owner.rebuild("B")
+    lease_b = await owner.acquire()
+
+    assert generation_b != generation_a
+    assert lease_b.generation_id == generation_b
+    assert lease_b.router is factory.routers[1]
+    assert router_a.provider.close_count == 0
+
+    await lease_a.release()
+    assert router_a.provider.close_count == 1
+
+    await lease_b.release()
+    await owner.close()
+    assert factory.routers[1].provider.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_lease_release_is_idempotent_and_async_context_managed() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    lease = await owner.acquire()
+    await owner.rebuild("B")
+
+    async with lease as entered:
+        assert entered is lease
+    await lease.release()
+
+    assert factory.routers[0].provider.close_count == 1
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_lease_holder_releases_retired_generation_once() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    entered = asyncio.Event()
+    hold = asyncio.Event()
+
+    async def serve() -> None:
+        async with await owner.acquire():
+            entered.set()
+            await hold.wait()
+
+    task = asyncio.create_task(serve())
+    await entered.wait()
+    await owner.rebuild("B")
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert factory.routers[0].provider.close_count == 1
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_release_finishes_reference_drop_before_propagating_cancel() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    lease = await owner.acquire()
+    generation = owner._generations[lease.generation_id]
+
+    await owner._state_lock.acquire()
+    release_task = asyncio.create_task(lease.release())
+    await asyncio.sleep(0)
+    release_task.cancel()
+    await asyncio.sleep(0)
+    release_task.cancel()
+    await asyncio.sleep(0)
+    owner._state_lock.release()
+
+    with pytest.raises(asyncio.CancelledError):
+        await release_task
+    assert lease.released is True
+    assert generation.references == 0
+    await asyncio.wait_for(owner.close(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_failed_rebuild_preserves_active_generation() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    generation_a = await owner.start("A")
+    factory.fail_for.add("broken")
+
+    with pytest.raises(RuntimeError, match="cannot build broken"):
+        await owner.rebuild("broken")
+
+    lease = await owner.acquire()
+    assert lease.generation_id == generation_a
+    assert lease.router is factory.routers[0]
+    assert factory.routers[0].provider.close_count == 0
+    await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_without_snapshot_inherits_active_generation_snapshot() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("snapshot-a")
+
+    await owner.rebuild()
+    lease = await owner.acquire()
+
+    assert lease.config_snapshot == "snapshot-a"
+    assert lease.router.label == "snapshot-a"
+    await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_acquire_rebuilds_stale_managed_generation_without_mutating_old_lease() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("snapshot-a")
+    old_lease = await owner.acquire()
+    stale = True
+
+    def needs_reload() -> bool:
+        return stale
+
+    old_lease.router.needs_provider_config_reload = needs_reload  # type: ignore[attr-defined]
+    refreshed_lease = await owner.acquire()
+    stale = False
+
+    assert refreshed_lease.generation_id != old_lease.generation_id
+    assert refreshed_lease.config_snapshot == "snapshot-a"
+    assert refreshed_lease.router is factory.routers[1]
+    assert old_lease.router is factory.routers[0]
+    assert old_lease.router.provider.close_count == 0
+
+    await refreshed_lease.release()
+    await old_lease.release()
+    assert factory.routers[0].provider.close_count == 1
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_acquires_share_one_provider_config_refresh() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("snapshot-a")
+    factory.routers[0].needs_provider_config_reload = lambda: True  # type: ignore[attr-defined]
+
+    leases = await asyncio.gather(*(owner.acquire() for _ in range(10)))
+
+    assert len(factory.routers) == 2
+    assert len({lease.generation_id for lease in leases}) == 1
+    for lease in leases:
+        await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_build_closes_candidate_after_factory_finishes() -> None:
+    routers: list[_GenerationRouter] = []
+    candidate_created = asyncio.Event()
+    finish_build = asyncio.Event()
+    close_started = asyncio.Event()
+    finish_close = asyncio.Event()
+
+    class BlockingRouter(_GenerationRouter):
+        async def close(self) -> None:
+            close_started.set()
+            await finish_close.wait()
+            await self.provider.close()
+
+    async def factory(snapshot: object | None) -> _GenerationRouter:
+        router = (
+            BlockingRouter(str(snapshot), _ClosingProvider())
+            if snapshot == "B"
+            else _GenerationRouter(str(snapshot), _ClosingProvider())
+        )
+        routers.append(router)
+        if snapshot == "B":
+            candidate_created.set()
+            await finish_build.wait()
+        return router
+
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    rebuild_task = asyncio.create_task(owner.rebuild("B"))
+    await candidate_created.wait()
+
+    rebuild_task.cancel()
+    finish_build.set()
+    await close_started.wait()
+    rebuild_task.cancel()
+    await asyncio.sleep(0)
+    finish_close.set()
+    with pytest.raises(asyncio.CancelledError):
+        await rebuild_task
+
+    assert routers[1].provider.close_count == 1
+    lease = await owner.acquire()
+    assert lease.router is routers[0]
+    await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_install_closes_built_candidate() -> None:
+    factory = _RouterFactory()
+    candidate_built = asyncio.Event()
+    finish_build = asyncio.Event()
+
+    async def build(snapshot: object | None) -> _GenerationRouter:
+        router = factory(snapshot)
+        if snapshot == "B":
+            candidate_built.set()
+            await finish_build.wait()
+        return router
+
+    owner = RouterOwner(build)
+    await owner.start("A")
+    rebuild_task = asyncio.create_task(owner.rebuild("B"))
+    await candidate_built.wait()
+    await owner._state_lock.acquire()
+    finish_build.set()
+    await asyncio.sleep(0)
+    rebuild_task.cancel()
+    owner._state_lock.release()
+
+    with pytest.raises(asyncio.CancelledError):
+        await rebuild_task
+    assert factory.routers[1].provider.close_count == 1
+    lease = await owner.acquire()
+    assert lease.router is factory.routers[0]
+    await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_before_swap_failure_closes_candidate_without_replacing_active() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    generation_a = await owner.start("A")
+
+    def reject_swap() -> object:
+        raise RuntimeError("CAS conflict")
+
+    with pytest.raises(RuntimeError, match="CAS conflict"):
+        await owner.rebuild("replacement", before_swap=reject_swap)
+
+    assert factory.routers[1].provider.close_count == 1
+    lease = await owner.acquire()
+    assert lease.generation_id == generation_a
+    assert lease.router is factory.routers[0]
+    await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_before_swap_return_becomes_installed_generation_snapshot() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    committed_snapshot = object()
+    observed_active: list[_GenerationRouter] = []
+
+    def commit() -> object:
+        assert owner._active is not None
+        observed_active.append(owner._active.router)
+        return committed_snapshot
+
+    await owner.rebuild("replacement", before_swap=commit)
+    lease = await owner.acquire()
+
+    assert observed_active == [factory.routers[0]]
+    assert lease.router.label == "replacement"
+    assert lease.config_snapshot is committed_snapshot
+    await lease.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_returns_committed_before_retired_generation_finishes_closing() -> None:
+    close_started = asyncio.Event()
+    finish_close = asyncio.Event()
+    routers: list[_GenerationRouter] = []
+
+    class BlockingRouter(_GenerationRouter):
+        async def close(self) -> None:
+            close_started.set()
+            await finish_close.wait()
+            await self.provider.close()
+
+    def build(snapshot: object | None) -> _GenerationRouter:
+        if snapshot == "A":
+            router = BlockingRouter("A", _ClosingProvider())
+        else:
+            router = _GenerationRouter(str(snapshot), _ClosingProvider())
+        routers.append(router)
+        return router
+
+    owner = RouterOwner(build)
+    await owner.start("A")
+    rebuild_task = asyncio.create_task(owner.rebuild("B"))
+    await close_started.wait()
+    await asyncio.sleep(0)
+
+    assert rebuild_task.done()
+    generation_b = rebuild_task.result()
+    lease = await owner.acquire()
+    assert lease.generation_id == generation_b
+    assert lease.router is routers[1]
+    assert routers[0].provider.close_count == 0
+
+    close_owner = asyncio.create_task(owner.close())
+    await asyncio.sleep(0)
+    assert not close_owner.done()
+    finish_close.set()
+    await lease.release()
+    await close_owner
+    assert routers[0].provider.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_lease_carries_the_snapshot_that_built_its_generation() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("snapshot-a")
+    lease_a = await owner.acquire()
+    await owner.rebuild("snapshot-b")
+    lease_b = await owner.acquire()
+
+    assert lease_a.config_snapshot == "snapshot-a"
+    assert lease_b.config_snapshot == "snapshot-b"
+
+    await lease_a.release()
+    await lease_b.release()
+    await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_active_lease_then_closes_exactly_once() -> None:
+    factory = _RouterFactory()
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    lease = await owner.acquire()
+
+    close_task = asyncio.create_task(owner.close())
+    await asyncio.sleep(0)
+    assert not close_task.done()
+    assert factory.routers[0].provider.close_count == 0
+
+    await lease.release()
+    await close_task
+    await owner.close()
+    assert factory.routers[0].provider.close_count == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        await owner.acquire()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_finishes_provider_close_before_propagating() -> None:
+    close_started = asyncio.Event()
+    finish_close = asyncio.Event()
+
+    class BlockingProvider(_ClosingProvider):
+        async def close(self) -> None:
+            close_started.set()
+            await finish_close.wait()
+            await super().close()
+
+    router = _GenerationRouter("A", BlockingProvider())
+    owner = RouterOwner(lambda _snapshot: router)
+    await owner.start("A")
+
+    close_task = asyncio.create_task(owner.close())
+    await close_started.wait()
+    concurrent_close = asyncio.create_task(owner.close())
+    close_task.cancel()
+    await asyncio.sleep(0)
+
+    assert not close_task.done()
+    assert not concurrent_close.done()
+    assert router.provider.close_count == 0
+
+    finish_close.set()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+    await concurrent_close
+
+    assert router.provider.close_count == 1
+    await owner.close()
+    assert router.provider.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_finishes_every_generation_close() -> None:
+    close_started = {label: asyncio.Event() for label in ("A", "B", "C")}
+    finish_close = {label: asyncio.Event() for label in ("A", "B", "C")}
+    routers: list[_GenerationRouter] = []
+
+    class BlockingProvider(_ClosingProvider):
+        def __init__(self, label: str) -> None:
+            super().__init__()
+            self.label = label
+
+        async def close(self) -> None:
+            close_started[self.label].set()
+            await finish_close[self.label].wait()
+            await super().close()
+
+    def factory(snapshot: object | None) -> _GenerationRouter:
+        label = str(snapshot)
+        router = _GenerationRouter(label, BlockingProvider(label))
+        routers.append(router)
+        return router
+
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    await owner.rebuild("B")
+    await close_started["A"].wait()
+    await owner.rebuild("C")
+    await close_started["B"].wait()
+
+    close_task = asyncio.create_task(owner.close())
+    await close_started["C"].wait()
+    close_task.cancel()
+    await asyncio.sleep(0)
+    close_task.cancel()
+    await asyncio.sleep(0)
+
+    assert not close_task.done()
+    for event in finish_close.values():
+        event.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert [router.provider.close_count for router in routers] == [1, 1, 1]
+    assert owner._closed is True
+    assert owner._generations == {}
+    await owner.close()
+    assert [router.provider.close_count for router in routers] == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_router_close_retries_only_provider_interrupted_by_cancellation(monkeypatch) -> None:
+    close_started = asyncio.Event()
+    finish_close = asyncio.Event()
+
+    class BlockingProvider(_ClosingProvider):
+        attempts = 0
+
+        async def close(self) -> None:
+            self.attempts += 1
+            close_started.set()
+            await finish_close.wait()
+            await super().close()
+
+    monkeypatch.setattr(Router, "_load_providers", lambda self: None)
+    router = Router()
+    closed_first = _ClosingProvider()
+    interrupted = BlockingProvider()
+    router.providers = {"first": closed_first, "interrupted": interrupted}
+
+    close_task = asyncio.create_task(router.close())
+    await close_started.wait()
+    close_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close_task
+
+    assert closed_first.close_count == 1
+    assert interrupted.close_count == 0
+    assert interrupted.attempts == 1
+    assert router._closed is False
+
+    finish_close.set()
+    await router.close()
+    await router.close()
+
+    assert closed_first.close_count == 1
+    assert interrupted.close_count == 1
+    assert interrupted.attempts == 2
+    assert router._closed is True
+
+
+@pytest.mark.asyncio
+async def test_lifespan_startup_cancellation_releases_prewarm_lease() -> None:
+    routers: list[_GenerationRouter] = []
+    prewarm_started = asyncio.Event()
+
+    class PrewarmRouter(_GenerationRouter):
+        async def list_models(self) -> list[ModelInfo]:
+            prewarm_started.set()
+            await asyncio.Event().wait()
+            return []
+
+    def build(value: object | None) -> PrewarmRouter:
+        router = PrewarmRouter(str(value), _ClosingProvider())
+        routers.append(router)
+        return router
+
+    owner = RouterOwner(build)
+    snapshot = object()
+    repository = type("Repository", (), {"read": lambda self: snapshot})()
+    state = type(
+        "State",
+        (),
+        {"runtime_config_repository": repository, "router_owner": owner},
+    )()
+    app = type("App", (), {"state": state})()
+    manager = lifespan(app)
+    startup = asyncio.create_task(manager.__aenter__())
+    await prewarm_started.wait()
+
+    startup.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await startup
+
+    assert routers[0].provider.close_count == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        await owner.acquire()
+
+
+def _catalog_response(model_id: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"data": [{"id": model_id}]},
+        request=httpx.Request("GET", "https://catalog.invalid/models"),
+    )
+
+
+async def _noop_token() -> None:
+    return None
+
+
+def _normalize(_model: Any) -> tuple[str, ...] | None:
+    return None
+
+
+def _operations(_model: Any) -> dict[str, bool]:
+    return {}
+
+
+def _protocol_error(*_args: Any, **_kwargs: Any) -> None:
+    raise AssertionError("valid catalog must not raise a protocol error")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_catalog_requests_share_one_refresh() -> None:
+    catalog = CopilotCatalog()
+    send_count = 0
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def send(*_args: Any, **_kwargs: Any) -> httpx.Response:
+        nonlocal send_count
+        send_count += 1
+        send_started.set()
+        await release_send.wait()
+        return _catalog_response("fresh")
+
+    calls = [
+        asyncio.create_task(
+            catalog.list_models(
+                provider_name="github-copilot",
+                ensure_token=_noop_token,
+                send=send,
+                normalize_endpoints=_normalize,
+                derive_operations=_operations,
+                raise_protocol_error=_protocol_error,
+            )
+        )
+        for _ in range(10)
+    ]
+    await send_started.wait()
+    assert send_count == 1
+    release_send.set()
+
+    results = await asyncio.gather(*calls)
+    assert send_count == 1
+    assert [[model.id for model in result] for result in results] == [["fresh"]] * 10
+    assert len({id(result) for result in results}) == 10
+
+
+@pytest.mark.asyncio
+async def test_stale_catalog_is_served_while_one_refresh_runs() -> None:
+    catalog = CopilotCatalog()
+    stale = [ModelInfo(id="stale", name="Stale", provider="github-copilot")]
+    catalog.models_ttl_cache.set(stale)
+    catalog.models_ttl_cache._timestamp = 0
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+    send_count = 0
+
+    async def send(*_args: Any, **_kwargs: Any) -> httpx.Response:
+        nonlocal send_count
+        send_count += 1
+        send_started.set()
+        await release_send.wait()
+        return _catalog_response("fresh")
+
+    first = await catalog.list_models(
+        provider_name="github-copilot",
+        ensure_token=_noop_token,
+        send=send,
+        normalize_endpoints=_normalize,
+        derive_operations=_operations,
+        raise_protocol_error=_protocol_error,
+    )
+    await send_started.wait()
+    second = await catalog.list_models(
+        provider_name="github-copilot",
+        ensure_token=_noop_token,
+        send=send,
+        normalize_endpoints=_normalize,
+        derive_operations=_operations,
+        raise_protocol_error=_protocol_error,
+    )
+
+    assert [model.id for model in first] == ["stale"]
+    assert [model.id for model in second] == ["stale"]
+    assert first is not second
+    assert send_count == 1
+
+    release_send.set()
+    refreshed = await catalog.list_models(
+        force_refresh=True,
+        provider_name="github-copilot",
+        ensure_token=_noop_token,
+        send=send,
+        normalize_endpoints=_normalize,
+        derive_operations=_operations,
+        raise_protocol_error=_protocol_error,
+    )
+    assert [model.id for model in refreshed] == ["fresh"]
+    assert send_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_catalog_refresh_runs_without_request_context() -> None:
+    catalog = CopilotCatalog()
+    stale = [ModelInfo(id="stale", name="Stale", provider="github-copilot")]
+    catalog.models_ttl_cache.set(stale)
+    catalog.models_ttl_cache._timestamp = 0
+    refresh_contexts: list[RequestContext | None] = []
+    refresh_finished = asyncio.Event()
+
+    async def send(*_args: Any, **_kwargs: Any) -> httpx.Response:
+        refresh_contexts.append(get_current_request_context())
+        refresh_finished.set()
+        return _catalog_response("fresh")
+
+    from router_maestro.runtime import request_context as request_context_module
+
+    token = request_context_module._current_request_context.set(object())  # type: ignore[arg-type]
+    try:
+        models = await catalog.list_models(
+            provider_name="github-copilot",
+            ensure_token=_noop_token,
+            send=send,
+            normalize_endpoints=_normalize,
+            derive_operations=_operations,
+            raise_protocol_error=_protocol_error,
+        )
+    finally:
+        request_context_module._current_request_context.reset(token)
+
+    assert [model.id for model in models] == ["stale"]
+    await refresh_finished.wait()
+    await catalog.aclose()
+    assert refresh_contexts == [None]
+
+
+@pytest.mark.asyncio
+async def test_cold_catalog_refresh_inherits_awaiting_request_context() -> None:
+    catalog = CopilotCatalog()
+    request_context = object()
+    refresh_contexts: list[object | None] = []
+
+    async def send(*_args: Any, **_kwargs: Any) -> httpx.Response:
+        refresh_contexts.append(get_current_request_context())
+        return _catalog_response("fresh")
+
+    from router_maestro.runtime import request_context as request_context_module
+
+    token = request_context_module._current_request_context.set(request_context)  # type: ignore[arg-type]
+    try:
+        models = await catalog.list_models(
+            provider_name="github-copilot",
+            ensure_token=_noop_token,
+            send=send,
+            normalize_endpoints=_normalize,
+            derive_operations=_operations,
+            raise_protocol_error=_protocol_error,
+        )
+    finally:
+        request_context_module._current_request_context.reset(token)
+
+    assert [model.id for model in models] == ["fresh"]
+    assert refresh_contexts == [request_context]
+    await catalog.aclose()
+
+
+@pytest.mark.asyncio
+async def test_catalog_aclose_cancels_and_awaits_active_refresh() -> None:
+    catalog = CopilotCatalog()
+    stale = [ModelInfo(id="stale", name="Stale", provider="github-copilot")]
+    catalog.models_ttl_cache.set(stale)
+    catalog.models_ttl_cache._timestamp = 0
+    refresh_started = asyncio.Event()
+    refresh_finished = asyncio.Event()
+
+    async def send(*_args: Any, **_kwargs: Any) -> httpx.Response:
+        refresh_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            refresh_finished.set()
+        raise AssertionError("unreachable")
+
+    await catalog.list_models(
+        provider_name="github-copilot",
+        ensure_token=_noop_token,
+        send=send,
+        normalize_endpoints=_normalize,
+        derive_operations=_operations,
+        raise_protocol_error=_protocol_error,
+    )
+    await refresh_started.wait()
+
+    await catalog.aclose()
+
+    assert refresh_finished.is_set()
+    assert catalog._refresh_task is None
+
+
+@pytest.mark.asyncio
+async def test_copilot_provider_closes_catalog_before_transport() -> None:
+    provider = CopilotProvider()
+    close_order: list[str] = []
+
+    async def close_catalog() -> None:
+        close_order.append("catalog")
+
+    async def close_transport() -> None:
+        close_order.append("transport")
+
+    provider._catalog.aclose = close_catalog  # type: ignore[method-assign]
+    provider._transport.close = close_transport  # type: ignore[method-assign]
+
+    await provider.close()
+
+    assert close_order == ["catalog", "transport"]
+
+
+def test_ttl_cache_uses_monotonic_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    from router_maestro.utils import cache as cache_module
+    from router_maestro.utils.cache import TTLCache
+
+    monotonic = 100.0
+    wall_clock = 1_000.0
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: monotonic)
+    monkeypatch.setattr(cache_module.time, "time", lambda: wall_clock)
+    cache = TTLCache[str](10)
+    cache.set("value")
+
+    wall_clock = -50_000.0
+    monotonic = 109.0
+    assert cache.get() == "value"
+
+    monotonic = 111.0
+    assert cache.get() is None
+    assert cache.peek() == "value"
+
+
+def test_catalog_effort_lookup_returns_a_defensive_copy() -> None:
+    catalog = CopilotCatalog()
+    catalog.models_ttl_cache.set(
+        [
+            ModelInfo(
+                id="model",
+                name="Model",
+                provider="github-copilot",
+                reasoning_effort_values=["low", "high"],
+            )
+        ]
+    )
+
+    values = catalog.effort_values("model")
+    assert values is not None
+    values.append("mutated")
+
+    assert catalog.effort_values("model") == ["low", "high"]
+
+
+def test_router_custom_provider_construction_delegates_credential_policy(monkeypatch) -> None:
+    provider_config = object()
+    repository = object()
+    expected_provider = object()
+    observed: dict[str, object] = {}
+
+    class FakeRepository:
+        def __new__(cls):
+            return repository
+
+    def create(provider_name, config, *, credential_repository):
+        observed.update(
+            provider_name=provider_name,
+            config=config,
+            credential_repository=credential_repository,
+        )
+        return expected_provider
+
+    monkeypatch.setattr("router_maestro.auth.repository.CredentialRepository", FakeRepository)
+    monkeypatch.setattr("router_maestro.providers.custom_factory.create_custom_provider", create)
+    router = Router.__new__(Router)
+
+    provider = router._create_custom_provider("local-llm", provider_config)
+
+    assert provider is expected_provider
+    assert observed == {
+        "provider_name": "local-llm",
+        "config": provider_config,
+        "credential_repository": repository,
+    }

--- a/tests/test_runtime_config_admin.py
+++ b/tests/test_runtime_config_admin.py
@@ -9,12 +9,30 @@ from router_maestro.server.routes import admin
 
 
 class _RouterOwnerSpy:
-    def __init__(self) -> None:
+    def __init__(self, *, before_swap_hook=None) -> None:
         self.snapshots = []
+        self.installed_snapshots = []
+        self.before_swap_calls = 0
+        self.before_swap_hook = before_swap_hook
 
-    async def rebuild(self, *, config_snapshot=None):
+    async def rebuild(self, config_snapshot=None, *, before_swap=None):
         self.snapshots.append(config_snapshot)
+        if self.before_swap_hook is not None:
+            self.before_swap_hook()
+        installed_snapshot = config_snapshot
+        if before_swap is not None:
+            self.before_swap_calls += 1
+            committed_snapshot = before_swap()
+            if committed_snapshot is not None:
+                installed_snapshot = committed_snapshot
+        self.installed_snapshots.append(installed_snapshot)
         return len(self.snapshots) + 1
+
+
+class _FailingRouterOwner(_RouterOwnerSpy):
+    async def rebuild(self, config_snapshot=None, *, before_swap=None):
+        self.snapshots.append(config_snapshot)
+        raise RuntimeError("router build failed")
 
 
 def _client(tmp_path):
@@ -58,7 +76,7 @@ def test_admin_get_returns_complete_config_revision_and_etag(tmp_path):
     assert response.headers["etag"] == f'"{body["revision"]}"'
 
 
-def test_admin_patch_uses_cas_and_rebuilds_after_persistence(tmp_path):
+def test_admin_patch_builds_candidate_then_commits_with_generation_swap(tmp_path):
     client, repository, owner = _client(tmp_path)
     initial = repository.read()
     payload = initial.config.model_dump(mode="json")
@@ -72,6 +90,8 @@ def test_admin_patch_uses_cas_and_rebuilds_after_persistence(tmp_path):
     assert body["revision"] != initial.revision
     assert repository.read().config.priorities == ["github-copilot/gpt-5"]
     assert [snapshot.revision for snapshot in owner.snapshots] == [body["revision"]]
+    assert [snapshot.revision for snapshot in owner.installed_snapshots] == [body["revision"]]
+    assert owner.before_swap_calls == 1
     assert response.headers["etag"] == f'"{body["revision"]}"'
 
 
@@ -119,3 +139,54 @@ def test_admin_put_alias_requires_revision(tmp_path):
 
     assert response.status_code == 422
     assert owner.snapshots == []
+
+
+def test_admin_patch_build_failure_never_commits_candidate(tmp_path):
+    application = FastAPI()
+    repository = RuntimeConfigRepository(tmp_path / "priorities.json")
+    owner = _FailingRouterOwner()
+    application.state.runtime_config_repository = repository
+    application.state.router_owner = owner
+    application.include_router(admin.router)
+    client = TestClient(application, raise_server_exceptions=False)
+    initial = repository.read()
+    payload = initial.config.model_dump(mode="json")
+    payload["priorities"] = ["provider/rejected"]
+    payload["revision"] = initial.revision
+
+    response = client.patch("/api/admin/priorities", json=payload)
+
+    assert response.status_code == 500
+    assert repository.read() == initial
+    assert owner.before_swap_calls == 0
+
+
+def test_admin_patch_cas_conflict_during_swap_returns_409_and_preserves_writer(tmp_path):
+    application = FastAPI()
+    repository = RuntimeConfigRepository(tmp_path / "priorities.json")
+    initial = repository.read()
+    concurrent = PrioritiesConfig(priorities=["provider/concurrent"])
+
+    def write_concurrently() -> None:
+        current = repository.read()
+        repository.compare_and_swap(
+            expected_revision=current.revision,
+            replacement=concurrent,
+        )
+
+    owner = _RouterOwnerSpy(before_swap_hook=write_concurrently)
+    application.state.runtime_config_repository = repository
+    application.state.router_owner = owner
+    application.include_router(admin.router)
+    client = TestClient(application, raise_server_exceptions=False)
+    payload = initial.config.model_dump(mode="json")
+    payload["priorities"] = ["provider/rejected"]
+    payload["revision"] = initial.revision
+
+    response = client.patch("/api/admin/priorities", json=payload)
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "config_revision_conflict"
+    assert repository.read().config == concurrent
+    assert owner.before_swap_calls == 1
+    assert owner.installed_snapshots == []

--- a/tests/test_runtime_config_admin.py
+++ b/tests/test_runtime_config_admin.py
@@ -1,0 +1,121 @@
+"""Admin HTTP contract for versioned runtime configuration."""
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.config.repository import RuntimeConfigRepository
+from router_maestro.server.routes import admin
+
+
+class _RouterOwnerSpy:
+    def __init__(self) -> None:
+        self.snapshots = []
+
+    async def rebuild(self, *, config_snapshot=None):
+        self.snapshots.append(config_snapshot)
+        return len(self.snapshots) + 1
+
+
+def _client(tmp_path):
+    application = FastAPI()
+    repository = RuntimeConfigRepository(tmp_path / "priorities.json")
+    owner = _RouterOwnerSpy()
+    application.state.runtime_config_repository = repository
+    application.state.router_owner = owner
+    application.include_router(admin.router, dependencies=[Depends(lambda: None)])
+    return TestClient(application), repository, owner
+
+
+def test_admin_get_returns_complete_config_revision_and_etag(tmp_path):
+    client, repository, _owner = _client(tmp_path)
+    repository.write_compat(
+        PrioritiesConfig(
+            priorities=["github-copilot/gpt-5"],
+            model_overrides={"gpt-5": {"max_output_tokens": 8192}},
+            beta_strip=["prompt-caching-*"],
+            audit={"enabled": True, "trace_dir": "/tmp/traces"},
+        )
+    )
+
+    response = client.get("/api/admin/priorities")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {
+        "priorities",
+        "fallback",
+        "model_overrides",
+        "thinking",
+        "guards",
+        "beta_strip",
+        "audit",
+        "revision",
+    }
+    assert body["model_overrides"]["gpt-5"]["max_output_tokens"] == 8192
+    assert body["beta_strip"] == ["prompt-caching-*"]
+    assert body["audit"] == {"enabled": True, "trace_dir": "/tmp/traces"}
+    assert response.headers["etag"] == f'"{body["revision"]}"'
+
+
+def test_admin_patch_uses_cas_and_rebuilds_after_persistence(tmp_path):
+    client, repository, owner = _client(tmp_path)
+    initial = repository.read()
+    payload = initial.config.model_dump(mode="json")
+    payload["priorities"] = ["github-copilot/gpt-5"]
+    payload["revision"] = initial.revision
+
+    response = client.patch("/api/admin/priorities", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["revision"] != initial.revision
+    assert repository.read().config.priorities == ["github-copilot/gpt-5"]
+    assert [snapshot.revision for snapshot in owner.snapshots] == [body["revision"]]
+    assert response.headers["etag"] == f'"{body["revision"]}"'
+
+
+def test_admin_stale_patch_returns_conflict_without_write_or_rebuild(tmp_path):
+    client, repository, owner = _client(tmp_path)
+    stale = repository.read()
+    current = repository.compare_and_swap(
+        expected_revision=stale.revision,
+        replacement=PrioritiesConfig(priorities=["provider/current"]),
+    )
+    payload = stale.config.model_dump(mode="json")
+    payload["priorities"] = ["provider/stale"]
+    payload["revision"] = stale.revision
+
+    response = client.patch("/api/admin/priorities", json=payload)
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "config_revision_conflict"
+    assert response.json()["detail"]["current_revision"] == current.revision
+    assert response.headers["etag"] == f'"{current.revision}"'
+    assert repository.read().revision == current.revision
+    assert owner.snapshots == []
+
+
+def test_admin_noop_patch_does_not_rebuild(tmp_path):
+    client, repository, owner = _client(tmp_path)
+    current = repository.read()
+    payload = current.config.model_dump(mode="json")
+    payload["revision"] = current.revision
+
+    response = client.patch("/api/admin/priorities", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["revision"] == current.revision
+    assert owner.snapshots == []
+
+
+def test_admin_put_alias_requires_revision(tmp_path):
+    client, _repository, owner = _client(tmp_path)
+
+    response = client.put(
+        "/api/admin/priorities",
+        json={"priorities": ["provider/model"], "fallback": {"maxRetries": 2}},
+    )
+
+    assert response.status_code == 422
+    assert owner.snapshots == []

--- a/tests/test_runtime_config_snapshot.py
+++ b/tests/test_runtime_config_snapshot.py
@@ -1,0 +1,384 @@
+"""Contract tests for versioned runtime configuration snapshots."""
+
+import hashlib
+import json
+import os
+import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from router_maestro.config import repository as repository_module
+from router_maestro.config import settings
+from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.config.repository import (
+    RuntimeConfigConflictError,
+    RuntimeConfigRepository,
+    RuntimeConfigSnapshot,
+    canonical_runtime_config_bytes,
+    runtime_config_revision,
+)
+
+
+@pytest.fixture
+def priorities_path(tmp_path):
+    return tmp_path / "priorities.json"
+
+
+@pytest.fixture
+def repositories(priorities_path):
+    return (
+        RuntimeConfigRepository(priorities_path),
+        RuntimeConfigRepository(priorities_path),
+    )
+
+
+def _config(*priorities: str, max_retries: int = 2) -> PrioritiesConfig:
+    return PrioritiesConfig(
+        priorities=list(priorities),
+        fallback={"maxRetries": max_retries},
+    )
+
+
+def test_revision_is_sha256_of_canonical_validated_json():
+    config = PrioritiesConfig(
+        priorities=["custom/模型"],
+        model_overrides={
+            "custom/模型": {
+                "max_prompt_tokens": None,
+                "max_output_tokens": 4096,
+            }
+        },
+    )
+    validated = PrioritiesConfig.model_validate(config.model_dump(mode="json"))
+    payload = validated.model_dump(
+        mode="json",
+        exclude_none=False,
+        exclude_defaults=False,
+    )
+    expected = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+    canonical_json = canonical_runtime_config_bytes(config)
+    revision = runtime_config_revision(canonical_json)
+
+    assert canonical_json == expected
+    assert "模型".encode() in canonical_json
+    assert json.loads(canonical_json)["audit"]["trace_dir"] is None
+    assert revision == hashlib.sha256(expected).hexdigest()
+    assert re.fullmatch(r"[0-9a-f]{64}", revision)
+
+
+def test_semantically_equal_formatting_key_order_and_defaults_share_revision(priorities_path):
+    repository = RuntimeConfigRepository(priorities_path)
+    priorities_path.write_text(
+        '{ "priorities" : [ "github-copilot/gpt-5" ] }\n',
+        encoding="utf-8",
+    )
+    minimal = repository.read()
+
+    expanded = minimal.config.model_dump(
+        mode="json",
+        exclude_none=False,
+        exclude_defaults=False,
+    )
+    reordered = dict(reversed(expanded.items()))
+    reordered["fallback"] = dict(reversed(reordered["fallback"].items()))
+    priorities_path.write_text(json.dumps(reordered, indent=7), encoding="utf-8")
+    explicit_defaults = repository.read()
+
+    assert explicit_defaults.revision == minimal.revision
+    assert explicit_defaults.canonical_json == minimal.canonical_json
+
+
+def test_revision_ignores_mtime_only_changes(priorities_path):
+    repository = RuntimeConfigRepository(priorities_path)
+    snapshot = repository.write_compat(_config("github-copilot/gpt-5"))
+    stat = priorities_path.stat()
+
+    os.utime(
+        priorities_path,
+        ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000),
+    )
+
+    assert repository.read().revision == snapshot.revision
+
+
+def test_revision_keeps_list_order_significant():
+    first = canonical_runtime_config_bytes(_config("provider/a", "provider/b"))
+    reversed_order = canonical_runtime_config_bytes(_config("provider/b", "provider/a"))
+
+    assert runtime_config_revision(first) != runtime_config_revision(reversed_order)
+
+
+def test_snapshot_survives_backing_file_replacement(repositories):
+    first_repository, second_repository = repositories
+    original = first_repository.write_compat(_config("provider/original"))
+    original_bytes = original.canonical_json
+
+    replacement = second_repository.write_compat(_config("provider/replacement"))
+
+    assert original.config.priorities == ["provider/original"]
+    assert original.canonical_json == original_bytes
+    assert original.revision == runtime_config_revision(original_bytes)
+    assert replacement.revision != original.revision
+    assert first_repository.read().revision == replacement.revision
+
+
+def test_snapshot_config_property_returns_defensive_models(priorities_path):
+    snapshot = RuntimeConfigRepository(priorities_path).write_compat(
+        _config("provider/original", max_retries=3)
+    )
+    original_bytes = snapshot.canonical_json
+    first = snapshot.config
+    second = snapshot.config
+
+    first.add_priority("provider", "mutated")
+    first.fallback.maxRetries = 9
+
+    assert first is not second
+    assert first.fallback is not second.fallback
+    assert second.priorities == ["provider/original"]
+    assert second.fallback.maxRetries == 3
+    assert snapshot.config.priorities == ["provider/original"]
+    assert snapshot.canonical_json == original_bytes
+    with pytest.raises(FrozenInstanceError):
+        snapshot.revision = "mutable"  # type: ignore[misc]
+
+
+def test_compare_and_swap_writes_replacement_and_new_revision(priorities_path):
+    repository = RuntimeConfigRepository(priorities_path)
+    initial = repository.read()
+    replacement = _config("github-copilot/gpt-5", max_retries=4)
+
+    updated = repository.compare_and_swap(
+        expected_revision=initial.revision,
+        replacement=replacement,
+    )
+
+    assert updated.revision != initial.revision
+    assert updated.revision == runtime_config_revision(updated.canonical_json)
+    assert updated.config == replacement
+    assert repository.read() == updated
+    assert json.loads(priorities_path.read_bytes()) == json.loads(updated.canonical_json)
+
+
+def test_compare_and_swap_rejects_stale_revision_without_writing(
+    priorities_path,
+    monkeypatch,
+):
+    first_repository = RuntimeConfigRepository(priorities_path)
+    second_repository = RuntimeConfigRepository(priorities_path)
+    stale = first_repository.write_compat(_config("provider/base"))
+    current = second_repository.compare_and_swap(
+        expected_revision=stale.revision,
+        replacement=_config("provider/current"),
+    )
+    persisted_before_conflict = priorities_path.read_bytes()
+    writer_calls = []
+
+    def record_writer(*args, **kwargs):
+        writer_calls.append((args, kwargs))
+
+    monkeypatch.setattr(repository_module, "write_json_owner_only", record_writer)
+
+    with pytest.raises(RuntimeConfigConflictError) as exc_info:
+        first_repository.compare_and_swap(
+            expected_revision=stale.revision,
+            replacement=_config("provider/stale-write"),
+        )
+
+    assert exc_info.value.expected_revision == stale.revision
+    assert exc_info.value.current_revision == current.revision
+    assert writer_calls == []
+    assert priorities_path.read_bytes() == persisted_before_conflict
+
+
+def test_two_repositories_with_same_revision_have_exactly_one_cas_winner(repositories):
+    first_repository, second_repository = repositories
+    initial = first_repository.write_compat(_config("provider/base"))
+    barrier = threading.Barrier(2)
+
+    def attempt(repository, replacement):
+        barrier.wait(timeout=5)
+        try:
+            return repository.compare_and_swap(
+                expected_revision=initial.revision,
+                replacement=replacement,
+            )
+        except RuntimeConfigConflictError as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(attempt, first_repository, _config("provider/first")),
+            executor.submit(attempt, second_repository, _config("provider/second")),
+        ]
+        outcomes = [future.result(timeout=5) for future in futures]
+
+    winners = [outcome for outcome in outcomes if isinstance(outcome, RuntimeConfigSnapshot)]
+    conflicts = [outcome for outcome in outcomes if isinstance(outcome, RuntimeConfigConflictError)]
+    assert len(winners) == 1
+    assert len(conflicts) == 1
+    assert conflicts[0].expected_revision == initial.revision
+    assert conflicts[0].current_revision == winners[0].revision
+    assert first_repository.read().revision == winners[0].revision
+    assert first_repository.read().config.priorities in [
+        ["provider/first"],
+        ["provider/second"],
+    ]
+
+
+def test_noop_compare_and_swap_skips_atomic_write(priorities_path, monkeypatch):
+    repository = RuntimeConfigRepository(priorities_path)
+    current = repository.write_compat(_config("provider/unchanged"))
+
+    def fail_writer(*args, **kwargs):
+        pytest.fail(f"no-op CAS unexpectedly wrote config: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(repository_module, "write_json_owner_only", fail_writer)
+
+    unchanged = repository.compare_and_swap(
+        expected_revision=current.revision,
+        replacement=current.config,
+    )
+
+    assert unchanged == current
+
+
+def test_repository_instances_share_lock_for_resolved_path_aliases(priorities_path):
+    nested = priorities_path.parent / "nested"
+    nested.mkdir()
+    alias = nested / ".." / priorities_path.name
+
+    direct_repository = RuntimeConfigRepository(priorities_path)
+    alias_repository = RuntimeConfigRepository(alias)
+
+    assert direct_repository._lock is alias_repository._lock
+
+
+def test_missing_file_initializes_valid_default_snapshot(priorities_path):
+    repository = RuntimeConfigRepository(priorities_path)
+
+    snapshot = repository.read()
+
+    expected = PrioritiesConfig.get_default()
+    assert priorities_path.exists()
+    assert snapshot.config == expected
+    assert snapshot.canonical_json == canonical_runtime_config_bytes(expected)
+    assert snapshot.revision == runtime_config_revision(snapshot.canonical_json)
+
+
+def test_compat_write_uses_same_path_lock(priorities_path, monkeypatch):
+    first_repository = RuntimeConfigRepository(priorities_path)
+    second_repository = RuntimeConfigRepository(priorities_path)
+    real_writer = repository_module.write_json_owner_only
+    writer_called = threading.Event()
+    write_started = threading.Event()
+
+    def observed_writer(path, data):
+        writer_called.set()
+        real_writer(path, data)
+
+    def write_from_second_repository():
+        write_started.set()
+        return second_repository.write_compat(_config("provider/replacement"))
+
+    monkeypatch.setattr(repository_module, "write_json_owner_only", observed_writer)
+    first_repository._lock.acquire()
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(write_from_second_repository)
+        assert write_started.wait(timeout=5)
+        assert not writer_called.wait(timeout=0.1)
+    finally:
+        first_repository._lock.release()
+
+    try:
+        snapshot = future.result(timeout=5)
+    finally:
+        executor.shutdown(wait=True)
+
+    assert writer_called.is_set()
+    assert snapshot.config.priorities == ["provider/replacement"]
+
+
+def test_settings_priorities_wrappers_return_defensive_models_and_keep_last_writer_wins(
+    priorities_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "PRIORITIES_FILE", priorities_path)
+    settings.save_priorities_config(_config("provider/base"))
+
+    first = settings.load_priorities_config()
+    second = settings.load_priorities_config()
+    first.add_priority("provider", "first")
+
+    assert second.priorities == ["provider/base"]
+
+    settings.save_priorities_config(first)
+    second.add_priority("provider", "second")
+    settings.save_priorities_config(second)
+
+    assert settings.load_priorities_config() == second
+    assert settings.load_priorities_config().priorities == ["provider/base", "provider/second"]
+
+
+def test_settings_priorities_wrappers_share_repository_lock(priorities_path, monkeypatch):
+    monkeypatch.setattr(settings, "PRIORITIES_FILE", priorities_path)
+    repository = RuntimeConfigRepository(priorities_path)
+    real_writer = repository_module.write_json_owner_only
+    writer_called = threading.Event()
+    save_started = threading.Event()
+
+    def observed_writer(path, data):
+        writer_called.set()
+        real_writer(path, data)
+
+    def save_through_settings():
+        save_started.set()
+        settings.save_priorities_config(_config("provider/settings"))
+
+    monkeypatch.setattr(repository_module, "write_json_owner_only", observed_writer)
+    repository._lock.acquire()
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(save_through_settings)
+        assert save_started.wait(timeout=5)
+        assert not writer_called.wait(timeout=0.1)
+    finally:
+        repository._lock.release()
+
+    try:
+        future.result(timeout=5)
+    finally:
+        executor.shutdown(wait=True)
+
+    assert writer_called.is_set()
+    assert repository.read().config.priorities == ["provider/settings"]
+
+
+def test_settings_priorities_save_preserves_atomic_persistence(priorities_path, monkeypatch):
+    monkeypatch.setattr(settings, "PRIORITIES_FILE", priorities_path)
+    settings.save_priorities_config(_config("provider/original"))
+    original = priorities_path.read_bytes()
+
+    def fail_after_partial_write(data, file, *args, **kwargs):
+        file.write('{"partial":')
+        file.flush()
+        raise RuntimeError("simulated serialization failure")
+
+    monkeypatch.setattr(settings.json, "dump", fail_after_partial_write)
+
+    with pytest.raises(RuntimeError, match="simulated serialization failure"):
+        settings.save_priorities_config(_config("provider/replacement"))
+
+    assert priorities_path.read_bytes() == original
+    assert list(priorities_path.parent.glob("*.tmp")) == []

--- a/tests/test_token_config.py
+++ b/tests/test_token_config.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from router_maestro.runtime import request_context as request_context_module
 from router_maestro.server.schemas.anthropic import (
     AnthropicTool,
     AnthropicUserMessage,
@@ -291,6 +292,123 @@ class TestCountTokensViaAnthropicApi:
                     model="claude-sonnet-4-20250514",
                     messages=[{"role": "user", "content": "Hello"}],
                 )
+
+    @pytest.mark.asyncio
+    async def test_request_context_audits_successful_transport_attempt(self):
+        class AuditSpy:
+            def __init__(self) -> None:
+                self.upstream = []
+                self.responses = []
+
+            def record_upstream(self, *args) -> None:
+                self.upstream.append(args)
+
+            def record_upstream_response(self, *args) -> None:
+                self.responses.append(args)
+
+        audit = AuditSpy()
+        mock_response = httpx.Response(
+            200,
+            json={"input_tokens": 42},
+            headers={"x-request-id": "upstream-1"},
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages/count_tokens"),
+        )
+
+        with patch("router_maestro.utils.token_config.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+            token = request_context_module._current_request_context.set(  # type: ignore[attr-defined]
+                type("Context", (), {"audit": audit})()
+            )
+            try:
+                result = await count_tokens_via_anthropic_api(
+                    base_url="https://api.anthropic.com/v1",
+                    api_key="secret-key",
+                    model="claude-sonnet-4-20250514",
+                    messages=[{"role": "user", "content": "Hello"}],
+                )
+            finally:
+                request_context_module._current_request_context.reset(token)  # type: ignore[attr-defined]
+
+        assert result == 42
+        assert audit.upstream == [
+            (
+                "POST",
+                "https://api.anthropic.com/v1/messages/count_tokens",
+                {
+                    "x-api-key": "secret-key",
+                    "anthropic-version": "2023-06-01",
+                    "content-type": "application/json",
+                },
+                {
+                    "model": "claude-sonnet-4-20250514",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        ]
+        assert audit.responses == [
+            (
+                200,
+                {
+                    "x-request-id": "upstream-1",
+                    "content-length": "19",
+                    "content-type": "application/json",
+                },
+                b'{"input_tokens":42}',
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_request_context_audits_http_error_response_before_reraising(self):
+        class AuditSpy:
+            def __init__(self) -> None:
+                self.upstream_count = 0
+                self.responses = []
+
+            def record_upstream(self, *_args) -> None:
+                self.upstream_count += 1
+
+            def record_upstream_response(self, *args) -> None:
+                self.responses.append(args)
+
+        audit = AuditSpy()
+        mock_response = httpx.Response(
+            429,
+            json={"error": "rate limited"},
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages/count_tokens"),
+        )
+
+        with patch("router_maestro.utils.token_config.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+            token = request_context_module._current_request_context.set(  # type: ignore[attr-defined]
+                type("Context", (), {"audit": audit})()
+            )
+            try:
+                with pytest.raises(httpx.HTTPStatusError):
+                    await count_tokens_via_anthropic_api(
+                        base_url="https://api.anthropic.com/v1",
+                        api_key="secret-key",
+                        model="claude-sonnet-4-20250514",
+                        messages=[{"role": "user", "content": "Hello"}],
+                    )
+            finally:
+                request_context_module._current_request_context.reset(token)  # type: ignore[attr-defined]
+
+        assert audit.upstream_count == 1
+        assert audit.responses == [
+            (
+                429,
+                {"content-length": "24", "content-type": "application/json"},
+                b'{"error":"rate limited"}',
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_trailing_slash_stripped(self):


### PR DESCRIPTION
## Summary

- Add immutable, revisioned runtime-config snapshots and conflict-safe Admin/CLI mutations.
- Introduce leased Router generations, single-flight model-catalog refresh, and request-scoped config/resource ownership through streaming completion.
- Make credential updates atomic, repair custom-provider credential discovery/resolution, and centralize audit, guard, and terminal-outcome handling.
- Keep Decision D pending: Task 19's administrator/inference authentication split remains explicitly deferred and excluded.

## Test plan

- `uv run pytest tests/ -q` — 3485 passed
- `uv run ruff check src/ tests/ integration_tests/`
- `uv run ruff format --check src/ tests/ integration_tests/`
- `uv run python -m compileall -q src/router_maestro`
- `git diff --check master..HEAD`
- unbounded live model matrix with model/reasoning selectors unset — 73 passed, 3 skipped
