### PR TITLE
chore: complete maintainability remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ All notable changes to Router-Maestro are documented here.
   is distinct from model capability. An explicitly selected model without the
   native transport is served through the standard translated path for that
   same model; this is not model fallback.
+- **Authoritative request lifecycle and audit documentation.** Document the
+  pre-commit non-2xx versus post-commit in-stream error boundary, native
+  Responses `incomplete`/`failed`/`cancelled` HTTP semantics, and the shared
+  request context that owns configuration, Router leases, audit, and cleanup
+  through final ASGI body delivery. Audit traces now retain numbered upstream
+  request and response observations instead of assuming one fixed four-file
+  bundle; the two observation streams are numbered independently. The
+  documented authentication contract
+  remains the current one: `ROUTER_MAESTRO_API_KEY` protects both inference and
+  administration routes.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Get a local server running in 3 steps. The server (started locally or via Docker
 > router-maestro context update local --endpoint http://localhost:8123
 > ```
 
-> **About the Router-Maestro API key.** Router-Maestro has **one server key** (format `sk-rm-...`) that every client must send on every request. It is **not** an OpenAI / Anthropic / Gemini / GitHub token — it only authenticates clients to *your* Router-Maestro server. The server auto-generates and persists this key on first start (in `~/.config/router-maestro/contexts.json` or its Docker-mounted equivalent), so you usually never type it by hand: the CLI reads it from the active context and the `config claude-code/codex/gemini` wizards write it into each tool's settings for you. The two times you do touch it explicitly are (1) `router-maestro server show-key` to copy it into a raw `curl` or environment variable like `ROUTER_MAESTRO_API_KEY`, and (2) `router-maestro context add ... --api-key sk-rm-...` when pointing a client machine at a **remote** server (see [Deployment](#deployment)). If a client returns `401`, it almost always means the key it sent doesn't match what the server expects — re-run `server show-key` and compare.
+> **About the Router-Maestro API key.** Router-Maestro has **one server key** (format `sk-rm-...`) that clients must send on inference, administration, and remote-management requests. Public health/docs and the independently configured metrics endpoint are exceptions. It is **not** an OpenAI / Anthropic / Gemini / GitHub token — it only authenticates clients to *your* Router-Maestro server. The server auto-generates and persists this key on first start (in `~/.config/router-maestro/contexts.json` or its Docker-mounted equivalent), so you usually never type it by hand: the CLI reads it from the active context and the `config claude-code/codex/gemini` wizards write it into each tool's settings for you. The two times you do touch it explicitly are (1) `router-maestro server show-key` to copy it into a raw `curl` or environment variable like `ROUTER_MAESTRO_API_KEY`, and (2) `router-maestro context add ... --api-key sk-rm-...` when pointing a client machine at a **remote** server (see [Deployment](#deployment)). If an authenticated request returns `401`, it almost always means the key it sent doesn't match what the server expects — re-run `server show-key` and compare.
 
 <https://github.com/user-attachments/assets/8f60ec7a-4fbe-4342-9408-084073a4d48d>
 
@@ -267,6 +267,24 @@ capability mismatches and invalid or unsupported request options return the
 entry protocol's native `400` response and do not switch models. Once a stream
 has emitted its first provider chunk, a later failure is surfaced in that same
 stream and Router-Maestro never replays the request on another candidate.
+
+Streaming has a strict terminal contract. A stream succeeds only after an
+explicit successful provider terminal; clean EOF without one is an
+`unexpected_eof`, not success. Failures discovered before an SSE response is
+returned use the entry protocol's non-2xx JSON error. After the HTTP response
+has started, its status is already committed (normally `200`), so an error,
+incomplete result, or unexpected EOF is encoded as exactly one protocol-native
+in-stream terminal instead. The standard Anthropic route may send a `ping`
+before opening a slow upstream stream; a failure after that ping is therefore
+post-commit even though no model content has arrived yet.
+
+OpenAI Responses preserves the upstream response's business status. A native
+Responses result with `status: "incomplete"`, `"failed"`, or `"cancelled"`
+remains an HTTP `200` Responses object/event with that status; it is not
+manufactured into `completed`. Transport failures and malformed provider
+payloads remain errors. When a failed/cancelled Responses result is bridged to
+Chat, Anthropic, or Gemini, whose non-stream response schemas cannot represent
+that native status, Router-Maestro returns that entry protocol's error envelope.
 
 ### Cross-Provider Translation
 
@@ -570,11 +588,16 @@ graph TD
 ```
 
 - **Traefik** — reverse proxy that handles TLS termination and auto-renews HTTPS certificates via Let's Encrypt. Only needed for public-facing deployments.
-- **Router-Maestro** — the API server. Listens on port 8080, requires an API key for all requests, and routes them to configured LLM providers.
+- **Router-Maestro** — the API server. Listens on port 8080, requires its API key for inference and administration requests, and routes inference to configured LLM providers. Health/docs are public; metrics has its own optional token.
 
 ### Server and Client API Keys
 
-Router-Maestro has one server API key. The server uses it to protect every API route except public health/status endpoints, and every client must send that same key.
+Router-Maestro currently has one server API key. The same
+`ROUTER_MAESTRO_API_KEY` protects inference routes and `/api/admin/*`; every
+inference client and remote CLI management command must send that key. A
+separate administrator key is not currently supported. Public health/docs and
+the independently configured metrics endpoint are the exceptions described in
+their respective sections.
 
 You can provide the key explicitly with `ROUTER_MAESTRO_API_KEY` or `router-maestro server start --api-key ...`. If you do not, the server generates a `sk-rm-...` key on first start and persists it in the `local` context inside `contexts.json` (the Docker image runs the same `server start` command, so the same behavior applies there). To read it later:
 
@@ -808,6 +831,16 @@ Configure in `~/.config/router-maestro/priorities.json`:
 }
 ```
 
+The five streaming encoders (OpenAI Chat, OpenAI Responses, standard
+Anthropic, beta-native Anthropic, and Gemini) attach these guards to their
+stream processing. `beta_strip` is also live: matching tokens are removed from
+the inbound `anthropic-beta` header before Copilot transport, and remaining
+tokens are forwarded. The broader request context is separate from this stream
+pipeline: it owns one immutable config/router generation, request ID, audit,
+terminal outcome, and cleanup for streaming and non-stream inference and token
+counting routes. Streaming cleanup finishes at the final ASGI body frame, not
+when the endpoint returns a stream object.
+
 **Audit Tracing** (opt-in, for debugging):
 
 ```bash
@@ -818,11 +851,22 @@ ROUTER_MAESTRO_TRACE=1 router-maestro server start
 { "audit": { "enabled": true } }
 ```
 
-Each request writes JSON trace files to `~/.local/share/router-maestro/traces/{request_id}/`:
-- `inbound.json` — what the client sent
-- `upstream.json` — what was forwarded to the provider
-- `upstream_resp.json` — provider response
-- `outbound.json` — what was returned to the client (with timing)
+Each traced request writes a directory under
+`~/.local/share/router-maestro/traces/{request_id}/`. Artifacts are lifecycle
+records, not a fixed four-file bundle:
+
+- `inbound.json` — the client request
+- `upstream.json`, `upstream_2.json`, ... — upstream request observations in order
+- `upstream_resp.json`, `upstream_resp_2.json`, ... — upstream response
+  observations, numbered independently in response order
+- `outbound.json` — wire status, timing, and semantic terminal outcome
+
+Some early failures have no upstream artifact, while fallback, authentication
+retry, catalog, or token-count traffic may produce multiple attempt records.
+The recognized `Authorization`, `X-API-Key`, and `X-Goog-API-Key` headers and
+common credential-shaped payload keys are redacted before the trace is written
+asynchronously. Treat traces as sensitive because prompts, model output, and
+unrecognized application-specific headers can still contain private data.
 
 For Docker, mount a volume to persist traces:
 ```bash

--- a/docs/api-translation.md
+++ b/docs/api-translation.md
@@ -9,7 +9,7 @@ capability-aware route plan, providers execute the selected wire operation, and
 the entry protocol encodes the result.
 
 ```
-Anthropic Request ──► translate_anthropic_to_openai() ──► ChatRequest ──► Provider ──► ChatResponse ──► translate_openai_to_anthropic() ──► Anthropic Response
+Anthropic Request ──► translate_anthropic_to_openai() ──► ChatRequest ──► Provider ──► ChatResponse ──► build_anthropic_response() ──► Anthropic Response
 OpenAI Request ──────────────── (passthrough) ──────────► ChatRequest ──► Provider ──► ChatResponse ──────────── (passthrough) ──────────────► OpenAI Response
 OpenAI Responses ───────────── typed normalization ─────► ResponsesRequest ──► Provider/bridge ──► Responses output
 Gemini Request ─────────────── protocol translation ────► ChatRequest ──► Provider ──► ChatResponse ──► Gemini Response
@@ -104,7 +104,8 @@ entry and snapshots its capabilities.
 
 ### Path 2: Internal → Anthropic (Response Outbound, Non-Streaming)
 
-**Function:** `translate_openai_to_anthropic()` in `translation.py`
+**Function:** `build_anthropic_response()` in
+`src/router_maestro/server/protocols/anthropic_reducer.py`
 
 | Internal / OpenAI Field | Anthropic Field | Transformation |
 |---|---|---|
@@ -162,13 +163,46 @@ object is a no-op. `reasoning.summary` and any unknown sibling are rejected with
 an OpenAI `invalid_request_error` whose parameter identifies the exact field;
 streaming validation occurs before SSE commitment.
 
+### Terminal and HTTP Semantics
+
+Transport termination and response semantics are independent. Router-Maestro
+records whether a provider ended with an explicit terminal, unexpected EOF,
+client cancellation, or exception, separately from whether the response was
+completed, incomplete, failed, cancelled, or unknown. Only an explicit
+`completed` terminal is success; a clean EOF without a terminal is
+`unexpected_eof`.
+
+| Boundary | HTTP behavior | Protocol behavior |
+|---|---|---|
+| Validation, routing, provider open, or primed first-chunk failure before the route returns SSE | Entry-protocol non-2xx JSON error | No success SSE terminal is emitted |
+| Failure after the response has started | HTTP status remains committed (normally `200`) | Exactly one protocol-native error/incomplete terminal; no fallback or replay |
+| Explicit incomplete terminal | HTTP `200` | Preserve the protocol's incomplete/length terminal |
+| Clean provider EOF without an explicit terminal | HTTP `200` after commitment | Encode `unexpected_eof` as a non-success in-stream terminal |
+| Downstream disconnect | Already-committed status if any | Record cancellation and finalize resources; do not manufacture success |
+
+The standard Anthropic stream emits a protocol `ping` while the Router opens
+and primes the provider stream. Consequently, an open/first-chunk failure after
+that ping is already post-commit and is encoded in-stream. OpenAI Chat,
+Responses, Gemini, and beta-native Anthropic open/prime before returning their
+stream response, so their corresponding early failures can still be non-2xx.
+
+Native OpenAI Responses status is part of the response body, not a replacement
+HTTP status. Non-stream `status: "incomplete"`, `"failed"`, or `"cancelled"`
+remains HTTP `200`; streaming uses `response.incomplete` or `response.failed`
+(with response status `failed`/`cancelled`) and also remains HTTP `200` once
+started. The Chat/Anthropic/Gemini non-stream bridges cannot represent a native
+failed/cancelled Responses result, so they return their own protocol-native
+error envelope rather than a false success.
+
 ---
 
 ### Path 4: Internal → Anthropic (Response Outbound, Streaming)
 
-**Function:** `translate_openai_chunk_to_anthropic_events()` in `translation.py`
+**Reducer:** `AnthropicReducer` in
+`src/router_maestro/server/protocols/anthropic_reducer.py`
 
-Uses a state machine (`AnthropicStreamState`) to translate OpenAI streaming chunks into Anthropic SSE events:
+The reducer owns an `AnthropicStreamState` and translates canonical
+`ChatStreamChunk` values into Anthropic SSE events:
 
 ```
 OpenAI chunk: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}
@@ -292,6 +326,31 @@ OpenAI errors use `invalid_request_error`, Anthropic errors use an
 `invalid_request_error` envelope, and Gemini errors use `INVALID_ARGUMENT`.
 Static capability/option failures are non-retryable and never authorize a model
 switch.
+
+The concrete provider policy is intentionally conservative:
+
+| Provider transport | Representative supported translations | Explicit rejection examples |
+|---|---|---|
+| Copilot Chat | temperature, tools/tool choice, `top_p`, penalties, stop, user, metadata, service tier, downward reasoning-tier selection | `top_k`, Gemini candidate count/response MIME type, conflicting stop fields, unknown extensions |
+| Copilot Responses | tools/tool choice, parallel tools, `top_p`, metadata, service tier, downward reasoning-tier selection | any explicit temperature, unsupported tool types, unknown extensions |
+| OpenAI/custom Chat Completions | OpenAI-native temperature, tools/tool choice, `top_p`, penalties, stop, user, metadata, service tier; extended reasoning tiers are downgraded to upstream `high` | `top_k`, Gemini candidate count/response MIME type, conflicting stop fields, unknown extensions |
+| Anthropic Messages | temperature, tools/tool choice, `top_p`, `top_k`, stop sequences, metadata/user, service tier, thinking and effort | penalties, Gemini candidate count/response MIME type, conflicting stop fields, unknown extensions |
+
+Model operation/feature capabilities are checked during route planning before
+this payload policy runs. A fallback candidate is eligible only when its
+provider transport and selected model can support the requested operation and
+required tools, vision, reasoning, or parallel-tool feature (or support is
+explicitly unknown and the runtime contract permits probing). An explicitly
+selected model remains primary; configured priorities can follow it only after
+a retryable execution failure, even when the primary was absent from the
+priority list. Static option/capability errors never trigger fallback.
+
+When a Chat-shaped request is adapted to the Copilot Responses transport, the
+Responses policy also rejects `frequency_penalty`, `presence_penalty`, `stop`,
+`user`, `top_k`, `stop_sequences`, Gemini candidate count, and Gemini response
+MIME type. This applies whether the entry protocol was OpenAI Chat, Anthropic,
+or Gemini: the rejection is encoded as that entry protocol's HTTP 400 and is
+resolved before provider I/O or model fallback.
 
 Some protocol information still has no lossless counterpart:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -195,6 +195,14 @@ docker compose exec router-maestro router-maestro server show-key
 
 Use that same key in remote client contexts and raw API calls. If deployment automation needs a stable pre-provisioned value, set `ROUTER_MAESTRO_API_KEY` in `.env` before starting the service.
 
+This is currently also the administrator credential: `/api/admin/*` and
+inference routes use the same `ROUTER_MAESTRO_API_KEY`, and remote CLI
+management reads that key from the active context. There is no separate
+administrator-key environment variable in the current release. Protect this
+key as both inference and configuration authority, expose admin routes only on
+trusted networks or behind an appropriate access-control layer, and rotate the
+single key consistently across all clients when required.
+
 ### Complete .env Example
 
 ```bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,11 +8,13 @@ deployments. The first observability layer is intentionally narrow:
 - HTTP request duration histograms
 - request IDs propagated through `X-Request-ID`
 
-Provider, fallback, and streaming-specific metrics are planned separately. In
-this layer, provider-side failures are visible through the HTTP status and
-request ID that connects the client response to server logs. Streaming response
-duration is measured when the response body finishes, not when the stream object
-is created.
+Provider, fallback, and terminal-outcome Prometheus metrics are not yet exposed.
+Provider-side attempts and streaming outcomes are available through opt-in audit
+traces, while the request ID connects client responses, audit directories, and
+server logs. Do not infer stream success from HTTP `200` alone: after a stream
+is committed, an upstream failure or unexpected EOF is encoded in-stream and
+recorded as a non-success terminal outcome. Streaming response duration is
+measured when the response body finishes, not when the stream object is created.
 
 ## Scraping `/metrics`
 
@@ -136,6 +138,36 @@ curl http://localhost:8080/api/openai/v1/models \
   -i
 ```
 
+## Request Lifecycle and Audit Traces
+
+Every inference and token-count request receives one request context. It binds
+the request ID to an immutable runtime configuration revision and Router
+generation, owns the optional audit trace, records the semantic terminal
+outcome separately from the wire HTTP status, and releases resources only
+after the final ASGI response-body frame or cancellation. The five streaming
+protocol encoders additionally use the guard pipeline; non-stream routes share
+the lifecycle/audit context without pretending to be streaming pipelines.
+
+Enable audit traces with `ROUTER_MAESTRO_TRACE=1` or
+`audit.enabled: true` in `priorities.json`. The directory
+`~/.local/share/router-maestro/traces/{request_id}/` can contain:
+
+| Artifact | Meaning |
+|---|---|
+| `inbound.json` | Redacted inbound request |
+| `upstream.json`, `upstream_2.json`, ... | Each upstream request attempt, in order |
+| `upstream_resp.json`, `upstream_resp_2.json`, ... | Upstream responses that were obtained, in order |
+| `outbound.json` | Wire status, duration, transport termination, response status, incomplete details, and safe terminal error |
+
+The set is dynamic. An early validation failure can have no upstream file; a
+fallback or authentication retry can have several. Upstream request and
+response observations are numbered independently because a failed request may
+produce no response. The recognized `Authorization`, `X-API-Key`, and
+`X-Goog-API-Key` headers and common credential-shaped payload keys are redacted
+before asynchronous disk writes. Treat traces as sensitive debugging data
+anyway because prompts, model output, and unrecognized application-specific
+headers can contain private data.
+
 ## Troubleshooting
 
 ### `/metrics` returns 401
@@ -187,6 +219,10 @@ sum by (path_template, status) (
 
 Then ask the client for the `X-Request-ID` response header and search the
 server logs for that request ID.
+
+For streaming requests, also inspect the protocol's final SSE event and the
+matching `outbound.json`. HTTP `200` can accompany `unexpected_eof`, failed, or
+cancelled terminal semantics after commitment.
 
 ### Requests are slow
 

--- a/docs/superpowers/plans/2026-07-10-codebase-maintainability-remediation.md
+++ b/docs/superpowers/plans/2026-07-10-codebase-maintainability-remediation.md
@@ -1039,6 +1039,28 @@ targeted re-review before the final acceptance gates below.
 
 - [ ] **Step 2: Delete only confirmed dead code/dependencies**
 
+  `pipeline/guards.py` is not deleted as a file merely because its original
+  helper functions have no in-repository callers.  The package exported those
+  helpers publicly, and the protocol audit found payload classes that the
+  inlined `RequestPipeline` loop did not inspect.  The approved replacement is
+  a typed guard domain boundary:
+
+  - retain `StreamGuard`, `build_guards`, and `guarded_stream` as compatibility
+    imports while implementing their dispatch through one `GuardChain`;
+  - let `RequestPipeline` own that chain and construct it from the request's
+    immutable configuration snapshot;
+  - leak-scan human-readable `content`, `refusal`, and `thinking` exactly once,
+    while runaway accounting also covers opaque reasoning identifiers,
+    signatures, and tool arguments;
+  - project beta-native Anthropic start and delta payloads onto the same guard
+    input contract before emitting their raw frames;
+  - keep the existing stream-only protection boundary.  Extending guards to
+    non-stream responses is a separate behavior decision, not Task 23 cleanup.
+
+  Regression tests must exercise the real guard chain, compatibility imports,
+  beta-native initial payloads and signature/tool deltas, protocol-native abort
+  terminals, and absence of double accounting.
+
 - [ ] **Step 3: Re-lock and verify imports/build**
 
   Run:

--- a/docs/token-calculation.md
+++ b/docs/token-calculation.md
@@ -139,6 +139,16 @@ output-token headroom exists. An adaptive budget may remain as an internal
 routing signal when effort is absent, but it is never serialized into an
 Anthropic-native adaptive thinking object.
 
+Reasoning effort stays on the selected base model. Router-Maestro does not
+rewrite model IDs to `-high`, `-xhigh`, or other reasoning suffixes. If the
+catalog does not advertise the requested tier, substitution is downward-only
+on `minimal < low < medium < high < xhigh < max`; no supported tier at or below
+the request means rejection. Likewise, Claude Code's synthetic `[1m]` selection
+is offered only for a Copilot base catalog entry that already advertises a
+one-million-token context window. The provider-qualified `[1m]` configuration
+maps to that base model and changes Claude Code's auto-compact threshold; it is
+not rewritten to a `-1m` upstream model variant.
+
 ---
 
 ## Key Differences

--- a/docs/tool-choice-behavior.md
+++ b/docs/tool-choice-behavior.md
@@ -1,8 +1,9 @@
 # tool_choice 与 finish_reason 行为分析
 
-## `finish_reason` 在不同 `tool_choice` 下的行为
+## 直连 OpenAI API 的 `finish_reason` 行为
 
-当请求中包含 `tools` 和 `tool_choice` 时，`finish_reason` 的值取决于 `tool_choice` 的格式：
+以下表格记录本页引用的原生 OpenAI API 观测结果，不是
+Router-Maestro 规范化后的输出：
 
 | tool_choice | finish_reason | tool_calls | 说明 |
 |---|---|---|---|
@@ -46,7 +47,19 @@ OpenAI 员工 @brianz-oai 在 [社区论坛](https://community.openai.com/t/new-
 
 ## Router-Maestro 代理行为
 
-直连 Copilot API 和经由 Router-Maestro 代理的响应**完全一致**，代理透传正确，无修改或丢失。
+上表记录的是直连 API 的观测行为。Router-Maestro 对 Copilot Chat
+响应做 canonical normalization，不保证逐字节透传：它会合并
+Copilot 分开返回的文本与工具 choices，将泄漏在文本中的 XML
+工具调用恢复为结构化 `tool_calls`，并在实际存在工具调用时将
+`finish_reason` 统一为 `"tool_calls"`。Anthropic 和 Gemini 入口还会
+分别编码为它们的原生工具终态。
+
+Router-Maestro 会在上游 I/O 前校验所选 provider/model 是否支持请求的
+operation、tools 和 parallel tool calls。支持的 `tools` / `tool_choice` 会按目标
+provider 的原生格式透传或等价翻译；无法表达的显式选项会以入口协议的 HTTP
+400 错误返回，不会静默丢弃，也不会借此切换到另一模型。Copilot Responses
+还会拒绝其不支持的 tool type；因此本页的 `finish_reason` 表格只描述已经通过
+这些能力与选项校验、实际发往 Copilot Chat transport 的请求。
 
 ## 客户端注意事项
 
@@ -58,10 +71,11 @@ if (message.tool_calls && message.tool_calls.length > 0) {
   handleToolCalls(message.tool_calls);
 }
 
-// 错误：依赖 finish_reason（强制工具调用时为 "stop"）
+// 错误：依赖上游或某一 API 版本的 finish_reason 差异
 if (finish_reason === "tool_calls") {
   handleToolCalls(message.tool_calls);
 }
 ```
 
-如果需要 `finish_reason` 一致为 `"tool_calls"`，可将 `tool_choice` 从 `{"type":"function",...}` 改为 `"required"`（仅在 Copilot API 下有效，原生 OpenAI API 仍返回 `"stop"`）。
+不要为了改变 `finish_reason` 而改写 `tool_choice`；两者表达的请求
+语义不同。客户端应直接检查规范化后的 `tool_calls`。

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 import os
 import socket
 import subprocess
+import threading
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import StrEnum
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 import pytest
@@ -24,7 +28,7 @@ from router_maestro.auth import AuthManager, AuthStorage, OAuthCredential, run_a
 from router_maestro.config.server import get_current_context_api_key
 from router_maestro.providers import CopilotProvider, ModelInfo
 from router_maestro.routing.model_ref import ModelRef
-from router_maestro.utils.model_match import normalize_model_id
+from router_maestro.utils.reasoning import EFFORT_ORDER
 from router_maestro.utils.responses_bridge import RESPONSES_ELIGIBLE_MODELS
 
 STARTUP_TIMEOUT_SECONDS = 45.0
@@ -48,6 +52,7 @@ OPENAI_REASONING_EFFORTS: tuple[str | None, ...] = (None, "low", "medium", "high
 STREAM_MODES: tuple[bool, ...] = (False, True)
 COMPAT_PROBE_BACKOFF_SECONDS = 0.25
 COMPAT_PROBE_MAX_ATTEMPTS = 3
+ANTHROPIC_EFFORT_PROBE_MAX_CANDIDATES = 3
 _PROVIDER_FAILURE_SIGNAL_HEADER = "X-Router-Maestro-Error-Signal"
 _COPILOT_BARE_BAD_REQUEST_SIGNAL = "copilot_bare_bad_request"
 _MAX_COMPAT_PROBE_DIAGNOSTIC_BODY = 256
@@ -68,15 +73,242 @@ class LiveServer:
     process: subprocess.Popen[str]
 
 
+@dataclass(frozen=True)
+class RecordedUpstreamRequest:
+    """One exact request observed by a controllable local upstream."""
+
+    method: str
+    path: str
+    payload: dict[str, Any] | None
+    headers: dict[str, str]
+
+
+@dataclass
+class ScriptedUpstream:
+    """Connection details and observations for one local fake upstream."""
+
+    base_url: str
+    requests: list[RecordedUpstreamRequest]
+
+
+@dataclass(frozen=True)
+class ControlledServer:
+    """One Router-Maestro subprocess backed only by temporary XDG state."""
+
+    base_url: str
+    api_key: str
+    process: subprocess.Popen[str]
+    xdg_root: Path
+
+
+def controlled_xdg_environment(
+    root,
+    *,
+    source: dict[str, str] | None = None,
+    api_key: str = DEFAULT_API_KEY,
+) -> dict[str, str]:
+    """Build a subprocess environment that cannot read the developer's RM state."""
+    root = os.fspath(root)
+    source = dict(os.environ if source is None else source)
+    allowed = {
+        key: value
+        for key, value in source.items()
+        if key
+        in {
+            "PATH",
+            "TMPDIR",
+            "LANG",
+            "LC_ALL",
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
+            "UV_CACHE_DIR",
+            "VIRTUAL_ENV",
+        }
+    }
+    allowed.update(
+        {
+            "HOME": os.path.join(root, "home"),
+            "XDG_CONFIG_HOME": os.path.join(root, "config"),
+            "XDG_DATA_HOME": os.path.join(root, "data"),
+            "ROUTER_MAESTRO_API_KEY": api_key,
+            "ROUTER_MAESTRO_LOG_LEVEL": source.get("ROUTER_MAESTRO_LOG_LEVEL", "WARNING"),
+        }
+    )
+    return allowed
+
+
+def select_recorded_request(
+    requests: list[RecordedUpstreamRequest],
+    *,
+    method: str,
+    path: str,
+    occurrence: int = 0,
+) -> RecordedUpstreamRequest:
+    """Select one exact method/path occurrence without substring matching."""
+    matches = [request for request in requests if request.method == method and request.path == path]
+    if not matches:
+        raise AssertionError(f"no upstream request matched {method} {path}")
+    if occurrence < 0 or occurrence >= len(matches):
+        raise AssertionError(
+            f"upstream request occurrence {occurrence} is unavailable for {method} {path}; "
+            f"matched {len(matches)}"
+        )
+    return matches[occurrence]
+
+
+def assert_exact_outbound_payload(
+    actual: dict[str, Any] | None,
+    expected: dict[str, Any],
+) -> None:
+    """Require exact outbound JSON equality, including omitted and extra fields."""
+    if actual != expected:
+        raise AssertionError(
+            f"exact outbound payload mismatch: expected={expected!r}, actual={actual!r}"
+        )
+
+
+@contextmanager
+def controlled_router_server(
+    root: Path,
+    *,
+    providers: dict[str, Any],
+    priorities: dict[str, Any],
+    credentials: dict[str, Any] | None = None,
+    api_key: str = DEFAULT_API_KEY,
+) -> Iterator[ControlledServer]:
+    """Start Router-Maestro against explicit temporary config and credentials."""
+    import json
+
+    env = controlled_xdg_environment(root, api_key=api_key)
+    config_dir = Path(env["XDG_CONFIG_HOME"]) / "router-maestro"
+    data_dir = Path(env["XDG_DATA_HOME"]) / "router-maestro"
+    Path(env["HOME"]).mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "providers.json").write_text(json.dumps({"providers": providers}))
+    (config_dir / "priorities.json").write_text(json.dumps(priorities))
+    (data_dir / "auth.json").write_text(json.dumps(credentials or {}))
+
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    command = [
+        "uv",
+        "run",
+        "uvicorn",
+        "router_maestro.server:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--log-level",
+        env["ROUTER_MAESTRO_LOG_LEVEL"].lower(),
+    ]
+    if "github-copilot" in (credentials or {}):
+        initialization = "\n".join(
+            (
+                "def init(self,*a,**k):",
+                " old(self,*a,**k)",
+                " c=self.auth_manager.get_credential(self.provider_name)",
+                " self.cached_token=c.access",
+                " self.token_expires=c.expires",
+                " self.api_base=c.api_endpoint",
+            )
+        )
+        bootstrap = (
+            "import uvicorn; "
+            "from router_maestro.providers.copilot_support.auth_session import CopilotAuthSession; "
+            "old=CopilotAuthSession.__init__; "
+            f"exec({initialization!r}); "
+            "CopilotAuthSession.__init__=init; "
+            f"uvicorn.run('router_maestro.server:app',host='127.0.0.1',port={port},log_level="
+            f"'{env['ROUTER_MAESTRO_LOG_LEVEL'].lower()}')"
+        )
+        command = ["uv", "run", "python", "-c", bootstrap]
+    output_path = root / "router-maestro-startup.log"
+    with output_path.open("w+", encoding="utf-8") as output:
+        process = subprocess.Popen(
+            command,
+            cwd=_repo_root(),
+            env=env,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        process._router_maestro_output_path = output_path  # type: ignore[attr-defined]
+        try:
+            _wait_for_health(base_url, process)
+            yield ControlledServer(base_url, api_key, process, root)
+        finally:
+            _terminate_process(process)
+
+
+@contextmanager
+def scripted_upstream(
+    responder: Callable[[RecordedUpstreamRequest], tuple[int, bytes, dict[str, str]]],
+) -> Iterator[ScriptedUpstream]:
+    """Run the smallest possible recording HTTP upstream on loopback."""
+    import json
+
+    requests: list[RecordedUpstreamRequest] = []
+    requests_lock = threading.Lock()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            self._dispatch()
+
+        def do_POST(self) -> None:  # noqa: N802
+            self._dispatch()
+
+        def _dispatch(self) -> None:
+            length = int(self.headers.get("content-length", "0"))
+            raw = self.rfile.read(length) if length else b""
+            payload = json.loads(raw) if raw else None
+            request = RecordedUpstreamRequest(
+                method=self.command,
+                path=urlsplit(self.path).path,
+                payload=payload,
+                headers={key.lower(): value for key, value in self.headers.items()},
+            )
+            with requests_lock:
+                requests.append(request)
+            try:
+                status_code, body, headers = responder(request)
+            except Exception as error:
+                status_code = 500
+                body = json.dumps({"error": str(error)}).encode()
+                headers = {"Content-Type": "application/json"}
+            self.send_response(status_code)
+            for key, value in headers.items():
+                self.send_header(key, value)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    upstream = ScriptedUpstream(f"http://{host}:{port}", requests)
+    try:
+        yield upstream
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 def post_gemini_generate_content_compat_probe(
     client: httpx.Client,
     model: str,
 ) -> httpx.Response:
-    """Run the fixed Gemini generateContent compatibility probe."""
+    """Run the base Gemini generateContent protocol probe."""
     return _post_compat_probe_with_marked_400_retry(
         client,
         f"/api/gemini/v1beta/models/{gemini_model_path(model)}:generateContent",
-        json_payload=gemini_compat_payload(),
+        json_payload=gemini_payload(),
     )
 
 
@@ -415,22 +647,67 @@ def anthropic_unsupported_thinking_model(
 
 
 @pytest.fixture(scope="session")
-def anthropic_effort_profile(copilot_models: list[str]) -> tuple[str, str]:
-    """Choose a Claude model and an effort tier verified by the Copilot endpoint."""
-    profiles = (
-        ("claude-opus-4.8", "xhigh"),
-        ("claude-opus-4.7", "xhigh"),
-        ("claude-opus-4.6", "high"),
-        ("claude-sonnet-4.6", "high"),
+def anthropic_effort_profile(
+    copilot_catalog: dict[str, ModelInfo],
+    client: httpx.Client,
+) -> tuple[str, str]:
+    """Probe catalog candidates for manual thinking plus explicit effort.
+
+    Copilot's catalog currently advertises endpoints and effort tiers but may
+    omit ``supports.thinking``. A bounded non-stream request therefore confirms
+    the combined native contract instead of inferring it from a model name or
+    collapsing an omitted capability into an explicit rejection.
+    """
+    required_endpoints = {"/chat/completions", "/v1/messages"}
+    candidates: list[tuple[str, str]] = []
+
+    for model in _prioritize_models(list(copilot_catalog)):
+        info = copilot_catalog[model]
+        endpoints = set(info.supported_endpoints or ())
+        efforts = [value for value in info.reasoning_effort_values or [] if value in EFFORT_ORDER]
+        if (
+            bare_model(model).lower().startswith("claude-")
+            and required_endpoints.issubset(endpoints)
+            and efforts
+        ):
+            candidates.append((model, min(efforts, key=EFFORT_ORDER.index)))
+
+    if not candidates:
+        pytest.skip(
+            "No Copilot Claude model advertises enabled thinking with effort prerequisites "
+            "across Chat and native Messages"
+        )
+
+    rejected: list[str] = []
+    bounded_candidates = candidates[:ANTHROPIC_EFFORT_PROBE_MAX_CANDIDATES]
+    for model, effort in bounded_candidates:
+        with client.stream(
+            "POST",
+            "/api/anthropic/beta/v1/messages",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": TEXT_PROMPT}],
+                "max_tokens": 1025,
+                "stream": False,
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+                "output_config": {"effort": effort},
+            },
+            timeout=120.0,
+        ) as response:
+            if response.status_code == 200:
+                return model, effort
+            if response.status_code == 400:
+                rejected.append(model)
+                continue
+            pytest.fail(
+                "Anthropic effort compatibility probe failed before validation: "
+                f"model={model}, HTTP {response.status_code}"
+            )
+
+    pytest.fail(
+        "All catalog candidates rejected enabled thinking with effort "
+        f"after {len(bounded_candidates)} bounded attempts: " + ", ".join(rejected)
     )
-    models_by_normalized_id = {
-        normalize_model_id(bare_model(model)): model for model in copilot_models
-    }
-    for bare_id, effort in profiles:
-        model = models_by_normalized_id.get(normalize_model_id(bare_id))
-        if model is not None:
-            return model, effort
-    pytest.skip("No Copilot Claude model with output_config.effort support is available")
 
 
 @pytest.fixture(scope="session")
@@ -665,23 +942,6 @@ def gemini_payload(*, max_output_tokens: int = 16) -> dict[str, Any]:
     }
 
 
-def gemini_compat_payload(*, max_output_tokens: int = 16) -> dict[str, Any]:
-    """Gemini request exercising systemInstruction and generationConfig."""
-    payload = gemini_payload(max_output_tokens=max_output_tokens)
-    payload.update(
-        {
-            "systemInstruction": {"parts": [{"text": "Return concise answers."}]},
-            "generationConfig": {
-                "temperature": 0,
-                "topP": 1,
-                "maxOutputTokens": max_output_tokens,
-                "stopSequences": ["\n\n"],
-            },
-        }
-    )
-    return payload
-
-
 def openai_chat_usage_payload(model: str, *, stream: bool = False) -> dict[str, Any]:
     """OpenAI Chat payload with compatibility fields and usage assertions."""
     payload = openai_chat_payload(model, stream=stream)
@@ -756,13 +1016,13 @@ def anthropic_effort_payload(
     budget: int = 1024,
     stream: bool = False,
 ) -> dict[str, Any]:
-    """Anthropic adaptive-thinking request with a deliberately conflicting budget."""
+    """Anthropic request combining enabled thinking, a budget, and explicit effort."""
     return {
         "model": model,
         "messages": [{"role": "user", "content": REASONING_PROMPT}],
         "max_tokens": max(4096, budget + 1024),
         "stream": stream,
-        "thinking": {"type": "adaptive", "budget_tokens": budget},
+        "thinking": {"type": "enabled", "budget_tokens": budget},
         "output_config": {"effort": effort},
     }
 
@@ -1209,6 +1469,7 @@ def _wait_for_health(base_url: str, process: subprocess.Popen[str]) -> None:
                 last_error = exc
             time.sleep(0.25)
 
+    _terminate_process(process)
     output = _read_process_output(process)
     pytest.fail(f"Router-Maestro server did not become healthy: {last_error}\n{output}")
 
@@ -1224,6 +1485,12 @@ def _terminate_process(process: subprocess.Popen[str]) -> None:
 
 
 def _read_process_output(process: subprocess.Popen[str]) -> str:
+    output_path = getattr(process, "_router_maestro_output_path", None)
+    if output_path is not None:
+        try:
+            return Path(output_path).read_text(encoding="utf-8")
+        except OSError:
+            return ""
     if process.stdout is None:
         return ""
     try:

--- a/integration_tests/test_controlled_boundaries.py
+++ b/integration_tests/test_controlled_boundaries.py
@@ -1,0 +1,789 @@
+"""Deterministic end-to-end checks against an isolated fake Copilot upstream."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from integration_tests.conftest import (
+    RecordedUpstreamRequest,
+    assert_exact_outbound_payload,
+    controlled_router_server,
+    parse_sse_events,
+    scripted_upstream,
+    select_recorded_request,
+)
+
+API_KEY = "controlled-router-key"
+_SUCCESS_TERMINALS = {
+    "openai-chat": "[DONE]",
+    "openai-responses": "response.completed",
+    "anthropic": "message_stop",
+    "anthropic-beta": "message_stop",
+    "gemini": '"finishReason"',
+}
+
+
+def _json_reply(status: int, payload: object) -> tuple[int, bytes, dict[str, str]]:
+    return status, json.dumps(payload).encode(), {"Content-Type": "application/json"}
+
+
+def _sse_reply(*events: dict[str, Any]) -> tuple[int, bytes, dict[str, str]]:
+    body = "".join(f"data: {json.dumps(event)}\n\n" for event in events).encode()
+    return 200, body, {"Content-Type": "text/event-stream"}
+
+
+def _chat_success(model: str) -> tuple[int, bytes, dict[str, str]]:
+    return _json_reply(
+        200,
+        {
+            "id": "chatcmpl-controlled",
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "pong"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+        },
+    )
+
+
+def _responses_success(model: str) -> tuple[int, bytes, dict[str, str]]:
+    return _json_reply(
+        200,
+        {
+            "id": "resp-controlled",
+            "object": "response",
+            "created_at": 1,
+            "model": model,
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg-controlled",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                }
+            ],
+            "usage": {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+        },
+    )
+
+
+def _models(*entries: dict[str, Any]) -> tuple[int, bytes, dict[str, str]]:
+    return _json_reply(200, {"data": list(entries)})
+
+
+def _catalog_model(
+    model: str,
+    *,
+    endpoints: list[str],
+    tools: bool = True,
+) -> dict[str, Any]:
+    return {
+        "id": model,
+        "name": model,
+        "supported_endpoints": endpoints,
+        "capabilities": {
+            "type": "chat",
+            "limits": {"max_output_tokens": 32768},
+            "supports": {
+                "tool_calls": tools,
+                "thinking": True,
+                "reasoning_effort": {"values": ["low", "medium", "high"]},
+            },
+        },
+    }
+
+
+def _anthropic_native_success(model: str) -> tuple[int, bytes, dict[str, str]]:
+    return _json_reply(
+        200,
+        {
+            "id": "msg-controlled",
+            "type": "message",
+            "role": "assistant",
+            "model": model,
+            "content": [{"type": "text", "text": "pong"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 2, "output_tokens": 1},
+        },
+    )
+
+
+def _auth(api_base: str) -> dict[str, Any]:
+    return {
+        "github-copilot": {
+            "type": "oauth",
+            "refresh": "controlled-refresh",
+            "access": "controlled-access",
+            "expires": int(time.time()) + 3600,
+            "api_endpoint": api_base,
+        }
+    }
+
+
+def _assert_native_open_failure(surface: str, response: httpx.Response) -> None:
+    """Require the exact native envelope for one controlled stream-open failure."""
+    if surface == "anthropic":
+        assert response.status_code == 200
+        errors = [
+            payload
+            for name, payload in parse_sse_events(response)
+            if name == "error" and isinstance(payload, dict)
+        ]
+        assert errors == [
+            {
+                "type": "error",
+                "error": {"type": "rate_limit_error", "message": "Copilot API error: 429"},
+            }
+        ]
+        return
+
+    assert response.status_code == 429
+    assert response.headers["content-type"].startswith("application/json")
+    assert "data:" not in response.text
+    body = response.json()
+    assert "detail" not in body
+    if surface in {"openai-chat", "openai-responses"}:
+        assert body["error"]["type"] == "rate_limit_error"
+        assert body["error"]["code"] == "rate_limit_exceeded"
+    elif surface == "anthropic-beta":
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "rate_limit_error"
+    else:
+        assert body["error"]["code"] == 429
+        assert body["error"]["status"] == "RESOURCE_EXHAUSTED"
+        assert body["error"]["details"] == []
+
+
+def _assert_unexpected_eof_terminal(surface: str, response: httpx.Response) -> None:
+    """Require one native EOF terminal and no protocol success terminal."""
+    events = parse_sse_events(response)
+    assert _SUCCESS_TERMINALS[surface] not in response.text
+
+    if surface == "openai-responses":
+        incomplete = [
+            payload
+            for name, payload in events
+            if name == "response.incomplete" and isinstance(payload, dict)
+        ]
+        assert len(incomplete) == 1
+        assert incomplete[0]["type"] == "response.incomplete"
+        terminal = incomplete[0]["response"]
+        assert terminal["status"] == "incomplete"
+        assert terminal["incomplete_details"] == {"reason": "unexpected_eof"}
+        assert terminal["error"] is None
+        return
+
+    payloads = [payload for _name, payload in events if isinstance(payload, dict)]
+    if surface in {"anthropic", "anthropic-beta"}:
+        errors = [payload for payload in payloads if payload.get("type") == "error"]
+        assert len(errors) == 1
+        assert errors[0]["type"] == "error"
+        assert errors[0]["error"]["type"] == "api_error"
+    elif surface == "openai-chat":
+        errors = [payload["error"] for payload in payloads if "error" in payload]
+        assert len(errors) == 1
+        assert errors[0]["type"] == "unexpected_eof"
+    else:
+        errors = [payload["error"] for payload in payloads if "error" in payload]
+        assert len(errors) == 1
+        assert errors[0]["code"] == 502
+        assert errors[0]["status"] == "INTERNAL"
+        assert errors[0]["details"] == []
+
+
+@contextmanager
+def _controlled_copilot(
+    tmp_path: Path,
+    responder: Callable[[RecordedUpstreamRequest], tuple[int, bytes, dict[str, str]]],
+    *,
+    priorities: list[str],
+) -> Iterator[tuple[httpx.Client, Any]]:
+    with scripted_upstream(responder) as upstream:
+        config = {
+            "priorities": priorities,
+            "fallback": {"strategy": "priority", "maxRetries": 3},
+        }
+        with controlled_router_server(
+            tmp_path,
+            providers={},
+            priorities=config,
+            credentials=_auth(upstream.base_url),
+            api_key=API_KEY,
+        ) as server:
+            with httpx.Client(
+                base_url=server.base_url,
+                headers={"Authorization": f"Bearer {API_KEY}"},
+                timeout=15,
+            ) as client:
+                yield client, upstream
+
+
+def test_operation_routing_uses_catalog_capability_and_exact_responses_payload(tmp_path: Path):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(
+                _catalog_model("chat-only", endpoints=["/chat/completions"]),
+                _catalog_model("responses-only", endpoints=["/responses"]),
+            )
+        if request.path == "/responses":
+            return _responses_success(request.payload["model"])
+        return _json_reply(500, {"error": "wrong operation"})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/chat-only", "github-copilot/responses-only"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/responses",
+            json={
+                "model": "router-maestro",
+                "input": "ping",
+                "instructions": "answer exactly",
+                "top_p": 0.7,
+                "metadata": {"case": "operation-routing"},
+                "service_tier": "default",
+                "max_output_tokens": 17,
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["model"] == "github-copilot/responses-only"
+    request = select_recorded_request(upstream.requests, method="POST", path="/responses")
+    assert_exact_outbound_payload(
+        request.payload,
+        {
+            "model": "responses-only",
+            "input": "ping",
+            "stream": False,
+            "instructions": "answer exactly",
+            "max_output_tokens": 17,
+            "top_p": 0.7,
+            "metadata": {"case": "operation-routing"},
+            "service_tier": "default",
+        },
+    )
+    assert not [r for r in upstream.requests if r.path == "/chat/completions"]
+
+
+def test_capability_mismatch_is_precommit_and_never_calls_upstream(tmp_path: Path):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("no-tools", endpoints=["/chat/completions"], tools=False))
+        return _json_reply(500, {"error": "must not execute"})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/no-tools"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/chat/completions",
+            json={
+                "model": "github-copilot/no-tools",
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "echo",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert "detail" not in response.json()
+    assert not [r for r in upstream.requests if r.path != "/models"]
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_explicit_responses_unsupported_temperature_is_native_400_without_completion_call(
+    tmp_path: Path,
+    stream: bool,
+):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("responses-model", endpoints=["/responses"]))
+        return _json_reply(500, {"error": "completion must not execute"})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/responses-model"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/responses",
+            json={
+                "model": "github-copilot/responses-model",
+                "input": "ping",
+                "stream": stream,
+                "temperature": 0.2,
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {
+        "error": {
+            "message": "GitHub Copilot Responses does not support request option 'temperature'",
+            "type": "invalid_request_error",
+            "param": "temperature",
+            "code": "unsupported_parameter",
+        }
+    }
+    assert [request.path for request in upstream.requests] == ["/models"]
+
+
+def test_automatic_fallback_skips_feature_incompatible_candidates(tmp_path: Path):
+    """Fallback execution must never attempt a candidate lacking required tools."""
+
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(
+                _catalog_model(
+                    "primary-tools",
+                    endpoints=["/chat/completions"],
+                    tools=True,
+                ),
+                _catalog_model(
+                    "no-tools",
+                    endpoints=["/chat/completions"],
+                    tools=False,
+                ),
+                _catalog_model(
+                    "fallback-tools",
+                    endpoints=["/chat/completions"],
+                    tools=True,
+                ),
+            )
+        if request.payload["model"] == "primary-tools":
+            return _json_reply(503, {"error": {"message": "retry", "type": "server_error"}})
+        if request.payload["model"] == "fallback-tools":
+            return _chat_success("fallback-tools")
+        return _json_reply(500, {"error": "feature-incompatible candidate was executed"})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=[
+            "github-copilot/primary-tools",
+            "github-copilot/no-tools",
+            "github-copilot/fallback-tools",
+        ],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/chat/completions",
+            json={
+                "model": "router-maestro",
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "echo",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["model"] == "github-copilot/fallback-tools"
+    attempts = [
+        request.payload["model"]
+        for request in upstream.requests
+        if request.path == "/chat/completions"
+    ]
+    assert attempts == ["primary-tools", "fallback-tools"]
+
+
+def test_precommit_failure_falls_back_and_reports_actual_model_identity(tmp_path: Path):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(
+                _catalog_model("primary", endpoints=["/chat/completions"]),
+                _catalog_model("fallback", endpoints=["/chat/completions"]),
+            )
+        if request.payload["model"] == "primary":
+            return _json_reply(503, {"error": {"message": "retry", "type": "server_error"}})
+        return _chat_success("fallback")
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/primary", "github-copilot/fallback"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/chat/completions",
+            json={"model": "router-maestro", "messages": [{"role": "user", "content": "ping"}]},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["model"] == "github-copilot/fallback"
+    attempts = [r.payload["model"] for r in upstream.requests if r.path == "/chat/completions"]
+    assert attempts == ["primary", "fallback"]
+
+
+@pytest.mark.parametrize(
+    ("surface", "path", "payload", "error_path"),
+    [
+        (
+            "openai-chat",
+            "/api/openai/v1/chat/completions",
+            {
+                "model": "github-copilot/stream-model",
+                "stream": True,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+            "/chat/completions",
+        ),
+        (
+            "openai-responses",
+            "/api/openai/v1/responses",
+            {"model": "github-copilot/stream-model", "stream": True, "input": "ping"},
+            "/responses",
+        ),
+        (
+            "anthropic",
+            "/api/anthropic/v1/messages",
+            {
+                "model": "github-copilot/stream-model",
+                "stream": True,
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+            "/chat/completions",
+        ),
+        (
+            "anthropic-beta",
+            "/api/anthropic/beta/v1/messages",
+            {
+                "model": "github-copilot/stream-model",
+                "stream": True,
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+            "/v1/messages",
+        ),
+        (
+            "gemini",
+            "/api/gemini/v1beta/models/github-copilot/stream-model:streamGenerateContent",
+            {"contents": [{"role": "user", "parts": [{"text": "ping"}]}]},
+            "/chat/completions",
+        ),
+    ],
+)
+def test_stream_open_errors_use_native_precommit_or_postcommit_envelope(
+    tmp_path: Path,
+    surface: str,
+    path: str,
+    payload: dict[str, Any],
+    error_path: str,
+):
+    endpoints = ["/chat/completions", "/responses", "/v1/messages"]
+
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("stream-model", endpoints=endpoints))
+        return _json_reply(429, {"error": {"message": "rate limited", "type": "rate_limit_error"}})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/stream-model"],
+    ) as (client, upstream):
+        response = client.post(path, json=payload)
+
+    assert len([r for r in upstream.requests if r.path == error_path]) == 1
+    _assert_native_open_failure(surface, response)
+
+
+def test_stream_postcommit_failure_is_normalized_once_and_never_replays(tmp_path: Path):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(
+                _catalog_model("primary", endpoints=["/chat/completions"]),
+                _catalog_model("fallback", endpoints=["/chat/completions"]),
+            )
+        if request.payload["model"] == "fallback":
+            return _chat_success("fallback")
+        return _sse_reply(
+            {"choices": [{"delta": {"content": "partial"}, "finish_reason": None}]},
+            {"choices": [{"delta": "malformed", "finish_reason": None}]},
+        )
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/primary", "github-copilot/fallback"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/chat/completions",
+            json={
+                "model": "router-maestro",
+                "stream": True,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+        )
+
+    assert response.status_code == 200
+    events = parse_sse_events(response)
+    contents = [
+        choice["delta"].get("content")
+        for _name, payload in events
+        if isinstance(payload, dict)
+        for choice in payload.get("choices", [])
+        if isinstance(choice.get("delta"), dict) and choice["delta"].get("content") is not None
+    ]
+    assert contents == ["partial"]
+    errors = [
+        payload["error"]
+        for _name, payload in events
+        if isinstance(payload, dict) and "error" in payload
+    ]
+    assert errors == [
+        {
+            "message": "github-copilot returned a malformed upstream response",
+            "type": "api_error",
+            "code": "upstream_protocol_error",
+        }
+    ]
+    assert "unexpected_eof" not in response.text
+    assert "[DONE]" not in response.text
+    attempts = [r.payload["model"] for r in upstream.requests if r.path == "/chat/completions"]
+    assert attempts == ["primary"]
+
+
+@pytest.mark.parametrize(
+    ("surface", "path", "payload", "upstream_path"),
+    [
+        (
+            "openai-chat",
+            "/api/openai/v1/chat/completions",
+            {
+                "model": "github-copilot/eof-model",
+                "stream": True,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+            "/chat/completions",
+        ),
+        (
+            "openai-responses",
+            "/api/openai/v1/responses",
+            {"model": "github-copilot/eof-model", "stream": True, "input": "ping"},
+            "/responses",
+        ),
+        (
+            "anthropic",
+            "/api/anthropic/v1/messages",
+            {
+                "model": "github-copilot/eof-model",
+                "stream": True,
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+            "/chat/completions",
+        ),
+        (
+            "anthropic-beta",
+            "/api/anthropic/beta/v1/messages",
+            {
+                "model": "github-copilot/eof-model",
+                "stream": True,
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+            "/v1/messages",
+        ),
+        (
+            "gemini",
+            "/api/gemini/v1beta/models/github-copilot/eof-model:streamGenerateContent",
+            {"contents": [{"role": "user", "parts": [{"text": "ping"}]}]},
+            "/chat/completions",
+        ),
+    ],
+)
+def test_stream_unexpected_eof_is_one_native_terminal_without_success_sentinel(
+    tmp_path: Path,
+    surface: str,
+    path: str,
+    payload: dict[str, Any],
+    upstream_path: str,
+):
+    endpoints = ["/chat/completions", "/responses", "/v1/messages"]
+
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("eof-model", endpoints=endpoints))
+        if request.path == "/responses":
+            return _sse_reply(
+                {"type": "response.output_text.delta", "item_id": "msg", "delta": "partial"}
+            )
+        if request.path == "/v1/messages":
+            return (
+                200,
+                b"event: message_start\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {
+                            "id": "msg",
+                            "type": "message",
+                            "role": "assistant",
+                            "model": "eof-model",
+                            "content": [],
+                            "usage": {"input_tokens": 1, "output_tokens": 0},
+                        },
+                    }
+                ).encode()
+                + b"\n\n",
+                {"Content-Type": "text/event-stream"},
+            )
+        return _sse_reply({"choices": [{"delta": {"content": "partial"}, "finish_reason": None}]})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/eof-model"],
+    ) as (client, upstream):
+        response = client.post(path, json=payload)
+
+    assert response.status_code == 200, response.text
+    assert len([r for r in upstream.requests if r.path == upstream_path]) == 1
+    _assert_unexpected_eof_terminal(surface, response)
+
+
+def test_beta_enabled_budget_effort_payload_is_exact_in_both_modes(tmp_path: Path):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("claude-controlled", endpoints=["/v1/messages"]))
+        if request.payload["stream"]:
+            return (
+                200,
+                b"event: message_start\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {
+                            "id": "msg",
+                            "type": "message",
+                            "role": "assistant",
+                            "model": "claude-controlled",
+                            "content": [],
+                            "usage": {"input_tokens": 1, "output_tokens": 0},
+                        },
+                    }
+                ).encode()
+                + b'\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n',
+                {"Content-Type": "text/event-stream"},
+            )
+        return _anthropic_native_success("claude-controlled")
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/claude-controlled"],
+    ) as (client, upstream):
+        for stream in (False, True):
+            payload = {
+                "model": "github-copilot/claude-controlled",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 4096,
+                "stream": stream,
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+                "output_config": {"effort": "high"},
+            }
+            response = client.post("/api/anthropic/beta/v1/messages", json=payload)
+            assert response.status_code == 200, response.text
+
+    attempts = [r for r in upstream.requests if r.path == "/v1/messages"]
+    assert len(attempts) == 2
+    for stream, request in zip((False, True), attempts, strict=True):
+        assert_exact_outbound_payload(
+            request.payload,
+            {
+                "model": "claude-controlled",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 4096,
+                "stream": stream,
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+                "output_config": {"effort": "high"},
+            },
+        )
+
+
+def test_standard_anthropic_enabled_budget_effort_payload_is_exact_in_both_modes(
+    tmp_path: Path,
+):
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("claude-controlled", endpoints=["/chat/completions"]))
+        if request.payload["stream"]:
+            return _sse_reply(
+                {
+                    "model": "claude-controlled",
+                    "choices": [{"index": 0, "delta": {"content": "pong"}, "finish_reason": None}],
+                },
+                {
+                    "model": "claude-controlled",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {
+                        "prompt_tokens": 2,
+                        "completion_tokens": 1,
+                        "total_tokens": 3,
+                    },
+                },
+            )
+        return _chat_success("claude-controlled")
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/claude-controlled"],
+    ) as (client, upstream):
+        for stream in (False, True):
+            response = client.post(
+                "/api/anthropic/v1/messages",
+                json={
+                    "model": "github-copilot/claude-controlled",
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "max_tokens": 4096,
+                    "stream": stream,
+                    "thinking": {"type": "enabled", "budget_tokens": 1024},
+                    "output_config": {"effort": "high"},
+                },
+            )
+            assert response.status_code == 200, response.text
+
+    attempts = [request for request in upstream.requests if request.path == "/chat/completions"]
+    assert len(attempts) == 2
+    for stream, request in zip((False, True), attempts, strict=True):
+        expected = {
+            "model": "claude-controlled",
+            "messages": [{"role": "user", "content": "ping"}],
+            "stream": stream,
+            "max_tokens": 4096,
+            "reasoning_effort": "high",
+        }
+        if stream:
+            expected["stream_options"] = {"include_usage": True}
+        assert_exact_outbound_payload(request.payload, expected)

--- a/integration_tests/test_live_anthropic_beta.py
+++ b/integration_tests/test_live_anthropic_beta.py
@@ -290,11 +290,11 @@ def test_beta_thinking_streaming(client: httpx.Client, chat_model: str):
     assert sig_deltas, "Expected signature_delta events"
 
 
-def test_beta_output_config_effort_precedence(
+def test_beta_enabled_budget_and_output_config_effort(
     client: httpx.Client,
     anthropic_effort_profile: tuple[str, str],
 ):
-    """Native path should preserve effort and remove its conflicting budget."""
+    """Native path preserves enabled thinking, budget, and effort together."""
     model, effort = anthropic_effort_profile
     failures: list[str] = []
 

--- a/integration_tests/test_live_reasoning_matrix.py
+++ b/integration_tests/test_live_reasoning_matrix.py
@@ -100,11 +100,11 @@ def test_anthropic_gpt5_responses_bridge_thinking_budget_matrix(
     assert not failures, "\n".join(failures)
 
 
-def test_anthropic_output_config_effort_precedence(
+def test_anthropic_enabled_budget_and_output_config_effort(
     client: httpx.Client,
     anthropic_effort_profile: tuple[str, str],
 ):
-    """Standard Anthropic path should prefer explicit effort over a low budget."""
+    """Standard Anthropic path accepts enabled thinking, budget, and effort together."""
     model, effort = anthropic_effort_profile
     failures: list[str] = []
 
@@ -300,8 +300,7 @@ def _assert_anthropic_reasoning_result(
     assert_anthropic_usage(usage)
     if not (text.strip() or thinking.strip()):
         assert stop_reason == "max_tokens", data
-        saturation_floor = requested_thinking_budget or requested_max_tokens
-        assert output_tokens >= saturation_floor, data
+        assert output_tokens > 0, data
 
 
 def _assert_openai_reasoning_result(data: dict[str, Any]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,25 +31,13 @@ dependencies = [
     "httpx[socks]>=0.26.0",
     "h2>=4.0.0",
 
-    # Data Validation
+    # Data validation
     "pydantic>=2.5.0",
-    "pydantic-settings>=2.1.0",
-
-    # OAuth
-    "authlib>=1.3.0",
 
     # Token Counting
     "tiktoken>=0.5.0",
 
-    # Anthropic SDK
-    "anthropic>=0.40.0",
-
-    # Visualization
-    "plotext>=5.2.0",
-
     # Utils
-    "aiosqlite>=0.19.0",
-    "python-dotenv>=1.0.0",
     "prometheus-client>=0.20.0",
 
     # TOML writing (for Codex config generation)
@@ -63,7 +51,6 @@ dependencies = [
 dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.23.0",
-    "pyinstaller>=6.3.0",
     "ruff>=0.1.0",
 ]
 

--- a/src/router_maestro/pipeline/__init__.py
+++ b/src/router_maestro/pipeline/__init__.py
@@ -1,14 +1,19 @@
-"""Unified stream processing pipeline.
-
-Provides guards (leak detection, runaway protection) and audit tracing
-via a single RequestPipeline that all routes share.
-"""
+"""Unified request processing pipeline."""
 
 from router_maestro.pipeline.guards import (
+    GuardChain,
+    GuardTextKind,
     StreamGuard,
     build_guards,
     guarded_stream,
 )
 from router_maestro.pipeline.request_pipeline import RequestPipeline
 
-__all__ = ["RequestPipeline", "StreamGuard", "build_guards", "guarded_stream"]
+__all__ = [
+    "GuardChain",
+    "GuardTextKind",
+    "RequestPipeline",
+    "StreamGuard",
+    "build_guards",
+    "guarded_stream",
+]

--- a/src/router_maestro/pipeline/guards.py
+++ b/src/router_maestro/pipeline/guards.py
@@ -1,29 +1,34 @@
-"""Stream guard protocol and pipeline wrapper."""
+"""Canonical stream-guard dispatch and compatibility helpers."""
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, AsyncIterator
-from typing import Protocol
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable
+from enum import StrEnum
+from typing import Protocol, TypeVar
 
-from router_maestro.providers.base import ChatStreamChunk
-from router_maestro.utils import get_logger
+from router_maestro.config.priorities import GuardsConfig
+from router_maestro.providers.base import ChatStreamChunk, ResponsesStreamChunk
 
-logger = get_logger("pipeline.guards")
+GuardChunk = ChatStreamChunk | ResponsesStreamChunk
+
+
+class GuardTextKind(StrEnum):
+    """Classification for human-visible text carried by a stream chunk."""
+
+    CONTENT = "content"
+    REFUSAL = "refusal"
+    THINKING = "thinking"
 
 
 class StreamGuard(Protocol):
-    """Protocol for streaming response guards.
+    """Contract implemented by stateful, per-request stream guards."""
 
-    A guard inspects each chunk and can signal abort by returning an abort
-    reason string. Guards are stateful per-stream (created fresh per request).
-    """
-
-    def feed_chunk(self, chunk: ChatStreamChunk) -> str | None:
-        """Process a chunk. Return abort reason to stop the stream, else None."""
+    def feed_chunk(self, chunk: GuardChunk) -> str | None:
+        """Inspect one typed chunk and return an abort reason when tripped."""
         ...
 
     def feed_text(self, text: str) -> str | None:
-        """Process raw text content. Return abort reason if triggered."""
+        """Inspect one human-visible text delta and return an abort reason."""
         ...
 
 
@@ -36,39 +41,99 @@ class GuardAbortError(Exception):
         super().__init__(f"{guard_name}: {reason}")
 
 
-async def guarded_stream(
-    inner: AsyncIterator[ChatStreamChunk],
-    guards: list[StreamGuard],
-) -> AsyncGenerator[tuple[ChatStreamChunk, str | None], None]:
-    """Wrap a provider stream with guards.
+_GuardT = TypeVar("_GuardT", bound=StreamGuard)
 
-    Yields (chunk, abort_reason) tuples. When a guard trips, the final
-    tuple has a non-None abort_reason and iteration stops. The caller is
-    responsible for emitting the appropriate error event for its API surface.
+
+class GuardChain:
+    """Own ordered dispatch across the guards for one response stream.
+
+    Chunk-aware guards see the complete typed payload once. Human-readable
+    ``content``, ``refusal``, and ``thinking`` deltas are then sent to that
+    guard's text scanner exactly once. Opaque signatures, reasoning IDs, and
+    structured tool arguments deliberately remain chunk-only payloads.
     """
-    async for chunk in inner:
-        abort_reason: str | None = None
-        for guard in guards:
+
+    __slots__ = ("_guards",)
+
+    def __init__(self, guards: Iterable[StreamGuard] = ()) -> None:
+        self._guards = tuple(guards)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: GuardsConfig,
+        *,
+        model: str,
+        tool_names: set[str] | None = None,
+    ) -> GuardChain:
+        """Build from the guards section of an already captured config snapshot."""
+        return cls(
+            build_guards(
+                model=model,
+                tool_names=tool_names,
+                leak_guard_enabled=config.leak_guard.enabled,
+                runaway_guard_enabled=config.runaway_guard.enabled,
+                runaway_max_bytes=config.runaway_guard.max_bytes,
+                runaway_max_deltas=config.runaway_guard.max_deltas,
+            )
+        )
+
+    def find(self, guard_type: type[_GuardT]) -> _GuardT | None:
+        """Return the first guard of ``guard_type``, if the chain contains one."""
+        for guard in self._guards:
+            if isinstance(guard, guard_type):
+                return guard
+        return None
+
+    def feed_chunk(self, chunk: GuardChunk) -> str | None:
+        """Dispatch one chunk in guard order, stopping at the first abort."""
+        visible_text = tuple(
+            (kind, value)
+            for kind in GuardTextKind
+            if isinstance((value := getattr(chunk, kind.value, None)), str) and value
+        )
+        for guard in self._guards:
             reason = guard.feed_chunk(chunk)
             if reason:
-                abort_reason = reason
-                break
-            if chunk.content:
-                reason = guard.feed_text(chunk.content)
+                return reason
+            feed_visible_text = getattr(guard, "feed_visible_text", None)
+            for kind, text in visible_text:
+                if callable(feed_visible_text):
+                    reason = feed_visible_text(text, kind)
+                elif kind is GuardTextKind.CONTENT:
+                    # Preserve the legacy StreamGuard contract: third-party
+                    # guards historically received only ``chunk.content``.
+                    reason = guard.feed_text(text)
+                else:
+                    continue
                 if reason:
-                    abort_reason = reason
-                    break
+                    return reason
+        return None
 
+    def feed_text(self, text: str) -> str | None:
+        """Dispatch raw human-visible text in guard order."""
+        for guard in self._guards:
+            reason = guard.feed_text(text)
+            if reason:
+                return reason
+        return None
+
+
+async def guarded_stream(
+    inner: AsyncIterator[ChatStreamChunk],
+    guards: Iterable[StreamGuard] | GuardChain,
+) -> AsyncGenerator[tuple[ChatStreamChunk, str | None], None]:
+    """Yield legacy ``(chunk, abort_reason)`` tuples through ``GuardChain``.
+
+    This compatibility wrapper remains available for external callers. New
+    Router-Maestro code should own a chain through ``RequestPipeline``.
+    """
+    chain = guards if isinstance(guards, GuardChain) else GuardChain(guards)
+    async for chunk in inner:
+        abort_reason = chain.feed_chunk(chunk)
+        yield chunk, abort_reason
         if abort_reason:
-            logger.warning(
-                "Stream guard triggered: reason=%s model=%s",
-                abort_reason,
-                chunk.model or "unknown",
-            )
-            yield chunk, abort_reason
             return
-
-        yield chunk, None
 
 
 def build_guards(
@@ -80,16 +145,23 @@ def build_guards(
     runaway_max_bytes: int = 10_000_000,
     runaway_max_deltas: int = 50_000,
 ) -> list[StreamGuard]:
-    """Build the appropriate guard chain based on configuration."""
+    """Build the legacy guard list without loading runtime configuration.
+
+    ``model`` remains in the compatibility signature for third-party callers;
+    the current guards are model-independent. New internal code should use
+    :meth:`GuardChain.from_config` with its request-scoped config snapshot.
+    """
     from router_maestro.pipeline.leak_guard import LeakGuard
     from router_maestro.pipeline.runaway_guard import RunawayGuard
 
     guards: list[StreamGuard] = []
-
     if leak_guard_enabled:
         guards.append(LeakGuard(allowed_tool_names=tool_names))
-
     if runaway_guard_enabled:
-        guards.append(RunawayGuard(max_bytes=runaway_max_bytes, max_deltas=runaway_max_deltas))
-
+        guards.append(
+            RunawayGuard(
+                max_bytes=runaway_max_bytes,
+                max_deltas=runaway_max_deltas,
+            )
+        )
     return guards

--- a/src/router_maestro/pipeline/leak_guard.py
+++ b/src/router_maestro/pipeline/leak_guard.py
@@ -25,8 +25,7 @@ accumulating the full response text. Memory is O(max_tag_length), not O(response
 Invoke recovery still accumulates text (it needs the full content at finish).
 """
 
-import json
-
+from router_maestro.pipeline.guards import GuardTextKind
 from router_maestro.providers.base import ChatStreamChunk
 from router_maestro.providers.tool_parsing import recover_invoke_tool_calls
 from router_maestro.utils import get_logger
@@ -47,6 +46,18 @@ _CONTROL_TAGS: list[tuple[str, str, str]] = [
     ("<cross-session-message", "</cross-session-message>", "cross-session-message"),
     ("<tick>", "</tick>", "tick"),
 ]
+
+
+class _VisibleTextScanner:
+    """Independent control-envelope and code-fence state for one text kind."""
+
+    def __init__(self) -> None:
+        self.in_fence = False
+        self.backtick_run = 0
+        self.matchers = [
+            _TagMatcher(open_prefix, close_tag, tag_name)
+            for open_prefix, close_tag, tag_name in _CONTROL_TAGS
+        ]
 
 
 class _TagMatcher:
@@ -192,14 +203,7 @@ class LeakGuard:
         self._tool_names = allowed_tool_names
         self._tripped = False
         self._trip_reason: str | None = None
-        self._in_fence = False
-        self._backtick_run = 0
-
-        # Character-fed matchers for control envelopes
-        self._matchers = [
-            _TagMatcher(open_prefix, close_tag, tag_name)
-            for open_prefix, close_tag, tag_name in _CONTROL_TAGS
-        ]
+        self._scanners = {kind: _VisibleTextScanner() for kind in GuardTextKind}
 
         # Invoke recovery still needs accumulated text
         self._invoke_text = ""
@@ -208,28 +212,35 @@ class LeakGuard:
         return None
 
     def feed_text(self, text: str) -> str | None:
-        """Feed a text delta. Returns abort reason if control envelope detected."""
+        """Feed recoverable content text using the compatibility API."""
+        return self.feed_visible_text(text, GuardTextKind.CONTENT)
+
+    def feed_visible_text(self, text: str, kind: GuardTextKind) -> str | None:
+        """Control-scan visible text while recovering invokes from content only."""
         if self._tripped:
             return self._trip_reason
 
-        # Accumulate for invoke recovery (unavoidable — recovery needs full text)
-        self._invoke_text += text
+        if kind is GuardTextKind.CONTENT:
+            # Recovery needs complete ordinary content, but private thinking and
+            # refusal text must never be promoted to downstream tool calls.
+            self._invoke_text += text
 
+        scanner = self._scanners[kind]
         # Feed character-by-character to matchers
         for c in text:
             # Track code fences (``` toggles)
             if c == "`":
-                self._backtick_run += 1
+                scanner.backtick_run += 1
             else:
-                if self._backtick_run >= 3:
-                    self._in_fence = not self._in_fence
-                self._backtick_run = 0
+                if scanner.backtick_run >= 3:
+                    scanner.in_fence = not scanner.in_fence
+                scanner.backtick_run = 0
 
             # Skip detection inside code fences
-            if self._in_fence:
+            if scanner.in_fence:
                 continue
 
-            for matcher in self._matchers:
+            for matcher in scanner.matchers:
                 if matcher.feed(c):
                     self._tripped = True
                     self._trip_reason = f"response_leak:control_envelope:{matcher.tag_name}"
@@ -250,44 +261,3 @@ class LeakGuard:
     @property
     def accumulated_text(self) -> str:
         return self._invoke_text
-
-
-class RawFrameLeakGuard:
-    """Leak guard for the anthropic_beta passthrough route.
-
-    Operates on raw SSE frame data strings. Extracts text from
-    content_block_delta events and feeds them to an inner LeakGuard.
-    """
-
-    def __init__(
-        self,
-        allowed_tool_names: set[str] | None = None,
-        *,
-        inner: LeakGuard | None = None,
-    ):
-        self._inner = inner or LeakGuard(allowed_tool_names=allowed_tool_names)
-
-    def feed_frame(self, event_type: str, data_str: str) -> str | None:
-        """Feed a raw SSE frame. Returns abort reason if leak detected."""
-        if event_type != "content_block_delta":
-            return None
-
-        text = self._extract_text(data_str)
-        if text:
-            return self._inner.feed_text(text)
-        return None
-
-    @staticmethod
-    def _extract_text(data_str: str) -> str | None:
-        """Extract text content from a content_block_delta payload."""
-        try:
-            data = json.loads(data_str)
-            delta = data.get("delta", {})
-            delta_type = delta.get("type", "")
-            if delta_type == "text_delta":
-                return delta.get("text")
-            if delta_type == "thinking_delta":
-                return delta.get("thinking")
-        except (json.JSONDecodeError, TypeError, AttributeError):
-            pass
-        return None

--- a/src/router_maestro/pipeline/request_pipeline.py
+++ b/src/router_maestro/pipeline/request_pipeline.py
@@ -25,8 +25,8 @@ from typing import Any
 
 from router_maestro.config import load_priorities_config
 from router_maestro.config.priorities import PrioritiesConfig
+from router_maestro.pipeline.guards import GuardChain, StreamGuard
 from router_maestro.pipeline.leak_guard import LeakGuard
-from router_maestro.pipeline.runaway_guard import RunawayGuard
 from router_maestro.providers.base import TerminalOutcome
 from router_maestro.utils import get_logger
 from router_maestro.utils.audit import AuditTrace, get_trace_dir, is_tracing_enabled
@@ -42,7 +42,7 @@ class RequestPipeline:
     """
 
     __slots__ = (
-        "_guards",
+        "_guard_chain",
         "_audit",
         "_leak_guard",
         "_config",
@@ -56,7 +56,7 @@ class RequestPipeline:
     def __init__(
         self,
         request_id: str,
-        guards: list,
+        guards: list[StreamGuard] | GuardChain,
         leak_guard: LeakGuard | None,
         audit: AuditTrace | None,
         config: PrioritiesConfig,
@@ -64,7 +64,7 @@ class RequestPipeline:
         defer_flush: bool = False,
     ):
         self._request_id = request_id
-        self._guards = guards
+        self._guard_chain = guards if isinstance(guards, GuardChain) else GuardChain(guards)
         self._leak_guard = leak_guard
         self._audit = audit
         self._config = config
@@ -92,22 +92,12 @@ class RequestPipeline:
             return context.pipeline
 
         config = context.config if context is not None else load_priorities_config()
-        guards_cfg = config.guards
-
-        guards: list = []
-        leak_guard: LeakGuard | None = None
-
-        if guards_cfg.leak_guard.enabled:
-            leak_guard = LeakGuard(allowed_tool_names=tool_names)
-            guards.append(leak_guard)
-
-        if guards_cfg.runaway_guard.enabled:
-            guards.append(
-                RunawayGuard(
-                    max_bytes=guards_cfg.runaway_guard.max_bytes,
-                    max_deltas=guards_cfg.runaway_guard.max_deltas,
-                )
-            )
+        guard_chain = GuardChain.from_config(
+            config.guards,
+            model=model,
+            tool_names=tool_names,
+        )
+        leak_guard = guard_chain.find(LeakGuard)
 
         audit = context.audit if context is not None else None
         if context is None and is_tracing_enabled(config.audit.enabled):
@@ -116,7 +106,7 @@ class RequestPipeline:
 
         pipeline = cls(
             request_id=request_id,
-            guards=guards,
+            guards=guard_chain,
             leak_guard=leak_guard,
             audit=audit,
             config=config,
@@ -147,10 +137,6 @@ class RequestPipeline:
     def wire_status(self) -> int | None:
         """Return the HTTP status recorded by the first finalization."""
         return self._wire_status
-
-    @property
-    def beta_strip_patterns(self) -> list[str]:
-        return self._config.beta_strip
 
     def record_inbound(
         self,
@@ -194,24 +180,11 @@ class RequestPipeline:
         Returns an abort reason string if any guard trips, else None.
         Works with both ChatStreamChunk and ResponsesStreamChunk.
         """
-        for guard in self._guards:
-            reason = guard.feed_chunk(chunk)
-            if reason:
-                return reason
-            content = getattr(chunk, "content", None)
-            if content:
-                reason = guard.feed_text(content)
-                if reason:
-                    return reason
-        return None
+        return self._guard_chain.feed_chunk(chunk)
 
     def feed_text(self, text: str) -> str | None:
         """Feed raw text (for passthrough routes that don't use ChatStreamChunk)."""
-        for guard in self._guards:
-            reason = guard.feed_text(text)
-            if reason:
-                return reason
-        return None
+        return self._guard_chain.feed_text(text)
 
     def check_invoke_at_finish(self) -> list[dict] | None:
         """Check for recoverable invoke leaks at stream end."""

--- a/src/router_maestro/pipeline/runaway_guard.py
+++ b/src/router_maestro/pipeline/runaway_guard.py
@@ -33,6 +33,10 @@ class RunawayGuard:
 
     def feed_chunk(self, chunk) -> str | None:
         """Feed a chunk and check volume thresholds."""
+        opaque_payload = getattr(chunk, "opaque_payload", None)
+        if isinstance(opaque_payload, str) and opaque_payload:
+            return self._record_payloads([opaque_payload])
+
         payloads: list[str] = []
         has_payload_event = False
         for field in (
@@ -68,6 +72,10 @@ class RunawayGuard:
 
         if not has_payload_event:
             return None
+        return self._record_payloads(payloads)
+
+    def _record_payloads(self, payloads: list[str]) -> str | None:
+        """Record one logical emitted payload event and apply circuit-breaker limits."""
         self._delta_count += 1
         self._total_bytes += sum(len(payload.encode("utf-8")) for payload in payloads)
 

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -376,6 +376,9 @@ class ChatStreamChunk:
     terminal_outcome: TerminalOutcome | None = None
     # OpenAI refusal delta. Appended to preserve the legacy positional constructor.
     refusal: str | None = None
+    # Internal-only payload projection for forward-compatible protocol events.
+    # Routes never emit this field; RunawayGuard counts its serialized bytes.
+    opaque_payload: str | None = None
 
 
 @dataclass

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -741,20 +741,15 @@ async def _encode_native_stream_errors(
     """Apply raw stream guards and preserve native semantic terminal state."""
     terminal_outcome: TerminalOutcome | None = None
     response_status = ResponseStatus.COMPLETED
-    raw_leak_guard = None
-    if pipeline is not None and pipeline.leak_guard is not None:
-        from router_maestro.pipeline.leak_guard import RawFrameLeakGuard
-
-        raw_leak_guard = RawFrameLeakGuard(inner=pipeline.leak_guard)
     try:
         async for frame in stream:
             event_type, data = _parse_native_frame(frame)
             if pipeline is not None:
                 abort_reason = _feed_native_frame_guards(
                     pipeline,
-                    raw_leak_guard,
                     event_type,
                     data,
+                    frame,
                 )
                 if abort_reason is not None:
                     terminal_outcome = exception_outcome(abort_reason, code="overloaded")
@@ -855,35 +850,161 @@ def _parse_native_frame(frame: str) -> tuple[str | None, dict | None]:
 
 def _feed_native_frame_guards(
     pipeline,
-    raw_leak_guard,
     event_type: str | None,
     data: dict | None,
+    wire_frame: str,
 ) -> str | None:
-    """Project native content deltas onto the shared guard input contract."""
-    if event_type != "content_block_delta" or data is None:
-        return None
-    delta = data.get("delta")
-    if not isinstance(delta, dict):
-        return None
+    """Project payload-bearing native events onto the shared guard contract."""
+    for chunk in _native_guard_chunks(event_type, data, wire_frame):
+        abort_reason = pipeline.feed_stream(chunk)
+        if abort_reason is not None:
+            return abort_reason
+    return None
+
+
+def _native_guard_chunks(
+    event_type: str | None,
+    data: dict | None,
+    wire_frame: str,
+):
+    """Project one raw frame into visible fields plus exact wire-volume payload."""
     from router_maestro.providers.base import ChatStreamChunk
 
+    if data is None:
+        return []
+
+    if not _native_frame_has_guard_payload(event_type, data):
+        return []
+
+    if event_type == "message_start":
+        message = data.get("message")
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            return [ChatStreamChunk(content="", opaque_payload=wire_frame)]
+        chunks = [
+            chunk
+            for block in content
+            if isinstance(block, dict)
+            for chunk in _native_content_block_guard_chunks(block)
+        ]
+        return [_combine_native_guard_chunks(chunks, wire_frame)]
+
+    if event_type == "content_block_start":
+        block = data.get("content_block")
+        chunks = _native_content_block_guard_chunks(block) if isinstance(block, dict) else []
+        return [_combine_native_guard_chunks(chunks, wire_frame)]
+
+    if event_type != "content_block_delta":
+        return [ChatStreamChunk(content="", opaque_payload=wire_frame)]
+    delta = data.get("delta")
+    if not isinstance(delta, dict):
+        return [ChatStreamChunk(content="", opaque_payload=wire_frame)]
     delta_type = delta.get("type")
     if delta_type == "text_delta":
-        chunk = ChatStreamChunk(content=delta.get("text", ""))
-    elif delta_type == "thinking_delta":
-        if raw_leak_guard is not None:
-            leak_reason = raw_leak_guard.feed_frame(event_type, json.dumps(data))
-            if leak_reason is not None:
-                return leak_reason
-        chunk = ChatStreamChunk(content="", thinking=delta.get("thinking", ""))
-    elif delta_type == "input_json_delta":
-        chunk = ChatStreamChunk(
-            content="",
-            tool_calls=[{"function": {"arguments": delta.get("partial_json", "")}}],
+        return [ChatStreamChunk(content=delta.get("text", ""), opaque_payload=wire_frame)]
+    if delta_type == "thinking_delta":
+        return [
+            ChatStreamChunk(
+                content="",
+                thinking=delta.get("thinking", ""),
+                opaque_payload=wire_frame,
+            )
+        ]
+    if delta_type == "signature_delta":
+        return [
+            ChatStreamChunk(
+                content="",
+                thinking_signature=delta.get("signature", ""),
+                opaque_payload=wire_frame,
+            )
+        ]
+    if delta_type == "input_json_delta":
+        return [
+            ChatStreamChunk(
+                content="",
+                tool_calls=[{"function": {"arguments": delta.get("partial_json", "")}}],
+                opaque_payload=wire_frame,
+            )
+        ]
+    return [ChatStreamChunk(content="", opaque_payload=wire_frame)]
+
+
+def _native_content_block_guard_chunks(block: dict):
+    """Project one initial native content block without scanning opaque payloads."""
+    from router_maestro.providers.base import ChatStreamChunk
+
+    block_type = block.get("type")
+    if block_type == "text":
+        return [ChatStreamChunk(content=block.get("text", ""))]
+    if block_type == "thinking":
+        return [
+            ChatStreamChunk(
+                content="",
+                thinking=block.get("thinking", ""),
+                thinking_signature=block.get("signature"),
+            )
+        ]
+    if block_type == "redacted_thinking":
+        return [ChatStreamChunk(content="", thinking_signature=block.get("data", ""))]
+    if block_type == "tool_use":
+        tool_input = block.get("input")
+        if not isinstance(tool_input, dict):
+            return []
+        return [
+            ChatStreamChunk(
+                content="",
+                tool_calls=[
+                    {
+                        "function": {
+                            "arguments": json.dumps(
+                                tool_input,
+                                ensure_ascii=False,
+                                separators=(",", ":"),
+                            )
+                        }
+                    }
+                ],
+            )
+        ]
+    return []
+
+
+def _combine_native_guard_chunks(chunks, wire_frame: str):
+    """Collapse initial block projections so one emitted frame is counted once."""
+    from router_maestro.providers.base import ChatStreamChunk
+
+    if not chunks:
+        return ChatStreamChunk(content="", opaque_payload=wire_frame)
+    return ChatStreamChunk(
+        content="".join(chunk.content for chunk in chunks if chunk.content),
+        thinking="".join(chunk.thinking for chunk in chunks if chunk.thinking) or None,
+        thinking_signature="".join(
+            chunk.thinking_signature for chunk in chunks if chunk.thinking_signature
         )
-    else:
-        return None
-    return pipeline.feed_stream(chunk)
+        or None,
+        tool_calls=[tool_call for chunk in chunks for tool_call in (chunk.tool_calls or [])]
+        or None,
+        opaque_payload=wire_frame,
+    )
+
+
+def _native_frame_has_guard_payload(event_type: str | None, data: dict) -> bool:
+    """Select emitted frames that carry output or forward-compatible extensions."""
+    if event_type in {
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "message_delta",
+        "error",
+    }:
+        return True
+    baseline_fields = {
+        "content_block_stop": {"type", "index"},
+        "message_stop": {"type"},
+        "ping": {"type"},
+    }
+    baseline = baseline_fields.get(event_type)
+    return baseline is not None and bool(set(data) - baseline)
 
 
 def _native_frame_outcome(

--- a/src/router_maestro/server/translation.py
+++ b/src/router_maestro/server/translation.py
@@ -3,12 +3,10 @@
 import json
 import re
 
-from router_maestro.providers import ChatRequest, ChatStreamChunk, Message
-from router_maestro.server.protocols.anthropic_reducer import AnthropicReducer
+from router_maestro.providers import ChatRequest, Message
 from router_maestro.server.schemas.anthropic import (
     AnthropicAssistantMessage,
     AnthropicMessagesRequest,
-    AnthropicStreamState,
     AnthropicTextBlock,
     AnthropicUserMessage,
 )
@@ -388,52 +386,3 @@ def _extract_multimodal_content(blocks: list) -> str | list:
     content_parts.extend(image_parts)
 
     return content_parts
-
-
-def translate_openai_chunk_to_anthropic_events(
-    chunk: dict, state: AnthropicStreamState, model: str
-) -> list[dict]:
-    """Adapt a legacy OpenAI chunk dict to the canonical Anthropic reducer."""
-    if state.message_complete:
-        return []
-
-    reducer = AnthropicReducer(
-        response_id=chunk.get("id", ""),
-        model=model,
-        state=state,
-    )
-    choices = chunk.get("choices") or []
-    if not choices:
-        reducer.observe_usage(chunk.get("usage"))
-        return []
-
-    choice = choices[0]
-    delta = choice.get("delta") or {}
-    thinking = None
-    for key in ("reasoning_text", "cot_summary", "thinking"):
-        value = delta.get(key)
-        if isinstance(value, str) and value:
-            thinking = value
-            break
-        if isinstance(value, dict):
-            inner = value.get("text") or value.get("content")
-            if isinstance(inner, str) and inner:
-                thinking = inner
-                break
-    thinking_signature = None
-    for key in ("reasoning_opaque", "cot_id", "signature"):
-        value = delta.get(key)
-        if isinstance(value, str) and value:
-            thinking_signature = value
-            break
-    return reducer.reduce(
-        ChatStreamChunk(
-            content=delta.get("content") or "",
-            refusal=delta.get("refusal") or None,
-            finish_reason=choice.get("finish_reason"),
-            usage=chunk.get("usage"),
-            tool_calls=delta.get("tool_calls"),
-            thinking=thinking,
-            thinking_signature=thinking_signature,
-        )
-    )

--- a/src/router_maestro/utils/audit.py
+++ b/src/router_maestro/utils/audit.py
@@ -1,13 +1,16 @@
 """Per-request audit tracing.
 
-When enabled, captures the full request/response cycle for each API call
-as JSON files for debugging. Each request gets a directory under the trace
-dir containing up to 4 files:
+When enabled, captures the request/response lifecycle for each API call as JSON
+files for debugging. Each request gets a directory under the trace directory;
+early failures may omit upstream records, while retries and fallback add
+independently numbered upstream request and response observations:
 
     {trace_dir}/{request_id}/
         inbound.json        — client request (method, path, headers, body)
-        upstream.json       — request sent to provider
-        upstream_resp.json  — provider response (status, headers, body summary)
+        upstream.json, upstream_2.json, ...
+                           — requests sent to providers, in observation order
+        upstream_resp.json, upstream_resp_2.json, ...
+                           — responses received, independently numbered
         outbound.json       — response sent to client
 
 Activation:

--- a/src/router_maestro/utils/reasoning.py
+++ b/src/router_maestro/utils/reasoning.py
@@ -27,10 +27,6 @@ EFFORT_TO_BUDGET: dict[str, int] = {
 EFFORT_ORDER: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh", "max")
 VALID_EFFORTS: tuple[str, ...] = EFFORT_ORDER
 
-# Effort tiers eligible for transparent variant rewriting (e.g. claude-opus-4.7
-# → claude-opus-4.7-high). low/medium are passed through as reasoning_effort.
-VARIANT_EFFORTS: tuple[str, ...] = ("high", "xhigh", "max")
-
 # Effort levels that vanilla OpenAI / Copilot upstreams accept directly.
 UPSTREAM_NATIVE_EFFORTS: tuple[str, ...] = ("minimal", "low", "medium", "high")
 

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -1223,7 +1223,7 @@ class TestBetaMessagesEndpoint:
             assert context.pipeline.outcome.response_status is ResponseStatus.COMPLETED
 
     @pytest.mark.asyncio
-    async def test_native_stream_with_both_guards_disabled_never_invokes_raw_leak_guard(self):
+    async def test_native_stream_with_both_guards_disabled_passes_payloads_through(self):
         from router_maestro.pipeline import RequestPipeline
 
         config = _guard_config(leak_enabled=False, runaway_enabled=False)
@@ -1249,17 +1249,13 @@ class TestBetaMessagesEndpoint:
             yield f"event: content_block_delta\ndata: {json.dumps(payload)}\n\n"
             yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
 
-        with patch(
-            "router_maestro.pipeline.leak_guard.RawFrameLeakGuard",
-            side_effect=AssertionError("disabled leak guard must not be constructed"),
-        ):
-            frames = [
-                frame
-                async for frame in _encode_native_stream_errors(
-                    stream(),
-                    pipeline=pipeline,
-                )
-            ]
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
 
         assert [
             line.removeprefix("event: ")
@@ -1363,6 +1359,329 @@ class TestBetaMessagesEndpoint:
         ] == ["error"]
         assert pipeline.outcome is not None
         assert pipeline.outcome.error.code == "overloaded"
+
+    @pytest.mark.parametrize(
+        ("event_type", "payload"),
+        [
+            pytest.param(
+                "message_start",
+                {
+                    **_VALID_MESSAGE_START,
+                    "message": {
+                        **_VALID_MESSAGE_START["message"],
+                        "content": [{"type": "text", "text": "x" * 100_001}],
+                    },
+                },
+                id="message-start-text",
+            ),
+            pytest.param(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "thinking", "thinking": "x" * 100_001},
+                },
+                id="content-block-start-thinking",
+            ),
+            pytest.param(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "redacted_thinking", "data": "x" * 100_001},
+                },
+                id="content-block-start-redacted-thinking",
+            ),
+            pytest.param(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "lookup",
+                        "input": {"value": "x" * 100_001},
+                    },
+                },
+                id="content-block-start-tool-input",
+            ),
+            pytest.param(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "signature_delta", "signature": "x" * 100_001},
+                },
+                id="signature-delta",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_runaway_guard_covers_all_payload_bearing_raw_events(
+        self,
+        event_type,
+        payload,
+    ):
+        from router_maestro.pipeline import RequestPipeline
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=True)
+        context = _CapturedGuardContext([config])
+        with patch(
+            "router_maestro.runtime.request_context.get_current_request_context",
+            return_value=context,
+        ):
+            pipeline = RequestPipeline.create(
+                request_id="req-raw-payload",
+                model="guarded-model",
+            )
+
+        async def stream():
+            yield f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert [
+            line.removeprefix("event: ")
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("event: ")
+        ] == ["error"]
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.error.code == "overloaded"
+
+    @pytest.mark.parametrize(
+        ("event_type", "payload"),
+        [
+            pytest.param(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "future_block",
+                        "future": "x" * 100_001,
+                    },
+                },
+                id="future-block",
+            ),
+            pytest.param(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "future_delta",
+                        "future": "x" * 100_001,
+                    },
+                },
+                id="future-delta",
+            ),
+            pytest.param(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "text",
+                        "text": "small",
+                        "future": "x" * 100_001,
+                    },
+                },
+                id="known-block-extension",
+            ),
+            pytest.param(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "text_delta",
+                        "text": "small",
+                        "future": "x" * 100_001,
+                    },
+                },
+                id="known-delta-extension",
+            ),
+            pytest.param(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": None, "stop_sequence": None},
+                    "usage": {"output_tokens": 1},
+                    "future": "x" * 100_001,
+                },
+                id="top-level-extension",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_runaway_guard_counts_forward_compatible_payloads(
+        self,
+        event_type,
+        payload,
+    ):
+        from router_maestro.pipeline import RequestPipeline
+
+        config = _guard_config(leak_enabled=False, runaway_enabled=True)
+        context = _CapturedGuardContext([config])
+        with patch(
+            "router_maestro.runtime.request_context.get_current_request_context",
+            return_value=context,
+        ):
+            pipeline = RequestPipeline.create(
+                request_id="req-future-native-payload",
+                model="guarded-model",
+            )
+
+        async def stream():
+            yield f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert [
+            line.removeprefix("event: ")
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("event: ")
+        ] == ["error"]
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.error.code == "overloaded"
+
+    @pytest.mark.parametrize(
+        ("event_type", "payload"),
+        [
+            pytest.param(
+                "message_start",
+                {
+                    **_VALID_MESSAGE_START,
+                    "message": {
+                        **_VALID_MESSAGE_START["message"],
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "<tick>private control</tick>",
+                            }
+                        ],
+                    },
+                },
+                id="message-start-thinking",
+            ),
+            pytest.param(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "text",
+                        "text": "<tick>private control</tick>",
+                    },
+                },
+                id="content-block-start-text",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_native_leak_guard_scans_human_readable_start_payloads(
+        self,
+        event_type,
+        payload,
+    ):
+        from router_maestro.pipeline import RequestPipeline
+
+        config = _guard_config(leak_enabled=True, runaway_enabled=False)
+        context = _CapturedGuardContext([config])
+        with patch(
+            "router_maestro.runtime.request_context.get_current_request_context",
+            return_value=context,
+        ):
+            pipeline = RequestPipeline.create(
+                request_id="req-raw-start-leak",
+                model="guarded-model",
+            )
+
+        async def stream():
+            yield f"event: {event_type}\ndata: {json.dumps(payload)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert [
+            line.removeprefix("event: ")
+            for frame in frames
+            for line in frame.splitlines()
+            if line.startswith("event: ")
+        ] == ["error"]
+        assert pipeline.outcome is not None
+        assert pipeline.outcome.error.code == "overloaded"
+
+    @pytest.mark.asyncio
+    async def test_native_guard_projection_feeds_each_payload_once(self):
+        class RecordingPipeline:
+            def __init__(self):
+                self.chunks = []
+
+            def feed_stream(self, chunk):
+                self.chunks.append(chunk)
+                return None
+
+            def finish(self, *, wire_status, outcome, body_summary=None):
+                return None
+
+        pipeline = RecordingPipeline()
+        start = {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "thinking",
+                "thinking": "visible",
+                "signature": "opaque",
+            },
+        }
+        signature = {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "more-opaque"},
+        }
+
+        async def stream():
+            yield f"event: content_block_start\ndata: {json.dumps(start)}\n\n"
+            yield f"event: content_block_delta\ndata: {json.dumps(signature)}\n\n"
+            yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        frames = [
+            frame
+            async for frame in _encode_native_stream_errors(
+                stream(),
+                pipeline=pipeline,
+            )
+        ]
+
+        assert len(frames) == 3
+        assert len(pipeline.chunks) == 2
+        assert pipeline.chunks[0].thinking == "visible"
+        assert pipeline.chunks[0].thinking_signature == "opaque"
+        assert pipeline.chunks[1].thinking_signature == "more-opaque"
 
     @pytest.mark.parametrize(
         ("terminal", "expected_transport", "expected_status", "expected_code"),

--- a/tests/test_anthropic_provider_stream.py
+++ b/tests/test_anthropic_provider_stream.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
-from router_maestro.auth.storage import ApiKeyCredential
+from router_maestro.auth.storage import ApiKeyCredential, AuthStorage
 from router_maestro.providers import ChatRequest, Message
 from router_maestro.providers.anthropic import AnthropicProvider
 
@@ -21,6 +21,7 @@ def _sse(*events: str) -> bytes:
 def _make_provider() -> AnthropicProvider:
     provider = AnthropicProvider()
     # Inject an API key credential so _get_api_key() succeeds.
+    provider.auth_manager.storage = AuthStorage()
     provider.auth_manager.storage.set("anthropic", ApiKeyCredential(key="sk-test"))
     return provider
 

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -3,6 +3,9 @@
 import ast
 import importlib
 import inspect
+import json
+import os
+import subprocess
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -16,6 +19,281 @@ from router_maestro.providers import CopilotProvider, ModelInfo
 from router_maestro.routing.capabilities import Operation
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+class _LivePipe:
+    def __init__(self, process) -> None:
+        self.process = process
+        self.read_calls = 0
+
+    def read(self) -> str:
+        self.read_calls += 1
+        if self.process.returncode is None:
+            raise AssertionError("stdout.read would block while the process is alive")
+        return "controlled startup diagnostic"
+
+
+class _HungStartupProcess:
+    def __init__(self) -> None:
+        self.returncode = None
+        self.terminate_calls = 0
+        self.stdout = _LivePipe(self)
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        self.returncode = -15
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired("router-maestro", timeout)
+        return self.returncode
+
+
+def test_startup_timeout_terminates_before_reading_live_stdout(monkeypatch):
+    conftest = importlib.import_module("integration_tests.conftest")
+    process = _HungStartupProcess()
+    monotonic = iter((0.0, 0.0, 1.0))
+    monkeypatch.setattr(conftest, "STARTUP_TIMEOUT_SECONDS", 0.5)
+    monkeypatch.setattr(conftest.time, "time", lambda: next(monotonic))
+    monkeypatch.setattr(conftest.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        httpx.Client,
+        "get",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(httpx.ConnectError("not ready")),
+    )
+
+    with pytest.raises(pytest.fail.Exception, match="controlled startup diagnostic"):
+        conftest._wait_for_health("http://127.0.0.1:1", process)
+
+    assert process.terminate_calls == 1
+    assert process.returncode == -15
+    assert process.stdout.read_calls == 1
+
+
+def test_startup_exit_reads_diagnostics_without_reterminating(monkeypatch):
+    conftest = importlib.import_module("integration_tests.conftest")
+    process = _HungStartupProcess()
+    process.returncode = 7
+    monkeypatch.setattr(conftest.time, "time", lambda: 0.0)
+
+    with pytest.raises(pytest.fail.Exception, match="controlled startup diagnostic"):
+        conftest._wait_for_health("http://127.0.0.1:1", process)
+
+    assert process.terminate_calls == 0
+    assert process.stdout.read_calls == 1
+
+
+def test_controlled_server_routes_subprocess_output_to_nonblocking_file(tmp_path, monkeypatch):
+    conftest = importlib.import_module("integration_tests.conftest")
+    process = _HungStartupProcess()
+    captured = {}
+
+    def popen(_command, **kwargs):
+        captured.update(kwargs)
+        return process
+
+    monkeypatch.setattr(conftest.subprocess, "Popen", popen)
+    monkeypatch.setattr(conftest, "_wait_for_health", lambda *_args: None)
+    monkeypatch.setattr(conftest, "_terminate_process", lambda *_args: None)
+
+    with conftest.controlled_router_server(
+        tmp_path,
+        providers={},
+        priorities={"priorities": []},
+    ):
+        assert captured["stdout"] is not subprocess.PIPE
+        assert not captured["stdout"].closed
+
+    assert captured["stdout"].closed
+    assert Path(process._router_maestro_output_path).parent == tmp_path
+
+
+def test_controlled_xdg_environment_is_isolated_and_drops_provider_secrets(tmp_path):
+    conftest = importlib.import_module("integration_tests.conftest")
+    source = {
+        "HOME": "/Users/example",
+        "PATH": os.environ.get("PATH", ""),
+        "OPENAI_API_KEY": "must-not-leak",
+        "ANTHROPIC_API_KEY": "must-not-leak",
+        "ROUTER_MAESTRO_API_KEY": "must-be-replaced",
+    }
+
+    env = conftest.controlled_xdg_environment(
+        tmp_path,
+        source=source,
+        api_key="controlled-key",
+    )
+
+    assert env["XDG_CONFIG_HOME"] == str(tmp_path / "config")
+    assert env["XDG_DATA_HOME"] == str(tmp_path / "data")
+    assert env["ROUTER_MAESTRO_API_KEY"] == "controlled-key"
+    assert env["HOME"] == str(tmp_path / "home")
+    assert env["PATH"] == source["PATH"]
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_recorded_request_selector_uses_exact_method_path_and_occurrence():
+    conftest = importlib.import_module("integration_tests.conftest")
+    requests = [
+        conftest.RecordedUpstreamRequest("GET", "/models", None, {}),
+        conftest.RecordedUpstreamRequest("POST", "/responses", {"model": "one"}, {}),
+        conftest.RecordedUpstreamRequest("POST", "/responses", {"model": "two"}, {}),
+    ]
+
+    selected = conftest.select_recorded_request(
+        requests,
+        method="POST",
+        path="/responses",
+        occurrence=1,
+    )
+
+    assert selected.payload == {"model": "two"}
+    with pytest.raises(AssertionError, match="no upstream request matched"):
+        conftest.select_recorded_request(requests, method="POST", path="responses")
+    with pytest.raises(AssertionError, match="occurrence 2"):
+        conftest.select_recorded_request(
+            requests,
+            method="POST",
+            path="/responses",
+            occurrence=2,
+        )
+
+
+def test_exact_outbound_payload_helper_rejects_missing_extra_and_changed_fields():
+    conftest = importlib.import_module("integration_tests.conftest")
+    actual = {"model": "m", "stream": False, "top_p": 0.7}
+
+    conftest.assert_exact_outbound_payload(
+        actual,
+        {"model": "m", "stream": False, "top_p": 0.7},
+    )
+    with pytest.raises(AssertionError, match="exact outbound payload mismatch"):
+        conftest.assert_exact_outbound_payload(actual, {"model": "m", "stream": False})
+    with pytest.raises(AssertionError, match="exact outbound payload mismatch"):
+        conftest.assert_exact_outbound_payload(
+            actual,
+            {"model": "m", "stream": False, "top_p": 0.8},
+        )
+
+
+def test_scripted_upstream_records_exact_json_and_returns_programmed_reply():
+    conftest = importlib.import_module("integration_tests.conftest")
+
+    def responder(request):
+        assert request.headers["authorization"] == "Bearer fake-token"
+        return (
+            200,
+            json.dumps({"received": request.payload}).encode(),
+            {"Content-Type": "application/json"},
+        )
+
+    with conftest.scripted_upstream(responder) as upstream:
+        response = httpx.post(
+            f"{upstream.base_url}/chat/completions?ignored=query",
+            headers={"Authorization": "Bearer fake-token"},
+            json={"model": "m", "stream": False},
+        )
+
+    assert response.json() == {"received": {"model": "m", "stream": False}}
+    recorded = conftest.select_recorded_request(
+        upstream.requests,
+        method="POST",
+        path="/chat/completions",
+    )
+    conftest.assert_exact_outbound_payload(recorded.payload, {"model": "m", "stream": False})
+
+
+def test_controlled_router_server_uses_only_declared_temporary_provider(tmp_path):
+    conftest = importlib.import_module("integration_tests.conftest")
+
+    def responder(request):
+        if request.path == "/chat/completions":
+            return (
+                200,
+                json.dumps(
+                    {
+                        "id": "chatcmpl-fake",
+                        "model": request.payload["model"],
+                        "choices": [
+                            {
+                                "index": 0,
+                                "message": {"role": "assistant", "content": "pong"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2,
+                        },
+                    }
+                ).encode(),
+                {"Content-Type": "application/json"},
+            )
+        return 404, b'{"error":"unexpected"}', {"Content-Type": "application/json"}
+
+    with conftest.scripted_upstream(responder) as upstream:
+        providers = {
+            "fake": {
+                "type": "openai-compatible",
+                "baseURL": upstream.base_url,
+                "models": {"echo": {"name": "Echo"}},
+                "options": {"allow_unauthenticated": True},
+            }
+        }
+        priorities = {
+            "priorities": ["fake/echo"],
+            "fallback": {"strategy": "none", "maxRetries": 0},
+        }
+        with conftest.controlled_router_server(
+            tmp_path,
+            providers=providers,
+            priorities=priorities,
+        ) as server:
+            response = httpx.post(
+                f"{server.base_url}/api/openai/v1/chat/completions",
+                headers={"Authorization": f"Bearer {server.api_key}"},
+                json={
+                    "model": "router-maestro",
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "temperature": 0,
+                },
+            )
+
+    assert response.status_code == 200
+    assert response.json()["model"] == "fake/echo"
+    sent = conftest.select_recorded_request(
+        upstream.requests,
+        method="POST",
+        path="/chat/completions",
+    )
+    conftest.assert_exact_outbound_payload(
+        sent.payload,
+        {
+            "model": "echo",
+            "messages": [{"role": "user", "content": "ping"}],
+            "stream": False,
+            "temperature": 0.0,
+        },
+    )
+
+
+def test_controlled_postcommit_protocol_failure_is_not_misclassified_as_eof(tmp_path):
+    """Keep the real transport/codec/Router/route post-commit chain in default CI."""
+    boundaries = importlib.import_module("integration_tests.test_controlled_boundaries")
+
+    boundaries.test_stream_postcommit_failure_is_normalized_once_and_never_replays(tmp_path)
+
+
+def test_controlled_automatic_fallback_filters_required_features(tmp_path):
+    """Keep capability-aware fallback execution in the default CI suite."""
+    boundaries = importlib.import_module("integration_tests.test_controlled_boundaries")
+
+    boundaries.test_automatic_fallback_skips_feature_incompatible_candidates(tmp_path)
 
 
 def test_integration_tests_are_outside_default_pytest_tree():
@@ -1274,8 +1552,10 @@ class _RecordingStreamClient:
     def __init__(self, *responses: httpx.Response):
         self.contexts = [_RecordingStreamContext(response) for response in responses]
         self.calls = 0
+        self.call_args = []
 
-    def stream(self, *_args, **_kwargs):
+    def stream(self, *args, **kwargs):
+        self.call_args.append((args, kwargs))
         context = self.contexts[self.calls]
         self.calls += 1
         return context
@@ -1403,6 +1683,31 @@ def test_marked_400_retry_apis_are_scoped_to_three_fixed_compat_probes():
         "_stream_compat_probe_with_marked_400_retry": [
             "stream_openai_chat_compat_probe",
         ],
+    }
+
+
+def test_gemini_generate_content_probe_uses_base_protocol_payload(monkeypatch):
+    conftest = importlib.import_module("integration_tests.conftest")
+    captured = {}
+    expected_response = Mock()
+
+    def post_probe(client, path, *, json_payload):
+        captured.update(client=client, path=path, json_payload=json_payload)
+        return expected_response
+
+    monkeypatch.setattr(conftest, "_post_compat_probe_with_marked_400_retry", post_probe)
+    client = Mock()
+
+    response = conftest.post_gemini_generate_content_compat_probe(
+        client,
+        "github-copilot/claude-haiku-4.5",
+    )
+
+    assert response is expected_response
+    assert captured == {
+        "client": client,
+        "path": ("/api/gemini/v1beta/models/github-copilot/claude-haiku-4.5:generateContent"),
+        "json_payload": conftest.gemini_payload(),
     }
 
 
@@ -1592,7 +1897,7 @@ def test_anthropic_reasoning_result_rejects_empty_end_turn():
         )
 
 
-def test_anthropic_reasoning_result_rejects_empty_content_below_requested_token_limit():
+def test_anthropic_reasoning_result_accepts_authoritative_max_tokens_below_requested_cap():
     matrix = importlib.import_module("integration_tests.test_live_reasoning_matrix")
     data = {
         "content": [],
@@ -1600,15 +1905,14 @@ def test_anthropic_reasoning_result_rejects_empty_content_below_requested_token_
         "usage": {"input_tokens": 12, "output_tokens": 2047},
     }
 
-    with pytest.raises(AssertionError):
-        matrix._assert_anthropic_reasoning_result(
-            data,
-            requested_max_tokens=2048,
-            requested_thinking_budget=None,
-        )
+    matrix._assert_anthropic_reasoning_result(
+        data,
+        requested_max_tokens=2048,
+        requested_thinking_budget=None,
+    )
 
 
-def test_anthropic_reasoning_result_rejects_empty_content_below_explicit_thinking_budget():
+def test_anthropic_reasoning_result_treats_thinking_budget_as_ceiling_not_usage_floor():
     matrix = importlib.import_module("integration_tests.test_live_reasoning_matrix")
     data = {
         "content": [],
@@ -1616,12 +1920,11 @@ def test_anthropic_reasoning_result_rejects_empty_content_below_explicit_thinkin
         "usage": {"input_tokens": 12, "output_tokens": 15999},
     }
 
-    with pytest.raises(AssertionError):
-        matrix._assert_anthropic_reasoning_result(
-            data,
-            requested_max_tokens=16384,
-            requested_thinking_budget=16000,
-        )
+    matrix._assert_anthropic_reasoning_result(
+        data,
+        requested_max_tokens=16384,
+        requested_thinking_budget=16000,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1664,8 +1967,8 @@ def test_anthropic_reasoning_result_rejects_missing_usage_or_terminal(missing_fi
         )
 
 
-def test_anthropic_effort_payload_includes_conflicting_budget():
-    """Live coverage must exercise effort precedence, not effort in isolation."""
+def test_anthropic_effort_payload_combines_enabled_budget_and_effort():
+    """Live coverage must exercise all three supported controls together."""
     conftest = importlib.import_module("integration_tests.conftest")
 
     payload = conftest.anthropic_effort_payload(
@@ -1675,9 +1978,172 @@ def test_anthropic_effort_payload_includes_conflicting_budget():
         stream=True,
     )
 
-    assert payload["thinking"] == {"type": "adaptive", "budget_tokens": 1024}
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 1024}
     assert payload["output_config"] == {"effort": "xhigh"}
     assert payload["stream"] is True
+
+
+def test_anthropic_effort_profile_probes_candidates_until_manual_thinking_is_accepted():
+    conftest = importlib.import_module("integration_tests.conftest")
+    incompatible = "github-copilot/claude-sonnet-4.6"
+    compatible = "github-copilot/claude-opus-4.6"
+    catalog = {
+        incompatible: ModelInfo(
+            id="claude-sonnet-4.6",
+            name="Claude Sonnet 4.6",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/v1/messages"),
+            reasoning_effort_values=["low", "xhigh"],
+        ),
+        compatible: ModelInfo(
+            id="claude-opus-4.6",
+            name="Claude Opus 4.6",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/v1/messages"),
+            reasoning_effort_values=["low", "high"],
+        ),
+    }
+    rejected = httpx.Response(
+        400,
+        stream=httpx.ByteStream(b'{"type":"error"}'),
+        request=httpx.Request("POST", "https://router.example/beta"),
+    )
+    accepted = httpx.Response(
+        200,
+        stream=httpx.ByteStream(b'{"type":"message"}'),
+        request=httpx.Request("POST", "https://router.example/beta"),
+    )
+    client = _RecordingStreamClient(rejected, accepted)
+
+    selected = conftest.anthropic_effort_profile.__wrapped__(catalog, client)
+
+    assert selected == (compatible, "low")
+    assert [kwargs["json"]["model"] for _args, kwargs in client.call_args] == [
+        incompatible,
+        compatible,
+    ]
+    assert all(kwargs["json"]["stream"] is False for _args, kwargs in client.call_args)
+    assert not rejected.is_stream_consumed
+    assert not accepted.is_stream_consumed
+    assert rejected.is_closed
+    assert accepted.is_closed
+
+
+@pytest.mark.parametrize(
+    "model_info",
+    [
+        ModelInfo(
+            id="claude-sonnet-4.6",
+            name="Claude Sonnet 4.6",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions",),
+            reasoning_effort_values=["low"],
+            feature_capabilities={"reasoning": True},
+        ),
+        ModelInfo(
+            id="claude-sonnet-4.6",
+            name="Claude Sonnet 4.6",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/v1/messages"),
+            reasoning_effort_values=[],
+            feature_capabilities={"reasoning": False},
+        ),
+    ],
+    ids=["missing-native-endpoint", "missing-effort-tier"],
+)
+def test_anthropic_effort_profile_requires_both_endpoints_and_live_effort(model_info):
+    conftest = importlib.import_module("integration_tests.conftest")
+    model = f"github-copilot/{model_info.id}"
+
+    with pytest.raises(pytest.skip.Exception, match="enabled thinking with effort"):
+        conftest.anthropic_effort_profile.__wrapped__({model: model_info}, Mock())
+
+
+def test_anthropic_effort_profile_fails_when_catalog_candidates_reject_manual_thinking():
+    conftest = importlib.import_module("integration_tests.conftest")
+    model = "github-copilot/claude-future"
+    catalog = {
+        model: ModelInfo(
+            id="claude-future",
+            name="Claude Future",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/v1/messages"),
+            reasoning_effort_values=["low"],
+        )
+    }
+    response = httpx.Response(
+        400,
+        stream=httpx.ByteStream(b'{"type":"error"}'),
+        request=httpx.Request("POST", "https://router.example/beta"),
+    )
+    client = _RecordingStreamClient(response)
+
+    with pytest.raises(pytest.fail.Exception, match="rejected enabled thinking with effort"):
+        conftest.anthropic_effort_profile.__wrapped__(catalog, client)
+
+    assert not response.is_stream_consumed
+    assert response.is_closed
+
+
+def test_anthropic_effort_profile_bounds_runtime_compatibility_probes():
+    conftest = importlib.import_module("integration_tests.conftest")
+    catalog = {
+        f"github-copilot/claude-candidate-{index}": ModelInfo(
+            id=f"claude-candidate-{index}",
+            name=f"Claude Candidate {index}",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/v1/messages"),
+            reasoning_effort_values=["low"],
+        )
+        for index in range(4)
+    }
+    responses = [
+        httpx.Response(
+            400,
+            stream=httpx.ByteStream(b'{"type":"error"}'),
+            request=httpx.Request("POST", "https://router.example/beta"),
+        )
+        for _index in range(4)
+    ]
+    client = _RecordingStreamClient(*responses)
+
+    with pytest.raises(pytest.fail.Exception, match="after 3 bounded attempts"):
+        conftest.anthropic_effort_profile.__wrapped__(catalog, client)
+
+    assert client.calls == 3
+    for response in responses[:3]:
+        assert not response.is_stream_consumed
+        assert response.is_closed
+    assert not responses[3].is_closed
+
+
+def test_anthropic_effort_profile_does_not_buffer_probe_response_body():
+    conftest = importlib.import_module("integration_tests.conftest")
+    model = "github-copilot/claude-future"
+    catalog = {
+        model: ModelInfo(
+            id="claude-future",
+            name="Claude Future",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/v1/messages"),
+            reasoning_effort_values=["low"],
+        )
+    }
+    response = httpx.Response(
+        200,
+        stream=httpx.ByteStream(b"must not be buffered"),
+        request=httpx.Request("POST", "https://router.example/beta"),
+    )
+    client = _RecordingStreamClient(response)
+
+    selected = conftest.anthropic_effort_profile.__wrapped__(catalog, client)
+
+    assert selected == (model, "low")
+    assert client.calls == 1
+    assert not response.is_stream_consumed
+    assert response.is_closed
+    context = client.contexts[0]
+    assert context.exit_args == (None, None, None)
 
 
 def test_integration_tests_include_reasoning_and_gemini_family_matrices():
@@ -1690,7 +2156,7 @@ def test_integration_tests_include_reasoning_and_gemini_family_matrices():
     assert "test_anthropic_claude_thinking_budget_matrix" in reasoning
     assert "test_anthropic_gpt5_responses_bridge_thinking_budget_matrix" in reasoning
     assert "test_openai_chat_reasoning_effort_matrix" in reasoning
-    assert "test_anthropic_output_config_effort_precedence" in reasoning
+    assert "test_anthropic_enabled_budget_and_output_config_effort" in reasoning
     assert "test_gemini_family_generate_content_matrix" in gemini
 
 

--- a/tests/test_live_reasoning_contract.py
+++ b/tests/test_live_reasoning_contract.py
@@ -1,0 +1,50 @@
+"""Regression checks for live reasoning response contracts."""
+
+import importlib
+
+import pytest
+
+
+def test_empty_max_token_response_accepts_upstream_usage_below_requested_cap():
+    """The terminal reason proves exhaustion; billable usage need not equal the cap."""
+    matrix = importlib.import_module("integration_tests.test_live_reasoning_matrix")
+
+    matrix._assert_anthropic_reasoning_result(
+        {
+            "content": [],
+            "stop_reason": "max_tokens",
+            "usage": {"input_tokens": 170, "output_tokens": 2045},
+        },
+        requested_max_tokens=2048,
+        requested_thinking_budget=None,
+    )
+
+
+def test_empty_max_token_response_rejects_zero_output_usage():
+    matrix = importlib.import_module("integration_tests.test_live_reasoning_matrix")
+
+    with pytest.raises(AssertionError):
+        matrix._assert_anthropic_reasoning_result(
+            {
+                "content": [],
+                "stop_reason": "max_tokens",
+                "usage": {"input_tokens": 170, "output_tokens": 0},
+            },
+            requested_max_tokens=2048,
+            requested_thinking_budget=None,
+        )
+
+
+def test_empty_response_rejects_non_max_token_terminal():
+    matrix = importlib.import_module("integration_tests.test_live_reasoning_matrix")
+
+    with pytest.raises(AssertionError):
+        matrix._assert_anthropic_reasoning_result(
+            {
+                "content": [],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 170, "output_tokens": 2045},
+            },
+            requested_max_tokens=2048,
+            requested_thinking_budget=None,
+        )

--- a/tests/test_pipeline_guards.py
+++ b/tests/test_pipeline_guards.py
@@ -1,11 +1,263 @@
 """Tests for the stream pipeline guards."""
 
+import importlib
+from types import SimpleNamespace
+
 import pytest
 
+import router_maestro.pipeline as pipeline_api
+import router_maestro.runtime.request_context as request_context_module
+from router_maestro.config.priorities import PrioritiesConfig
 from router_maestro.pipeline.beta_strip import strip_beta_tokens
-from router_maestro.pipeline.leak_guard import LeakGuard, RawFrameLeakGuard
+from router_maestro.pipeline.leak_guard import LeakGuard
+from router_maestro.pipeline.request_pipeline import RequestPipeline
 from router_maestro.pipeline.runaway_guard import RunawayGuard
 from router_maestro.providers.base import ChatStreamChunk, ResponsesStreamChunk, ResponsesToolCall
+
+
+class _RecordingGuard:
+    def __init__(self, *, abort_text: str | None = None):
+        self.abort_text = abort_text
+        self.calls: list[tuple[str, object]] = []
+
+    def feed_chunk(self, chunk: object) -> str | None:
+        self.calls.append(("chunk", chunk))
+        return None
+
+    def feed_text(self, text: str) -> str | None:
+        self.calls.append(("text", text))
+        if text == self.abort_text:
+            return "recording_guard:abort"
+        return None
+
+
+def test_guard_compatibility_imports_remain_available():
+    guards_module = importlib.import_module("router_maestro.pipeline.guards")
+
+    assert pipeline_api.StreamGuard is guards_module.StreamGuard
+    assert pipeline_api.build_guards is guards_module.build_guards
+    assert pipeline_api.guarded_stream is guards_module.guarded_stream
+    assert guards_module.GuardAbortError.__module__ == "router_maestro.pipeline.guards"
+
+
+def test_superseded_raw_frame_guard_is_not_a_second_production_entrypoint():
+    leak_guard_module = importlib.import_module("router_maestro.pipeline.leak_guard")
+
+    assert not hasattr(leak_guard_module, "RawFrameLeakGuard")
+
+
+def test_guard_chain_dispatches_in_order_and_stops_after_first_abort():
+    first = _RecordingGuard(abort_text="stop")
+    second = _RecordingGuard()
+    chain = pipeline_api.GuardChain([first, second])
+    chunk = ChatStreamChunk(content="stop")
+
+    result = chain.feed_chunk(chunk)
+
+    assert result == "recording_guard:abort"
+    assert first.calls == [("chunk", chunk), ("text", "stop")]
+    assert second.calls == []
+
+
+def test_legacy_custom_guard_receives_only_content_text():
+    guard = _RecordingGuard()
+    chain = pipeline_api.GuardChain([guard])
+    chunk = ResponsesStreamChunk(
+        content="content",
+        refusal="refusal",
+        thinking="thinking",
+    )
+
+    assert chain.feed_chunk(chunk) is None
+    assert guard.calls == [("chunk", chunk), ("text", "content")]
+
+
+@pytest.mark.parametrize("field", ["content", "refusal", "thinking"])
+def test_guard_chain_leak_scans_each_human_visible_text_field(field):
+    leak_guard = LeakGuard()
+    chain = pipeline_api.GuardChain([leak_guard])
+    payload = {"content": "", "refusal": None, "thinking": None}
+    payload[field] = '<channel source="guard-test">visible</channel>'
+    chunk = ResponsesStreamChunk(**payload)
+
+    result = chain.feed_chunk(chunk)
+
+    assert result == "response_leak:control_envelope:channel"
+
+
+def test_guard_chain_separates_visible_leak_text_from_opaque_counted_payloads():
+    leak_guard = LeakGuard()
+    runaway_guard = RunawayGuard(max_bytes=10_000, max_deltas=50_000)
+    chain = pipeline_api.GuardChain([leak_guard, runaway_guard])
+    chunk = ResponsesStreamChunk(
+        content="content",
+        refusal="refusal",
+        thinking="thinking",
+        thinking_id="<tick>opaque-id</tick>",
+        thinking_signature="<tick>opaque-signature</tick>",
+        tool_call=ResponsesToolCall(
+            call_id="call-1",
+            name="lookup",
+            arguments="<tick>structured-arguments</tick>",
+        ),
+    )
+
+    result = chain.feed_chunk(chunk)
+
+    assert result is None
+    assert leak_guard.accumulated_text == "content"
+    counted_payloads = (
+        chunk.content,
+        chunk.refusal,
+        chunk.thinking,
+        chunk.thinking_id,
+        chunk.thinking_signature,
+        chunk.tool_call.arguments,
+    )
+    assert runaway_guard._total_bytes == sum(
+        len(payload.encode("utf-8")) for payload in counted_payloads if payload is not None
+    )
+    assert runaway_guard._delta_count == 1
+
+
+def test_guard_chain_recovers_invoke_from_content_but_not_refusal_or_thinking():
+    leak_guard = LeakGuard(allowed_tool_names={"Read"})
+    chain = pipeline_api.GuardChain([leak_guard])
+    invoke = '<invoke name="Read"><parameter name="file_path">/tmp/x</parameter></invoke>'
+
+    assert (
+        chain.feed_chunk(
+            ResponsesStreamChunk(
+                content="",
+                refusal=invoke,
+                thinking=invoke,
+            )
+        )
+        is None
+    )
+    assert leak_guard.check_invoke_at_finish() is None
+
+    assert chain.feed_chunk(ResponsesStreamChunk(content=invoke)) is None
+    recovered = leak_guard.check_invoke_at_finish()
+    assert recovered is not None
+    assert [tool_call["function"]["name"] for tool_call in recovered] == ["Read"]
+
+
+def test_leak_guard_scanner_state_is_isolated_between_visible_text_kinds():
+    leak_guard = LeakGuard()
+    chain = pipeline_api.GuardChain([leak_guard])
+
+    assert chain.feed_chunk(ResponsesStreamChunk(content="```")) is None
+    result = chain.feed_chunk(
+        ResponsesStreamChunk(
+            content="",
+            thinking="<tick>private control</tick>",
+        )
+    )
+
+    assert result == "response_leak:control_envelope:tick"
+
+
+def test_leak_guard_never_joins_control_envelope_across_visible_text_kinds():
+    leak_guard = LeakGuard()
+    chain = pipeline_api.GuardChain([leak_guard])
+
+    assert chain.feed_chunk(ResponsesStreamChunk(content="<tick>content")) is None
+    result = chain.feed_chunk(
+        ResponsesStreamChunk(
+            content="",
+            thinking="thinking</tick>",
+        )
+    )
+
+    assert result is None
+
+
+def test_request_pipeline_normalizes_legacy_guard_list_to_guard_chain():
+    guard = _RecordingGuard()
+    pipeline = RequestPipeline(
+        request_id="req-guard-list",
+        guards=[guard],
+        leak_guard=None,
+        audit=None,
+        config=PrioritiesConfig(),
+    )
+    chunk = ChatStreamChunk(content="visible")
+
+    assert pipeline.feed_stream(chunk) is None
+    assert isinstance(pipeline._guard_chain, pipeline_api.GuardChain)
+    assert guard.calls == [("chunk", chunk), ("text", "visible")]
+
+
+def test_request_pipeline_builds_guards_from_bound_request_config(monkeypatch):
+    config = PrioritiesConfig.model_validate(
+        {
+            "guards": {
+                "leak_guard": {"enabled": False},
+                "runaway_guard": {"enabled": False},
+            }
+        }
+    )
+    context = SimpleNamespace(config=config, audit=None, pipeline=None)
+    monkeypatch.setattr(
+        request_context_module,
+        "get_current_request_context",
+        lambda: context,
+    )
+
+    def fail_config_reload():
+        pytest.fail("RequestPipeline reloaded config instead of using the request snapshot")
+
+    monkeypatch.setattr(
+        "router_maestro.pipeline.request_pipeline.load_priorities_config",
+        fail_config_reload,
+    )
+
+    pipeline = RequestPipeline.create(
+        request_id="req-snapshot-guards",
+        model="github-copilot/gpt-4o",
+    )
+
+    assert context.pipeline is pipeline
+    assert isinstance(pipeline._guard_chain, pipeline_api.GuardChain)
+    assert pipeline.feed_stream(ChatStreamChunk(content="<tick>visible</tick>")) is None
+
+
+def test_build_guards_retains_legacy_list_api():
+    guards = pipeline_api.build_guards(
+        model="github-copilot/gpt-4o",
+        leak_guard_enabled=True,
+        runaway_guard_enabled=True,
+    )
+
+    assert isinstance(guards, list)
+    assert [type(guard) for guard in guards] == [LeakGuard, RunawayGuard]
+
+
+@pytest.mark.asyncio
+async def test_guarded_stream_retains_abort_tuple_behavior_without_wrapper_warning(caplog):
+    guard = _RecordingGuard(abort_text="stop")
+    chunks = [
+        ChatStreamChunk(content="first"),
+        ChatStreamChunk(content="stop"),
+        ChatStreamChunk(content="unreachable"),
+    ]
+
+    async def inner():
+        for chunk in chunks:
+            yield chunk
+
+    with caplog.at_level("WARNING", logger="router_maestro.pipeline.guards"):
+        results = [
+            item
+            async for item in pipeline_api.guarded_stream(
+                inner(),
+                [guard],
+            )
+        ]
+
+    assert results == [(chunks[0], None), (chunks[1], "recording_guard:abort")]
+    assert caplog.records == []
 
 
 class TestLeakGuard:
@@ -122,39 +374,6 @@ class TestLeakGuard:
         r1 = guard.feed_text(text)
         r2 = guard.feed_text("more text")
         assert r1 == r2
-
-
-class TestRawFrameLeakGuard:
-    """Tests for the passthrough-route leak guard variant."""
-
-    def test_text_delta_detected(self):
-        import json
-
-        guard = RawFrameLeakGuard()
-        data = json.dumps({"delta": {"type": "text_delta", "text": "<tick>content</tick>"}})
-        result = guard.feed_frame("content_block_delta", data)
-        assert result is not None
-        assert "tick" in result
-
-    def test_non_delta_event_ignored(self):
-        guard = RawFrameLeakGuard()
-        result = guard.feed_frame("message_start", '{"message":{}}')
-        assert result is None
-
-    def test_thinking_delta_scanned(self):
-        import json
-
-        guard = RawFrameLeakGuard()
-        data = json.dumps(
-            {
-                "delta": {
-                    "type": "thinking_delta",
-                    "thinking": '<channel source="x">leak</channel>',
-                }
-            }
-        )
-        result = guard.feed_frame("content_block_delta", data)
-        assert result is not None
 
 
 class TestRunawayGuard:
@@ -320,6 +539,18 @@ class TestRunawayGuard:
 
         assert result == "runaway_guard:max_bytes_exceeded:11>10"
         assert guard._total_bytes == 11
+        assert guard._delta_count == 1
+
+    def test_opaque_wire_payload_overrides_typed_field_byte_accounting(self):
+        guard = RunawayGuard(max_bytes=10_000, max_deltas=50_000)
+        chunk = ChatStreamChunk(
+            content="visible",
+            thinking="private",
+            opaque_payload="exact-wire-frame",
+        )
+
+        assert guard.feed_chunk(chunk) is None
+        assert guard._total_bytes == len(b"exact-wire-frame")
         assert guard._delta_count == 1
 
 

--- a/tests/test_provider_protocol_errors.py
+++ b/tests/test_provider_protocol_errors.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from router_maestro.auth.storage import OAuthCredential
+from router_maestro.auth.storage import AuthStorage, OAuthCredential
 from router_maestro.providers import (
     AnthropicProvider,
     ChatRequest,
@@ -3297,6 +3297,7 @@ async def test_copilot_token_refresh_529_is_rate_limit() -> None:
         response=response,
     )
     provider = CopilotProvider()
+    provider.auth_manager.storage = AuthStorage()
     provider.auth_manager.storage.set(
         "github-copilot",
         OAuthCredential(refresh="github-token", access="", expires=0),

--- a/tests/test_streaming_accumulation.py
+++ b/tests/test_streaming_accumulation.py
@@ -1,7 +1,8 @@
 """Tests for streaming chunk token accumulation (Feature 3)."""
 
+from router_maestro.providers import ChatStreamChunk
+from router_maestro.server.protocols.anthropic_reducer import AnthropicReducer
 from router_maestro.server.schemas.anthropic import AnthropicStreamState
-from router_maestro.server.translation import translate_openai_chunk_to_anthropic_events
 
 
 def _make_chunk(
@@ -10,18 +11,18 @@ def _make_chunk(
     usage: dict | None = None,
     tool_calls: list | None = None,
     chunk_id: str = "chatcmpl-test",
-) -> dict:
-    """Build a minimal OpenAI-style streaming chunk."""
-    delta: dict = {}
-    if content is not None:
-        delta["content"] = content
-    if tool_calls is not None:
-        delta["tool_calls"] = tool_calls
-    return {
-        "id": chunk_id,
-        "choices": [{"delta": delta, "finish_reason": finish_reason}],
-        "usage": usage,
-    }
+) -> ChatStreamChunk:
+    """Build a minimal canonical streaming chunk."""
+    return ChatStreamChunk(
+        content=content or "",
+        finish_reason=finish_reason,
+        usage=usage,
+        tool_calls=tool_calls,
+    )
+
+
+def _reduce(chunk: ChatStreamChunk, state: AnthropicStreamState, model: str) -> list[dict]:
+    return AnthropicReducer(response_id="chatcmpl-test", model=model, state=state).reduce(chunk)
 
 
 class TestStreamingAccumulation:
@@ -34,7 +35,7 @@ class TestStreamingAccumulation:
             content="hello",
             usage={"prompt_tokens": 50, "completion_tokens": 10},
         )
-        translate_openai_chunk_to_anthropic_events(chunk, state, "test-model")
+        _reduce(chunk, state, "test-model")
 
         assert state.accumulated_prompt_tokens == 50
         assert state.accumulated_completion_tokens == 10
@@ -49,7 +50,7 @@ class TestStreamingAccumulation:
             content="hi",
             usage={"prompt_tokens": 50, "completion_tokens": 5},
         )
-        translate_openai_chunk_to_anthropic_events(chunk1, state, "test-model")
+        _reduce(chunk1, state, "test-model")
         assert state.accumulated_completion_tokens == 5
 
         # Second chunk with higher cumulative total
@@ -57,7 +58,7 @@ class TestStreamingAccumulation:
             content=" there",
             usage={"prompt_tokens": 50, "completion_tokens": 15},
         )
-        translate_openai_chunk_to_anthropic_events(chunk2, state, "test-model")
+        _reduce(chunk2, state, "test-model")
         assert state.accumulated_completion_tokens == 15
         assert state.accumulated_prompt_tokens == 50
 
@@ -72,7 +73,7 @@ class TestStreamingAccumulation:
                 "completion_tokens_details": {"reasoning_tokens": 3},
             },
         )
-        translate_openai_chunk_to_anthropic_events(chunk, state, "test-model")
+        _reduce(chunk, state, "test-model")
         assert state.completion_tokens_details == {"reasoning_tokens": 3}
 
     def test_prompt_tokens_details_tracked(self):
@@ -86,7 +87,7 @@ class TestStreamingAccumulation:
                 "prompt_tokens_details": {"cached_tokens": 8},
             },
         )
-        translate_openai_chunk_to_anthropic_events(chunk, state, "test-model")
+        _reduce(chunk, state, "test-model")
         assert state.prompt_tokens_details == {"cached_tokens": 8}
 
     def test_finish_uses_accumulated_tokens(self):
@@ -98,11 +99,11 @@ class TestStreamingAccumulation:
             content="hello",
             usage={"prompt_tokens": 200, "completion_tokens": 30},
         )
-        translate_openai_chunk_to_anthropic_events(chunk1, state, "test-model")
+        _reduce(chunk1, state, "test-model")
 
         # Finish chunk without usage
         finish_chunk = _make_chunk(finish_reason="stop")
-        events = translate_openai_chunk_to_anthropic_events(finish_chunk, state, "test-model")
+        events = _reduce(finish_chunk, state, "test-model")
 
         # Find message_delta event
         delta_events = [e for e in events if e.get("type") == "message_delta"]
@@ -117,14 +118,14 @@ class TestStreamingAccumulation:
 
         # Content chunk without usage
         chunk1 = _make_chunk(content="hello")
-        translate_openai_chunk_to_anthropic_events(chunk1, state, "test-model")
+        _reduce(chunk1, state, "test-model")
 
         # Finish chunk with usage
         finish_chunk = _make_chunk(
             finish_reason="stop",
             usage={"prompt_tokens": 150, "completion_tokens": 20},
         )
-        events = translate_openai_chunk_to_anthropic_events(finish_chunk, state, "test-model")
+        events = _reduce(finish_chunk, state, "test-model")
 
         delta_events = [e for e in events if e.get("type") == "message_delta"]
         assert len(delta_events) == 1
@@ -138,11 +139,11 @@ class TestStreamingAccumulation:
 
         # Content chunk
         chunk1 = _make_chunk(content="hello")
-        translate_openai_chunk_to_anthropic_events(chunk1, state, "test-model")
+        _reduce(chunk1, state, "test-model")
 
         # Finish with no usage
         finish_chunk = _make_chunk(finish_reason="stop")
-        events = translate_openai_chunk_to_anthropic_events(finish_chunk, state, "test-model")
+        events = _reduce(finish_chunk, state, "test-model")
 
         delta_events = [e for e in events if e.get("type") == "message_delta"]
         assert len(delta_events) == 1
@@ -158,14 +159,14 @@ class TestStreamingAccumulation:
             content="x",
             usage={"prompt_tokens": 100, "completion_tokens": 10},
         )
-        translate_openai_chunk_to_anthropic_events(chunk1, state, "test-model")
+        _reduce(chunk1, state, "test-model")
 
         # Chunk with zero values should not reduce accumulated
         chunk2 = _make_chunk(
             content="y",
             usage={"prompt_tokens": 0, "completion_tokens": 0},
         )
-        translate_openai_chunk_to_anthropic_events(chunk2, state, "test-model")
+        _reduce(chunk2, state, "test-model")
 
         assert state.accumulated_prompt_tokens == 100
         assert state.accumulated_completion_tokens == 10

--- a/tests/test_translation_advanced.py
+++ b/tests/test_translation_advanced.py
@@ -4,8 +4,9 @@ import json
 
 import pytest
 
-from router_maestro.providers import ChatResponse
+from router_maestro.providers import ChatResponse, ChatStreamChunk
 from router_maestro.server.protocols.anthropic_reducer import (
+    AnthropicReducer,
     AnthropicStreamProtocolError,
     build_anthropic_response,
 )
@@ -30,7 +31,6 @@ from router_maestro.server.translation import (
     _translate_model_name,
     _translate_tool_choice,
     _translate_tools,
-    translate_openai_chunk_to_anthropic_events,
 )
 
 
@@ -39,16 +39,12 @@ def _stream_chunk(
     content: str | None = None,
     tool_calls: list[dict] | None = None,
     finish_reason: str | None = None,
-) -> dict:
-    delta: dict = {}
-    if content is not None:
-        delta["content"] = content
-    if tool_calls is not None:
-        delta["tool_calls"] = tool_calls
-    return {
-        "id": "chunk-test",
-        "choices": [{"delta": delta, "finish_reason": finish_reason}],
-    }
+) -> ChatStreamChunk:
+    return ChatStreamChunk(
+        content=content or "",
+        tool_calls=tool_calls,
+        finish_reason=finish_reason,
+    )
 
 
 def _tool_delta(
@@ -681,15 +677,15 @@ class TestTranslateOpenAIToAnthropic:
         assert tool_blocks[0].input == {"command": "hostname"}
 
 
-class TestTranslateOpenAIChunkToAnthropicEvents:
-    """Tests for streaming chunk translation."""
+class TestAnthropicReducerStreaming:
+    """Tests for canonical Anthropic stream reduction."""
 
     def test_message_start_event(self):
         """Test that first chunk generates message_start."""
         state = AnthropicStreamState()
-        chunk = {"id": "chunk-1", "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]}
+        reducer = AnthropicReducer(response_id="chunk-1", model="claude-3", state=state)
 
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        events = reducer.reduce(ChatStreamChunk(content="Hi"))
 
         # Should have message_start
         assert any(e["type"] == "message_start" for e in events)
@@ -699,13 +695,9 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
         """Test content delta event generation."""
         state = AnthropicStreamState()
         state.message_start_sent = True
+        reducer = AnthropicReducer(response_id="chunk-1", model="claude-3", state=state)
 
-        chunk = {
-            "id": "chunk-1",
-            "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}],
-        }
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        events = reducer.reduce(ChatStreamChunk(content="Hello"))
 
         # Should have content_block_start and content_block_delta
         delta_events = [e for e in events if e["type"] == "content_block_delta"]
@@ -717,10 +709,9 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
         state = AnthropicStreamState()
         state.message_start_sent = True
         state.content_block_open = True
+        reducer = AnthropicReducer(response_id="chunk-1", model="claude-3", state=state)
 
-        chunk = {"id": "chunk-1", "choices": [{"delta": {}, "finish_reason": "stop"}]}
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        events = reducer.reduce(ChatStreamChunk(content="", finish_reason="stop"))
 
         # Should have message_delta and message_stop
         assert any(e["type"] == "message_delta" for e in events)
@@ -731,34 +722,24 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
         """Tool blocks are transactional and cannot be exposed before validation."""
         state = AnthropicStreamState()
         state.message_start_sent = True
+        reducer = AnthropicReducer(response_id="chunk-1", model="claude-3", state=state)
 
-        chunk = {
-            "id": "chunk-1",
-            "choices": [
-                {
-                    "delta": {
-                        "tool_calls": [
-                            {
-                                "index": 0,
-                                "id": "tc-1",
-                                "function": {"name": "test", "arguments": "{}"},
-                            }
-                        ]
-                    },
-                    "finish_reason": None,
-                }
-            ],
-        }
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        events = reducer.reduce(
+            ChatStreamChunk(
+                content="",
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "tc-1",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
+                ],
+            )
+        )
 
         assert events == []
 
-        terminal = {
-            "id": "chunk-2",
-            "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
-        }
-        events = translate_openai_chunk_to_anthropic_events(terminal, state, "claude-3")
+        events = reducer.reduce(ChatStreamChunk(content="", finish_reason="tool_calls"))
 
         assert [event["type"] for event in events] == [
             "content_block_start",
@@ -780,6 +761,7 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
 
     def test_interleaved_parallel_tools_flush_in_stable_explicit_index_order(self):
         state = AnthropicStreamState(message_start_sent=True)
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
 
         chunks = [
             _stream_chunk(
@@ -793,14 +775,8 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
             _stream_chunk(tool_calls=[_tool_delta(index=7, arguments="1}")]),
         ]
 
-        before_terminal = [
-            event
-            for chunk in chunks
-            for event in translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
-        ]
-        terminal = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        before_terminal = [event for chunk in chunks for event in reducer.reduce(chunk)]
+        terminal = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert before_terminal == []
         blocks = _tool_blocks(terminal)
@@ -812,6 +788,7 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
 
     def test_indexless_calls_use_id_identity_and_arrival_order(self):
         state = AnthropicStreamState(message_start_sent=True)
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
 
         chunks = [
             _stream_chunk(
@@ -823,11 +800,9 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
             _stream_chunk(tool_calls=[_tool_delta(tool_id="tool-a", arguments="1}")]),
         ]
         for chunk in chunks:
-            assert translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3") == []
+            assert reducer.reduce(chunk) == []
 
-        events = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        events = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert [(block["id"], block["json"]) for block in _tool_blocks(events)] == [
             ("tool-a", '{"a":1}'),
@@ -836,37 +811,30 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
 
     def test_tool_text_tool_keeps_text_live_and_flushes_tools_after_text(self):
         state = AnthropicStreamState(message_start_sent=True)
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
 
         assert (
-            translate_openai_chunk_to_anthropic_events(
+            reducer.reduce(
                 _stream_chunk(
                     tool_calls=[
                         _tool_delta(index=1, tool_id="tool-a", name="alpha", arguments="{}")
                     ]
-                ),
-                state,
-                "claude-3",
+                )
             )
             == []
         )
-        text_events = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(content="still working"), state, "claude-3"
-        )
+        text_events = reducer.reduce(_stream_chunk(content="still working"))
         assert any(event.get("delta", {}).get("text") == "still working" for event in text_events)
         assert (
-            translate_openai_chunk_to_anthropic_events(
+            reducer.reduce(
                 _stream_chunk(
                     tool_calls=[_tool_delta(index=0, tool_id="tool-b", name="beta", arguments="{}")]
-                ),
-                state,
-                "claude-3",
+                )
             )
             == []
         )
 
-        terminal = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        terminal = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert terminal[0] == {"type": "content_block_stop", "index": 0}
         blocks = _tool_blocks(terminal)
@@ -878,34 +846,19 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
 
     def test_tool_fragment_does_not_close_live_thinking_block(self):
         state = AnthropicStreamState(message_start_sent=True)
-        first_thinking = translate_openai_chunk_to_anthropic_events(
-            {
-                "id": "chunk-thinking-1",
-                "choices": [{"delta": {"reasoning_text": "first"}, "finish_reason": None}],
-            },
-            state,
-            "claude-3",
-        )
+        reducer = AnthropicReducer(response_id="chunk-thinking", model="claude-3", state=state)
+        first_thinking = reducer.reduce(ChatStreamChunk(content="", thinking="first"))
         assert [event["type"] for event in first_thinking] == [
             "content_block_start",
             "content_block_delta",
         ]
 
-        tool_events = translate_openai_chunk_to_anthropic_events(
+        tool_events = reducer.reduce(
             _stream_chunk(
                 tool_calls=[_tool_delta(index=0, tool_id="tool-a", name="alpha", arguments="{}")]
-            ),
-            state,
-            "claude-3",
+            )
         )
-        second_thinking = translate_openai_chunk_to_anthropic_events(
-            {
-                "id": "chunk-thinking-2",
-                "choices": [{"delta": {"reasoning_text": "second"}, "finish_reason": None}],
-            },
-            state,
-            "claude-3",
-        )
+        second_thinking = reducer.reduce(ChatStreamChunk(content="", thinking="second"))
 
         assert tool_events == []
         assert second_thinking == [
@@ -916,9 +869,7 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
             }
         ]
 
-        terminal = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        terminal = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
         assert terminal[0] == {"type": "content_block_stop", "index": 0}
         tool_block = _tool_blocks(terminal)[0]
         assert tool_block["id"] == "tool-a"
@@ -948,71 +899,54 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
     )
     def test_terminal_validation_is_transactional(self, tool_calls, match):
         state = AnthropicStreamState(message_start_sent=True)
-        assert (
-            translate_openai_chunk_to_anthropic_events(
-                _stream_chunk(tool_calls=tool_calls), state, "claude-3"
-            )
-            == []
-        )
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
+        assert reducer.reduce(_stream_chunk(tool_calls=tool_calls)) == []
 
         with pytest.raises(AnthropicStreamProtocolError, match=match):
-            translate_openai_chunk_to_anthropic_events(
-                _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-            )
+            reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert state.message_complete is False
         assert state.content_block_open is False
 
     def test_explicit_incomplete_terminal_still_validates_tool_arguments(self):
         state = AnthropicStreamState(message_start_sent=True)
-        translate_openai_chunk_to_anthropic_events(
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
+        reducer.reduce(
             _stream_chunk(
                 tool_calls=[_tool_delta(index=0, tool_id="tool-a", name="alpha", arguments="{")]
-            ),
-            state,
-            "claude-3",
+            )
         )
 
         with pytest.raises(AnthropicStreamProtocolError, match="valid JSON object"):
-            translate_openai_chunk_to_anthropic_events(
-                _stream_chunk(finish_reason="length"), state, "claude-3"
-            )
+            reducer.reduce(_stream_chunk(finish_reason="length"))
 
     def test_conflicting_tool_identity_is_protocol_error(self):
         state = AnthropicStreamState(message_start_sent=True)
-        translate_openai_chunk_to_anthropic_events(
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
+        reducer.reduce(
             _stream_chunk(
                 tool_calls=[_tool_delta(index=0, tool_id="tool-a", name="alpha", arguments="{")]
-            ),
-            state,
-            "claude-3",
+            )
         )
 
         with pytest.raises(AnthropicStreamProtocolError, match="conflicting id"):
-            translate_openai_chunk_to_anthropic_events(
+            reducer.reduce(
                 _stream_chunk(
                     tool_calls=[_tool_delta(index=0, tool_id="tool-b", name="alpha", arguments="}")]
-                ),
-                state,
-                "claude-3",
+                )
             )
 
     def test_indexless_tool_is_upgraded_when_later_delta_adds_index(self):
         state = AnthropicStreamState(message_start_sent=True)
-        translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(tool_calls=[_tool_delta(tool_id="tool-a", name="alpha", arguments="{")]),
-            state,
-            "claude-3",
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
+        reducer.reduce(
+            _stream_chunk(tool_calls=[_tool_delta(tool_id="tool-a", name="alpha", arguments="{")])
         )
-        translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(tool_calls=[_tool_delta(index=4, tool_id="tool-a", arguments='"a":1}')]),
-            state,
-            "claude-3",
+        reducer.reduce(
+            _stream_chunk(tool_calls=[_tool_delta(index=4, tool_id="tool-a", arguments='"a":1}')])
         )
 
-        events = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        events = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert [(block["id"], json.loads(block["json"])) for block in _tool_blocks(events)] == [
             ("tool-a", {"a": 1})
@@ -1020,22 +954,17 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
 
     def test_indexed_tool_is_completed_by_later_id_only_delta(self):
         state = AnthropicStreamState(message_start_sent=True)
-        translate_openai_chunk_to_anthropic_events(
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
+        reducer.reduce(
             _stream_chunk(
                 tool_calls=[_tool_delta(index=4, tool_id="tool-a", name="alpha", arguments="{")]
-            ),
-            state,
-            "claude-3",
+            )
         )
-        translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(tool_calls=[_tool_delta(tool_id="tool-a", arguments='"a":1}')]),
-            state,
-            "claude-3",
+        reducer.reduce(
+            _stream_chunk(tool_calls=[_tool_delta(tool_id="tool-a", arguments='"a":1}')])
         )
 
-        events = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        events = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert [(block["id"], json.loads(block["json"])) for block in _tool_blocks(events)] == [
             ("tool-a", {"a": 1})
@@ -1043,8 +972,9 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
 
     def test_empty_object_split_across_multiple_argument_fragments(self):
         state = AnthropicStreamState(message_start_sent=True)
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
         for fragment in ("{", "", "}"):
-            translate_openai_chunk_to_anthropic_events(
+            reducer.reduce(
                 _stream_chunk(
                     tool_calls=[
                         _tool_delta(
@@ -1054,14 +984,10 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
                             arguments=fragment,
                         )
                     ]
-                ),
-                state,
-                "claude-3",
+                )
             )
 
-        events = translate_openai_chunk_to_anthropic_events(
-            _stream_chunk(finish_reason="tool_calls"), state, "claude-3"
-        )
+        events = reducer.reduce(_stream_chunk(finish_reason="tool_calls"))
 
         assert _tool_blocks(events)[0]["json"] == "{}"
 
@@ -1076,15 +1002,14 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
     )
     def test_conflicting_index_id_or_name_is_protocol_error(self, second_delta):
         state = AnthropicStreamState(message_start_sent=True)
-        translate_openai_chunk_to_anthropic_events(
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
+        reducer.reduce(
             _stream_chunk(
                 tool_calls=[_tool_delta(index=0, tool_id="tool-a", name="alpha", arguments="{")]
-            ),
-            state,
-            "claude-3",
+            )
         )
         if second_delta["index"] == 1:
-            translate_openai_chunk_to_anthropic_events(
+            reducer.reduce(
                 _stream_chunk(
                     tool_calls=[
                         _tool_delta(
@@ -1094,25 +1019,18 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
                             arguments="{}",
                         )
                     ]
-                ),
-                state,
-                "claude-3",
+                )
             )
 
         with pytest.raises(AnthropicStreamProtocolError, match="conflicting"):
-            translate_openai_chunk_to_anthropic_events(
-                _stream_chunk(tool_calls=[second_delta]), state, "claude-3"
-            )
+            reducer.reduce(_stream_chunk(tool_calls=[second_delta]))
 
     def test_fragment_without_index_or_id_is_protocol_error(self):
         state = AnthropicStreamState(message_start_sent=True)
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
 
         with pytest.raises(AnthropicStreamProtocolError, match="missing both index and id"):
-            translate_openai_chunk_to_anthropic_events(
-                _stream_chunk(tool_calls=[_tool_delta(arguments='{"a":1}')]),
-                state,
-                "claude-3",
-            )
+            reducer.reduce(_stream_chunk(tool_calls=[_tool_delta(arguments='{"a":1}')]))
 
     @pytest.mark.parametrize(
         "tool_call",
@@ -1126,23 +1044,18 @@ class TestTranslateOpenAIChunkToAnthropicEvents:
     )
     def test_malformed_tool_delta_shape_is_protocol_error(self, tool_call):
         state = AnthropicStreamState(message_start_sent=True)
+        reducer = AnthropicReducer(response_id="chunk-test", model="claude-3", state=state)
 
         with pytest.raises(AnthropicStreamProtocolError):
-            translate_openai_chunk_to_anthropic_events(
-                _stream_chunk(tool_calls=[tool_call]), state, "claude-3"
-            )
+            reducer.reduce(_stream_chunk(tool_calls=[tool_call]))
 
     def test_no_events_after_complete(self):
         """Test that no events are generated after message is complete."""
         state = AnthropicStreamState()
         state.message_complete = True
+        reducer = AnthropicReducer(response_id="chunk-1", model="claude-3", state=state)
 
-        chunk = {
-            "id": "chunk-1",
-            "choices": [{"delta": {"content": "More"}, "finish_reason": None}],
-        }
-
-        events = translate_openai_chunk_to_anthropic_events(chunk, state, "claude-3")
+        events = reducer.reduce(ChatStreamChunk(content="More"))
         assert len(events) == 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,24 +3,6 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
-name = "aiosqlite"
-version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
-]
-
-[[package]]
-name = "altgraph"
-version = "0.17.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -39,25 +21,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.76.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/be/d11abafaa15d6304826438170f7574d750218f49a106c54424a40cef4494/anthropic-0.76.0.tar.gz", hash = "sha256:e0cae6a368986d5cf6df743dfbb1b9519e6a9eee9c6c942ad8121c0b34416ffe", size = 495483, upload-time = "2026-01-13T18:41:14.908Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/70/7b0fd9c1a738f59d3babe2b4212031c34ab7d0fda4ffef15b58a55c5bcea/anthropic-0.76.0-py3-none-any.whl", hash = "sha256:81efa3113901192af2f0fe977d3ec73fdadb1e691586306c4256cd6d5ccc331c", size = 390309, upload-time = "2026-01-13T18:41:13.483Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -71,94 +34,12 @@ wheels = [
 ]
 
 [[package]]
-name = "authlib"
-version = "1.6.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
-    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
-    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
-    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
-    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -253,86 +134,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "cryptography"
-version = "46.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/42/9c391dd801d6cf0d561b5890549d4b27bafcc53b39c31a817e69d87c625b/cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a", size = 7225004, upload-time = "2025-10-15T23:16:52.239Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/67/38769ca6b65f07461eb200e85fc1639b438bdc667be02cf7f2cd6a64601c/cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc", size = 4296667, upload-time = "2025-10-15T23:16:54.369Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/49/498c86566a1d80e978b42f0d702795f69887005548c041636df6ae1ca64c/cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d", size = 4450807, upload-time = "2025-10-15T23:16:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0a/863a3604112174c8624a2ac3c038662d9e59970c7f926acdcfaed8d61142/cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb", size = 4299615, upload-time = "2025-10-15T23:16:58.442Z" },
-    { url = "https://files.pythonhosted.org/packages/64/02/b73a533f6b64a69f3cd3872acb6ebc12aef924d8d103133bb3ea750dc703/cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849", size = 4016800, upload-time = "2025-10-15T23:17:00.378Z" },
-    { url = "https://files.pythonhosted.org/packages/25/d5/16e41afbfa450cde85a3b7ec599bebefaef16b5c6ba4ec49a3532336ed72/cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8", size = 4984707, upload-time = "2025-10-15T23:17:01.98Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/56/e7e69b427c3878352c2fb9b450bd0e19ed552753491d39d7d0a2f5226d41/cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec", size = 4482541, upload-time = "2025-10-15T23:17:04.078Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f6/50736d40d97e8483172f1bb6e698895b92a223dba513b0ca6f06b2365339/cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91", size = 4299464, upload-time = "2025-10-15T23:17:05.483Z" },
-    { url = "https://files.pythonhosted.org/packages/00/de/d8e26b1a855f19d9994a19c702fa2e93b0456beccbcfe437eda00e0701f2/cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e", size = 4950838, upload-time = "2025-10-15T23:17:07.425Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/29/798fc4ec461a1c9e9f735f2fc58741b0daae30688f41b2497dcbc9ed1355/cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926", size = 4481596, upload-time = "2025-10-15T23:17:09.343Z" },
-    { url = "https://files.pythonhosted.org/packages/15/8d/03cd48b20a573adfff7652b76271078e3045b9f49387920e7f1f631d125e/cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71", size = 4426782, upload-time = "2025-10-15T23:17:11.22Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/b1/ebacbfe53317d55cf33165bda24c86523497a6881f339f9aae5c2e13e57b/cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac", size = 4698381, upload-time = "2025-10-15T23:17:12.829Z" },
-    { url = "https://files.pythonhosted.org/packages/96/92/8a6a9525893325fc057a01f654d7efc2c64b9de90413adcf605a85744ff4/cryptography-46.0.3-cp311-abi3-win32.whl", hash = "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018", size = 3055988, upload-time = "2025-10-15T23:17:14.65Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/bf/80fbf45253ea585a1e492a6a17efcb93467701fa79e71550a430c5e60df0/cryptography-46.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb", size = 3514451, upload-time = "2025-10-15T23:17:16.142Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/af/9b302da4c87b0beb9db4e756386a7c6c5b8003cd0e742277888d352ae91d/cryptography-46.0.3-cp311-abi3-win_arm64.whl", hash = "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c", size = 2928007, upload-time = "2025-10-15T23:17:18.04Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e2/a510aa736755bffa9d2f75029c229111a1d02f8ecd5de03078f4c18d91a3/cryptography-46.0.3-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217", size = 7158012, upload-time = "2025-10-15T23:17:19.982Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dc/9aa866fbdbb95b02e7f9d086f1fccfeebf8953509b87e3f28fff927ff8a0/cryptography-46.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5", size = 4288728, upload-time = "2025-10-15T23:17:21.527Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/fd/bc1daf8230eaa075184cbbf5f8cd00ba9db4fd32d63fb83da4671b72ed8a/cryptography-46.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715", size = 4435078, upload-time = "2025-10-15T23:17:23.042Z" },
-    { url = "https://files.pythonhosted.org/packages/82/98/d3bd5407ce4c60017f8ff9e63ffee4200ab3e23fe05b765cab805a7db008/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54", size = 4293460, upload-time = "2025-10-15T23:17:24.885Z" },
-    { url = "https://files.pythonhosted.org/packages/26/e9/e23e7900983c2b8af7a08098db406cf989d7f09caea7897e347598d4cd5b/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459", size = 3995237, upload-time = "2025-10-15T23:17:26.449Z" },
-    { url = "https://files.pythonhosted.org/packages/91/15/af68c509d4a138cfe299d0d7ddb14afba15233223ebd933b4bbdbc7155d3/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422", size = 4967344, upload-time = "2025-10-15T23:17:28.06Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/e3/8643d077c53868b681af077edf6b3cb58288b5423610f21c62aadcbe99f4/cryptography-46.0.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7", size = 4466564, upload-time = "2025-10-15T23:17:29.665Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/43/c1e8726fa59c236ff477ff2b5dc071e54b21e5a1e51aa2cee1676f1c986f/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044", size = 4292415, upload-time = "2025-10-15T23:17:31.686Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f9/2f8fefdb1aee8a8e3256a0568cffc4e6d517b256a2fe97a029b3f1b9fe7e/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665", size = 4931457, upload-time = "2025-10-15T23:17:33.478Z" },
-    { url = "https://files.pythonhosted.org/packages/79/30/9b54127a9a778ccd6d27c3da7563e9f2d341826075ceab89ae3b41bf5be2/cryptography-46.0.3-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3", size = 4466074, upload-time = "2025-10-15T23:17:35.158Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/68/b4f4a10928e26c941b1b6a179143af9f4d27d88fe84a6a3c53592d2e76bf/cryptography-46.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20", size = 4420569, upload-time = "2025-10-15T23:17:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/49/3746dab4c0d1979888f125226357d3262a6dd40e114ac29e3d2abdf1ec55/cryptography-46.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de", size = 4681941, upload-time = "2025-10-15T23:17:39.236Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/30/27654c1dbaf7e4a3531fa1fc77986d04aefa4d6d78259a62c9dc13d7ad36/cryptography-46.0.3-cp314-cp314t-win32.whl", hash = "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914", size = 3022339, upload-time = "2025-10-15T23:17:40.888Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/30/640f34ccd4d2a1bc88367b54b926b781b5a018d65f404d409aba76a84b1c/cryptography-46.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db", size = 3494315, upload-time = "2025-10-15T23:17:42.769Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8b/88cc7e3bd0a8e7b861f26981f7b820e1f46aa9d26cc482d0feba0ecb4919/cryptography-46.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21", size = 2919331, upload-time = "2025-10-15T23:17:44.468Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/23/45fe7f376a7df8daf6da3556603b36f53475a99ce4faacb6ba2cf3d82021/cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936", size = 7218248, upload-time = "2025-10-15T23:17:46.294Z" },
-    { url = "https://files.pythonhosted.org/packages/27/32/b68d27471372737054cbd34c84981f9edbc24fe67ca225d389799614e27f/cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683", size = 4294089, upload-time = "2025-10-15T23:17:48.269Z" },
-    { url = "https://files.pythonhosted.org/packages/26/42/fa8389d4478368743e24e61eea78846a0006caffaf72ea24a15159215a14/cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d", size = 4440029, upload-time = "2025-10-15T23:17:49.837Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/f483db0ec5ac040824f269e93dd2bd8a21ecd1027e77ad7bdf6914f2fd80/cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0", size = 4297222, upload-time = "2025-10-15T23:17:51.357Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/cf/da9502c4e1912cb1da3807ea3618a6829bee8207456fbbeebc361ec38ba3/cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc", size = 4012280, upload-time = "2025-10-15T23:17:52.964Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8f/9adb86b93330e0df8b3dcf03eae67c33ba89958fc2e03862ef1ac2b42465/cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3", size = 4978958, upload-time = "2025-10-15T23:17:54.965Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a0/5fa77988289c34bdb9f913f5606ecc9ada1adb5ae870bd0d1054a7021cc4/cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971", size = 4473714, upload-time = "2025-10-15T23:17:56.754Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e5/fc82d72a58d41c393697aa18c9abe5ae1214ff6f2a5c18ac470f92777895/cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac", size = 4296970, upload-time = "2025-10-15T23:17:58.588Z" },
-    { url = "https://files.pythonhosted.org/packages/78/06/5663ed35438d0b09056973994f1aec467492b33bd31da36e468b01ec1097/cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04", size = 4940236, upload-time = "2025-10-15T23:18:00.897Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/59/873633f3f2dcd8a053b8dd1d38f783043b5fce589c0f6988bf55ef57e43e/cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506", size = 4472642, upload-time = "2025-10-15T23:18:02.749Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/39/8e71f3930e40f6877737d6f69248cf74d4e34b886a3967d32f919cc50d3b/cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963", size = 4423126, upload-time = "2025-10-15T23:18:04.85Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c7/f65027c2810e14c3e7268353b1681932b87e5a48e65505d8cc17c99e36ae/cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4", size = 4686573, upload-time = "2025-10-15T23:18:06.908Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/6e/1c8331ddf91ca4730ab3086a0f1be19c65510a33b5a441cb334e7a2d2560/cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df", size = 3036695, upload-time = "2025-10-15T23:18:08.672Z" },
-    { url = "https://files.pythonhosted.org/packages/90/45/b0d691df20633eff80955a0fc7695ff9051ffce8b69741444bd9ed7bd0db/cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f", size = 3501720, upload-time = "2025-10-15T23:18:10.632Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cb/2da4cc83f5edb9c3257d09e1e7ab7b23f049c7962cae8d842bbef0a9cec9/cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372", size = 2918740, upload-time = "2025-10-15T23:18:12.277Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8a/e60e46adab4362a682cf142c7dcb5bf79b782ab2199b0dcb81f55970807f/cryptography-46.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7ce938a99998ed3c8aa7e7272dca1a610401ede816d36d0693907d863b10d9ea", size = 3698132, upload-time = "2025-10-15T23:18:17.056Z" },
-    { url = "https://files.pythonhosted.org/packages/da/38/f59940ec4ee91e93d3311f7532671a5cef5570eb04a144bf203b58552d11/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:191bb60a7be5e6f54e30ba16fdfae78ad3a342a0599eb4193ba88e3f3d6e185b", size = 4243992, upload-time = "2025-10-15T23:18:18.695Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/0c/35b3d92ddebfdfda76bb485738306545817253d0a3ded0bfe80ef8e67aa5/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c70cc23f12726be8f8bc72e41d5065d77e4515efae3690326764ea1b07845cfb", size = 4409944, upload-time = "2025-10-15T23:18:20.597Z" },
-    { url = "https://files.pythonhosted.org/packages/99/55/181022996c4063fc0e7666a47049a1ca705abb9c8a13830f074edb347495/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717", size = 4242957, upload-time = "2025-10-15T23:18:22.18Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/af/72cd6ef29f9c5f731251acadaeb821559fe25f10852f44a63374c9ca08c1/cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9", size = 4409447, upload-time = "2025-10-15T23:18:24.209Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c3/e90f4a4feae6410f914f8ebac129b9ae7a8c92eb60a638012dde42030a9d/cryptography-46.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c", size = 3438528, upload-time = "2025-10-15T23:18:26.227Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -442,103 +243,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jiter"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/f9/eaca4633486b527ebe7e681c431f529b63fe2709e7c5242fc0f43f77ce63/jiter-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d8f8a7e317190b2c2d60eb2e8aa835270b008139562d70fe732e1c0020ec53c9", size = 316435, upload-time = "2025-11-09T20:47:02.087Z" },
-    { url = "https://files.pythonhosted.org/packages/10/c1/40c9f7c22f5e6ff715f28113ebaba27ab85f9af2660ad6e1dd6425d14c19/jiter-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2218228a077e784c6c8f1a8e5d6b8cb1dea62ce25811c356364848554b2056cd", size = 320548, upload-time = "2025-11-09T20:47:03.409Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/1b/efbb68fe87e7711b00d2cfd1f26bb4bfc25a10539aefeaa7727329ffb9cb/jiter-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9354ccaa2982bf2188fd5f57f79f800ef622ec67beb8329903abf6b10da7d423", size = 351915, upload-time = "2025-11-09T20:47:05.171Z" },
-    { url = "https://files.pythonhosted.org/packages/15/2d/c06e659888c128ad1e838123d0638f0efad90cc30860cb5f74dd3f2fc0b3/jiter-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2607185ea89b4af9a604d4c7ec40e45d3ad03ee66998b031134bc510232bb7", size = 368966, upload-time = "2025-11-09T20:47:06.508Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/20/058db4ae5fb07cf6a4ab2e9b9294416f606d8e467fb74c2184b2a1eeacba/jiter-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a585a5e42d25f2e71db5f10b171f5e5ea641d3aa44f7df745aa965606111cc2", size = 482047, upload-time = "2025-11-09T20:47:08.382Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bb/dc2b1c122275e1de2eb12905015d61e8316b2f888bdaac34221c301495d6/jiter-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd9e21d34edff5a663c631f850edcb786719c960ce887a5661e9c828a53a95d9", size = 380835, upload-time = "2025-11-09T20:47:09.81Z" },
-    { url = "https://files.pythonhosted.org/packages/23/7d/38f9cd337575349de16da575ee57ddb2d5a64d425c9367f5ef9e4612e32e/jiter-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a612534770470686cd5431478dc5a1b660eceb410abade6b1b74e320ca98de6", size = 364587, upload-time = "2025-11-09T20:47:11.529Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/a3/b13e8e61e70f0bb06085099c4e2462647f53cc2ca97614f7fedcaa2bb9f3/jiter-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3985aea37d40a908f887b34d05111e0aae822943796ebf8338877fee2ab67725", size = 390492, upload-time = "2025-11-09T20:47:12.993Z" },
-    { url = "https://files.pythonhosted.org/packages/07/71/e0d11422ed027e21422f7bc1883c61deba2d9752b720538430c1deadfbca/jiter-0.12.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b1207af186495f48f72529f8d86671903c8c10127cac6381b11dddc4aaa52df6", size = 522046, upload-time = "2025-11-09T20:47:14.6Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/59/b968a9aa7102a8375dbbdfbd2aeebe563c7e5dddf0f47c9ef1588a97e224/jiter-0.12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ef2fb241de583934c9915a33120ecc06d94aa3381a134570f59eed784e87001e", size = 513392, upload-time = "2025-11-09T20:47:16.011Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/e4/7df62002499080dbd61b505c5cb351aa09e9959d176cac2aa8da6f93b13b/jiter-0.12.0-cp311-cp311-win32.whl", hash = "sha256:453b6035672fecce8007465896a25b28a6b59cfe8fbc974b2563a92f5a92a67c", size = 206096, upload-time = "2025-11-09T20:47:17.344Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/60/1032b30ae0572196b0de0e87dce3b6c26a1eff71aad5fe43dee3082d32e0/jiter-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:ca264b9603973c2ad9435c71a8ec8b49f8f715ab5ba421c85a51cde9887e421f", size = 204899, upload-time = "2025-11-09T20:47:19.365Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d5/c145e526fccdb834063fb45c071df78b0cc426bbaf6de38b0781f45d956f/jiter-0.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:cb00ef392e7d684f2754598c02c409f376ddcef857aae796d559e6cacc2d78a5", size = 188070, upload-time = "2025-11-09T20:47:20.75Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c9/5b9f7b4983f1b542c64e84165075335e8a236fa9e2ea03a0c79780062be8/jiter-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:305e061fa82f4680607a775b2e8e0bcb071cd2205ac38e6ef48c8dd5ebe1cf37", size = 314449, upload-time = "2025-11-09T20:47:22.999Z" },
-    { url = "https://files.pythonhosted.org/packages/98/6e/e8efa0e78de00db0aee82c0cf9e8b3f2027efd7f8a71f859d8f4be8e98ef/jiter-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c1860627048e302a528333c9307c818c547f214d8659b0705d2195e1a94b274", size = 319855, upload-time = "2025-11-09T20:47:24.779Z" },
-    { url = "https://files.pythonhosted.org/packages/20/26/894cd88e60b5d58af53bec5c6759d1292bd0b37a8b5f60f07abf7a63ae5f/jiter-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df37577a4f8408f7e0ec3205d2a8f87672af8f17008358063a4d6425b6081ce3", size = 350171, upload-time = "2025-11-09T20:47:26.469Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/27/a7b818b9979ac31b3763d25f3653ec3a954044d5e9f5d87f2f247d679fd1/jiter-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fdd787356c1c13a4f40b43c2156276ef7a71eb487d98472476476d803fb2cf", size = 365590, upload-time = "2025-11-09T20:47:27.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/7e/e46195801a97673a83746170b17984aa8ac4a455746354516d02ca5541b4/jiter-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eb5db8d9c65b112aacf14fcd0faae9913d07a8afea5ed06ccdd12b724e966a1", size = 479462, upload-time = "2025-11-09T20:47:29.654Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/75/f833bfb009ab4bd11b1c9406d333e3b4357709ed0570bb48c7c06d78c7dd/jiter-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73c568cc27c473f82480abc15d1301adf333a7ea4f2e813d6a2c7d8b6ba8d0df", size = 378983, upload-time = "2025-11-09T20:47:31.026Z" },
-    { url = "https://files.pythonhosted.org/packages/71/b3/7a69d77943cc837d30165643db753471aff5df39692d598da880a6e51c24/jiter-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4321e8a3d868919bcb1abb1db550d41f2b5b326f72df29e53b2df8b006eb9403", size = 361328, upload-time = "2025-11-09T20:47:33.286Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ac/a78f90caf48d65ba70d8c6efc6f23150bc39dc3389d65bbec2a95c7bc628/jiter-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a51bad79f8cc9cac2b4b705039f814049142e0050f30d91695a2d9a6611f126", size = 386740, upload-time = "2025-11-09T20:47:34.703Z" },
-    { url = "https://files.pythonhosted.org/packages/39/b6/5d31c2cc8e1b6a6bcf3c5721e4ca0a3633d1ab4754b09bc7084f6c4f5327/jiter-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2a67b678f6a5f1dd6c36d642d7db83e456bc8b104788262aaefc11a22339f5a9", size = 520875, upload-time = "2025-11-09T20:47:36.058Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b5/4df540fae4e9f68c54b8dab004bd8c943a752f0b00efd6e7d64aa3850339/jiter-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efe1a211fe1fd14762adea941e3cfd6c611a136e28da6c39272dbb7a1bbe6a86", size = 511457, upload-time = "2025-11-09T20:47:37.932Z" },
-    { url = "https://files.pythonhosted.org/packages/07/65/86b74010e450a1a77b2c1aabb91d4a91dd3cd5afce99f34d75fd1ac64b19/jiter-0.12.0-cp312-cp312-win32.whl", hash = "sha256:d779d97c834b4278276ec703dc3fc1735fca50af63eb7262f05bdb4e62203d44", size = 204546, upload-time = "2025-11-09T20:47:40.47Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c7/6659f537f9562d963488e3e55573498a442503ced01f7e169e96a6110383/jiter-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8269062060212b373316fe69236096aaf4c49022d267c6736eebd66bbbc60bb", size = 205196, upload-time = "2025-11-09T20:47:41.794Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f4/935304f5169edadfec7f9c01eacbce4c90bb9a82035ac1de1f3bd2d40be6/jiter-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:06cb970936c65de926d648af0ed3d21857f026b1cf5525cb2947aa5e01e05789", size = 186100, upload-time = "2025-11-09T20:47:43.007Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a6/97209693b177716e22576ee1161674d1d58029eb178e01866a0422b69224/jiter-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6cc49d5130a14b732e0612bc76ae8db3b49898732223ef8b7599aa8d9810683e", size = 313658, upload-time = "2025-11-09T20:47:44.424Z" },
-    { url = "https://files.pythonhosted.org/packages/06/4d/125c5c1537c7d8ee73ad3d530a442d6c619714b95027143f1b61c0b4dfe0/jiter-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37f27a32ce36364d2fa4f7fdc507279db604d27d239ea2e044c8f148410defe1", size = 318605, upload-time = "2025-11-09T20:47:45.973Z" },
-    { url = "https://files.pythonhosted.org/packages/99/bf/a840b89847885064c41a5f52de6e312e91fa84a520848ee56c97e4fa0205/jiter-0.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbc0944aa3d4b4773e348cda635252824a78f4ba44328e042ef1ff3f6080d1cf", size = 349803, upload-time = "2025-11-09T20:47:47.535Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/88/e63441c28e0db50e305ae23e19c1d8fae012d78ed55365da392c1f34b09c/jiter-0.12.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da25c62d4ee1ffbacb97fac6dfe4dcd6759ebdc9015991e92a6eae5816287f44", size = 365120, upload-time = "2025-11-09T20:47:49.284Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7c/49b02714af4343970eb8aca63396bc1c82fa01197dbb1e9b0d274b550d4e/jiter-0.12.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:048485c654b838140b007390b8182ba9774621103bd4d77c9c3f6f117474ba45", size = 479918, upload-time = "2025-11-09T20:47:50.807Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ba/0a809817fdd5a1db80490b9150645f3aae16afad166960bcd562be194f3b/jiter-0.12.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:635e737fbb7315bef0037c19b88b799143d2d7d3507e61a76751025226b3ac87", size = 379008, upload-time = "2025-11-09T20:47:52.211Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/c3/c9fc0232e736c8877d9e6d83d6eeb0ba4e90c6c073835cc2e8f73fdeef51/jiter-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e017c417b1ebda911bd13b1e40612704b1f5420e30695112efdbed8a4b389ed", size = 361785, upload-time = "2025-11-09T20:47:53.512Z" },
-    { url = "https://files.pythonhosted.org/packages/96/61/61f69b7e442e97ca6cd53086ddc1cf59fb830549bc72c0a293713a60c525/jiter-0.12.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:89b0bfb8b2bf2351fba36bb211ef8bfceba73ef58e7f0c68fb67b5a2795ca2f9", size = 386108, upload-time = "2025-11-09T20:47:54.893Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/2e/76bb3332f28550c8f1eba3bf6e5efe211efda0ddbbaf24976bc7078d42a5/jiter-0.12.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f5aa5427a629a824a543672778c9ce0c5e556550d1569bb6ea28a85015287626", size = 519937, upload-time = "2025-11-09T20:47:56.253Z" },
-    { url = "https://files.pythonhosted.org/packages/84/d6/fa96efa87dc8bff2094fb947f51f66368fa56d8d4fc9e77b25d7fbb23375/jiter-0.12.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed53b3d6acbcb0fd0b90f20c7cb3b24c357fe82a3518934d4edfa8c6898e498c", size = 510853, upload-time = "2025-11-09T20:47:58.32Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/28/93f67fdb4d5904a708119a6ab58a8f1ec226ff10a94a282e0215402a8462/jiter-0.12.0-cp313-cp313-win32.whl", hash = "sha256:4747de73d6b8c78f2e253a2787930f4fffc68da7fa319739f57437f95963c4de", size = 204699, upload-time = "2025-11-09T20:47:59.686Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/1f/30b0eb087045a0abe2a5c9c0c0c8da110875a1d3be83afd4a9a4e548be3c/jiter-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:e25012eb0c456fcc13354255d0338cd5397cce26c77b2832b3c4e2e255ea5d9a", size = 204258, upload-time = "2025-11-09T20:48:01.01Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/f4/2b4daf99b96bce6fc47971890b14b2a36aef88d7beb9f057fafa032c6141/jiter-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:c97b92c54fe6110138c872add030a1f99aea2401ddcdaa21edf74705a646dd60", size = 185503, upload-time = "2025-11-09T20:48:02.35Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ca/67bb15a7061d6fe20b9b2a2fd783e296a1e0f93468252c093481a2f00efa/jiter-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53839b35a38f56b8be26a7851a48b89bc47e5d88e900929df10ed93b95fea3d6", size = 317965, upload-time = "2025-11-09T20:48:03.783Z" },
-    { url = "https://files.pythonhosted.org/packages/18/af/1788031cd22e29c3b14bc6ca80b16a39a0b10e611367ffd480c06a259831/jiter-0.12.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f669548e55c91ab47fef8bddd9c954dab1938644e715ea49d7e117015110a4", size = 345831, upload-time = "2025-11-09T20:48:05.55Z" },
-    { url = "https://files.pythonhosted.org/packages/05/17/710bf8472d1dff0d3caf4ced6031060091c1320f84ee7d5dcbed1f352417/jiter-0.12.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351d54f2b09a41600ffea43d081522d792e81dcfb915f6d2d242744c1cc48beb", size = 361272, upload-time = "2025-11-09T20:48:06.951Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f1/1dcc4618b59761fef92d10bcbb0b038b5160be653b003651566a185f1a5c/jiter-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2a5e90604620f94bf62264e7c2c038704d38217b7465b863896c6d7c902b06c7", size = 204604, upload-time = "2025-11-09T20:48:08.328Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/32/63cb1d9f1c5c6632a783c0052cde9ef7ba82688f7065e2f0d5f10a7e3edb/jiter-0.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:88ef757017e78d2860f96250f9393b7b577b06a956ad102c29c8237554380db3", size = 185628, upload-time = "2025-11-09T20:48:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/99/45c9f0dbe4a1416b2b9a8a6d1236459540f43d7fb8883cff769a8db0612d/jiter-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c46d927acd09c67a9fb1416df45c5a04c27e83aae969267e98fba35b74e99525", size = 312478, upload-time = "2025-11-09T20:48:10.898Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a7/54ae75613ba9e0f55fcb0bc5d1f807823b5167cc944e9333ff322e9f07dd/jiter-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:774ff60b27a84a85b27b88cd5583899c59940bcc126caca97eb2a9df6aa00c49", size = 318706, upload-time = "2025-11-09T20:48:12.266Z" },
-    { url = "https://files.pythonhosted.org/packages/59/31/2aa241ad2c10774baf6c37f8b8e1f39c07db358f1329f4eb40eba179c2a2/jiter-0.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5433fab222fb072237df3f637d01b81f040a07dcac1cb4a5c75c7aa9ed0bef1", size = 351894, upload-time = "2025-11-09T20:48:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/54/4f/0f2759522719133a9042781b18cc94e335b6d290f5e2d3e6899d6af933e3/jiter-0.12.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8c593c6e71c07866ec6bfb790e202a833eeec885022296aff6b9e0b92d6a70e", size = 365714, upload-time = "2025-11-09T20:48:15.083Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6f/806b895f476582c62a2f52c453151edd8a0fde5411b0497baaa41018e878/jiter-0.12.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90d32894d4c6877a87ae00c6b915b609406819dce8bc0d4e962e4de2784e567e", size = 478989, upload-time = "2025-11-09T20:48:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/86/6c/012d894dc6e1033acd8db2b8346add33e413ec1c7c002598915278a37f79/jiter-0.12.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:798e46eed9eb10c3adbbacbd3bdb5ecd4cf7064e453d00dbef08802dae6937ff", size = 378615, upload-time = "2025-11-09T20:48:18.614Z" },
-    { url = "https://files.pythonhosted.org/packages/87/30/d718d599f6700163e28e2c71c0bbaf6dace692e7df2592fd793ac9276717/jiter-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3f1368f0a6719ea80013a4eb90ba72e75d7ea67cfc7846db2ca504f3df0169a", size = 364745, upload-time = "2025-11-09T20:48:20.117Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/85/315b45ce4b6ddc7d7fceca24068543b02bdc8782942f4ee49d652e2cc89f/jiter-0.12.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65f04a9d0b4406f7e51279710b27484af411896246200e461d80d3ba0caa901a", size = 386502, upload-time = "2025-11-09T20:48:21.543Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0b/ce0434fb40c5b24b368fe81b17074d2840748b4952256bab451b72290a49/jiter-0.12.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:fd990541982a24281d12b67a335e44f117e4c6cbad3c3b75c7dea68bf4ce3a67", size = 519845, upload-time = "2025-11-09T20:48:22.964Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/a3/7a7a4488ba052767846b9c916d208b3ed114e3eb670ee984e4c565b9cf0d/jiter-0.12.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b111b0e9152fa7df870ecaebb0bd30240d9f7fff1f2003bcb4ed0f519941820b", size = 510701, upload-time = "2025-11-09T20:48:24.483Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/16/052ffbf9d0467b70af24e30f91e0579e13ded0c17bb4a8eb2aed3cb60131/jiter-0.12.0-cp314-cp314-win32.whl", hash = "sha256:a78befb9cc0a45b5a5a0d537b06f8544c2ebb60d19d02c41ff15da28a9e22d42", size = 205029, upload-time = "2025-11-09T20:48:25.749Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/18/3cf1f3f0ccc789f76b9a754bdb7a6977e5d1d671ee97a9e14f7eb728d80e/jiter-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:e1fe01c082f6aafbe5c8faf0ff074f38dfb911d53f07ec333ca03f8f6226debf", size = 204960, upload-time = "2025-11-09T20:48:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/02/68/736821e52ecfdeeb0f024b8ab01b5a229f6b9293bbdb444c27efade50b0f/jiter-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:d72f3b5a432a4c546ea4bedc84cce0c3404874f1d1676260b9c7f048a9855451", size = 185529, upload-time = "2025-11-09T20:48:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/30/61/12ed8ee7a643cce29ac97c2281f9ce3956eb76b037e88d290f4ed0d41480/jiter-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e6ded41aeba3603f9728ed2b6196e4df875348ab97b28fc8afff115ed42ba7a7", size = 318974, upload-time = "2025-11-09T20:48:30.87Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c6/f3041ede6d0ed5e0e79ff0de4c8f14f401bbf196f2ef3971cdbe5fd08d1d/jiter-0.12.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a947920902420a6ada6ad51892082521978e9dd44a802663b001436e4b771684", size = 345932, upload-time = "2025-11-09T20:48:32.658Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5d/4d94835889edd01ad0e2dbfc05f7bdfaed46292e7b504a6ac7839aa00edb/jiter-0.12.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:add5e227e0554d3a52cf390a7635edaffdf4f8fce4fdbcef3cc2055bb396a30c", size = 367243, upload-time = "2025-11-09T20:48:34.093Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/76/0051b0ac2816253a99d27baf3dda198663aff882fa6ea7deeb94046da24e/jiter-0.12.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f9b1cda8fcb736250d7e8711d4580ebf004a46771432be0ae4796944b5dfa5d", size = 479315, upload-time = "2025-11-09T20:48:35.507Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/83f793acd68e5cb24e483f44f482a1a15601848b9b6f199dacb970098f77/jiter-0.12.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:deeb12a2223fe0135c7ff1356a143d57f95bbf1f4a66584f1fc74df21d86b993", size = 380714, upload-time = "2025-11-09T20:48:40.014Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/4808a88338ad2c228b1126b93fcd8ba145e919e886fe910d578230dabe3b/jiter-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c596cc0f4cb574877550ce4ecd51f8037469146addd676d7c1a30ebe6391923f", size = 365168, upload-time = "2025-11-09T20:48:41.462Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/d4/04619a9e8095b42aef436b5aeb4c0282b4ff1b27d1db1508df9f5dc82750/jiter-0.12.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ab4c823b216a4aeab3fdbf579c5843165756bd9ad87cc6b1c65919c4715f783", size = 387893, upload-time = "2025-11-09T20:48:42.921Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ea/d3c7e62e4546fdc39197fa4a4315a563a89b95b6d54c0d25373842a59cbe/jiter-0.12.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e427eee51149edf962203ff8db75a7514ab89be5cb623fb9cea1f20b54f1107b", size = 520828, upload-time = "2025-11-09T20:48:44.278Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/0b/c6d3562a03fd767e31cb119d9041ea7958c3c80cb3d753eafb19b3b18349/jiter-0.12.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:edb868841f84c111255ba5e80339d386d937ec1fdce419518ce1bd9370fac5b6", size = 511009, upload-time = "2025-11-09T20:48:45.726Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/51/2cb4468b3448a8385ebcd15059d325c9ce67df4e2758d133ab9442b19834/jiter-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8bbcfe2791dfdb7c5e48baf646d37a6a3dcb5a97a032017741dea9f817dca183", size = 205110, upload-time = "2025-11-09T20:48:47.033Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c5/ae5ec83dec9c2d1af805fd5fe8f74ebded9c8670c5210ec7820ce0dbeb1e/jiter-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2fa940963bf02e1d8226027ef461e36af472dea85d36054ff835aeed944dd873", size = 205223, upload-time = "2025-11-09T20:48:49.076Z" },
-    { url = "https://files.pythonhosted.org/packages/97/9a/3c5391907277f0e55195550cf3fa8e293ae9ee0c00fb402fec1e38c0c82f/jiter-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:506c9708dd29b27288f9f8f1140c3cb0e3d8ddb045956d7757b1fa0e0f39a473", size = 185564, upload-time = "2025-11-09T20:48:50.376Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/54/5339ef1ecaa881c6948669956567a64d2670941925f245c434f494ffb0e5/jiter-0.12.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:4739a4657179ebf08f85914ce50332495811004cc1747852e8b2041ed2aab9b8", size = 311144, upload-time = "2025-11-09T20:49:10.503Z" },
-    { url = "https://files.pythonhosted.org/packages/27/74/3446c652bffbd5e81ab354e388b1b5fc1d20daac34ee0ed11ff096b1b01a/jiter-0.12.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:41da8def934bf7bec16cb24bd33c0ca62126d2d45d81d17b864bd5ad721393c3", size = 305877, upload-time = "2025-11-09T20:49:12.269Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f4/ed76ef9043450f57aac2d4fbeb27175aa0eb9c38f833be6ef6379b3b9a86/jiter-0.12.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c44ee814f499c082e69872d426b624987dbc5943ab06e9bbaa4f81989fdb79e", size = 340419, upload-time = "2025-11-09T20:49:13.803Z" },
-    { url = "https://files.pythonhosted.org/packages/21/01/857d4608f5edb0664aa791a3d45702e1a5bcfff9934da74035e7b9803846/jiter-0.12.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd2097de91cf03eaa27b3cbdb969addf83f0179c6afc41bbc4513705e013c65d", size = 347212, upload-time = "2025-11-09T20:49:15.643Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/f5/12efb8ada5f5c9edc1d4555fe383c1fb2eac05ac5859258a72d61981d999/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e8547883d7b96ef2e5fe22b88f8a4c8725a56e7f4abafff20fd5272d634c7ecb", size = 309974, upload-time = "2025-11-09T20:49:17.187Z" },
-    { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
-]
-
-[[package]]
-name = "macholib"
-version = "1.16.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "altgraph" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -569,24 +273,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pefile"
-version = "2024.8.26"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
-]
-
-[[package]]
-name = "plotext"
-version = "5.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/d7/f75f397af966fe252d0d34ffd3cae765317fce2134f925f95e7d6725d1ce/plotext-5.3.2.tar.gz", hash = "sha256:52d1e932e67c177bf357a3f0fe6ce14d1a96f7f7d5679d7b455b929df517068e", size = 61967, upload-time = "2024-09-24T15:13:37.728Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/1e/12fe7c40cd2099a1f454518754ed229b01beaf3bbb343127f0cc13ce6c22/plotext-5.3.2-py3-none-any.whl", hash = "sha256:394362349c1ddbf319548cfac17ca65e6d5dfc03200c40dfdc0503b3e95a2283", size = 64047, upload-time = "2024-09-24T15:13:36.296Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -602,15 +288,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -726,67 +403,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pyinstaller"
-version = "6.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "altgraph" },
-    { name = "macholib", marker = "sys_platform == 'darwin'" },
-    { name = "packaging" },
-    { name = "pefile", marker = "sys_platform == 'win32'" },
-    { name = "pyinstaller-hooks-contrib" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/b8/0fe3359920b0a4e7008e0e93ff383003763e3eee3eb31a07c52868722960/pyinstaller-6.18.0.tar.gz", hash = "sha256:cdc507542783511cad4856fce582fdc37e9f29665ca596889c663c83ec8c6ec9", size = 4034976, upload-time = "2026-01-13T03:13:23.886Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/e6/51b0146a1a3eec619e58f5d69fb4e3d0f65a31cbddbeef557c9bb83eeed9/pyinstaller-6.18.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:cb7aa5a71bfa7c0af17a4a4e21855663c89e4bd7c40f1d337c8370636d8847c3", size = 1040056, upload-time = "2026-01-13T03:12:15.397Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/9c/a3634c0ec8e1ed31b373b548848b5c0b39b56edc191cf737e697d484ec23/pyinstaller-6.18.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:07785459b3bf8a48889eac0b4d0667ade84aef8930ce030bc7cbb32f41283b33", size = 734971, upload-time = "2026-01-13T03:12:20.912Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/04/6756442078ccfcd552ccce636be1574035e62f827ffa1f5d8a0382682546/pyinstaller-6.18.0-py3-none-manylinux2014_i686.whl", hash = "sha256:f998675b7ccb2dabbb1dc2d6f18af61d55428ad6d38e6c4d700417411b697d37", size = 746637, upload-time = "2026-01-13T03:12:29.302Z" },
-    { url = "https://files.pythonhosted.org/packages/54/39/fbc56519000cdbf450f472692a7b9b55d42077ce8529f1be631db7b75a36/pyinstaller-6.18.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:779817a0cf69604cddcdb5be1fd4959dc2ce048d6355c73e5da97884df2f3387", size = 744343, upload-time = "2026-01-13T03:12:33.369Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f2/50887badf282fee776e83d1e4feab74c026f50a1ea16e109ed939e32aa28/pyinstaller-6.18.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:31b5d109f8405be0b7cddcede43e7b074792bc9a5bbd54ec000a3e779183c2af", size = 741084, upload-time = "2026-01-13T03:12:37.528Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/08/3a1419183e4713ef77d912ecbdd6ef858689ed9deb34d547133f724ca745/pyinstaller-6.18.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:4328c9837f1aef4fe1a127d4ff1b09a12ce53c827ce87c94117628b0e1fd098b", size = 740943, upload-time = "2026-01-13T03:12:41.589Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/309305e36d116f1434b42d91c420ff951fa79b2c398bbd59930c830450be/pyinstaller-6.18.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:3638fc81eb948e5e5eab1d4ad8f216e3fec6d4a350648304f0adb227b746ee5e", size = 740107, upload-time = "2026-01-13T03:12:45.694Z" },
-    { url = "https://files.pythonhosted.org/packages/83/0f/a59a95cd1df59ddbc9e74d5a663387551333bcf19a5dd3086f5c81a2e83c/pyinstaller-6.18.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe59da34269e637f97fd3c43024f764586fc319141d245ff1a2e9af1036aa3", size = 739843, upload-time = "2026-01-13T03:12:49.728Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/09/e7a870e7205cdbd2f8785010a5d3fe48a9df2591156ee34a8b29b774fa14/pyinstaller-6.18.0-py3-none-win32.whl", hash = "sha256:496205e4fa92ec944f9696eb597962a83aef4d4c3479abfab83d730e1edf016b", size = 1323811, upload-time = "2026-01-13T03:12:55.717Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d5/48eef2002b6d3937ceac2717fe17e9ca3a43a4c9826bafee367dfc75ba85/pyinstaller-6.18.0-py3-none-win_amd64.whl", hash = "sha256:976fabd90ecfbda47571c87055ad73413ec615ff7dea35e12a4304174de78de9", size = 1384389, upload-time = "2026-01-13T03:13:01.993Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/8d/1a88e6e94107de3ea1c842fd59c3aa132d344ad8e52ea458ffa9a748726e/pyinstaller-6.18.0-py3-none-win_arm64.whl", hash = "sha256:dba4b70e3c9ba09aab51152c72a08e58a751851548f77ad35944d32a300c8381", size = 1324869, upload-time = "2026-01-13T03:13:08.192Z" },
-]
-
-[[package]]
-name = "pyinstaller-hooks-contrib"
-version = "2026.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/8f/8052ff65067697ee80fde45b9731842e160751c41ac5690ba232c22030e8/pyinstaller_hooks_contrib-2026.0.tar.gz", hash = "sha256:0120893de491a000845470ca9c0b39284731ac6bace26f6849dea9627aaed48e", size = 170311, upload-time = "2026-01-20T00:15:23.922Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/b1/9da6ec3e88696018ee7bb9dc4a7310c2cfaebf32923a19598cd342767c10/pyinstaller_hooks_contrib-2026.0-py3-none-any.whl", hash = "sha256:0590db8edeba3e6c30c8474937021f5cd39c0602b4d10f74a064c73911efaca5", size = 452318, upload-time = "2026-01-20T00:15:21.88Z" },
 ]
 
 [[package]]
@@ -816,24 +438,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
-]
-
-[[package]]
-name = "pywin32-ctypes"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1052,17 +656,11 @@ name = "router-maestro"
 version = "0.5.4"
 source = { editable = "." }
 dependencies = [
-    { name = "aiosqlite" },
-    { name = "anthropic" },
-    { name = "authlib" },
     { name = "fastapi" },
     { name = "h2" },
     { name = "httpx", extra = ["socks"] },
-    { name = "plotext" },
     { name = "prometheus-client" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
     { name = "rapidfuzz" },
     { name = "rich" },
     { name = "tiktoken" },
@@ -1073,7 +671,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "pyinstaller" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -1081,20 +678,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.19.0" },
-    { name = "anthropic", specifier = ">=0.40.0" },
-    { name = "authlib", specifier = ">=1.3.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "h2", specifier = ">=4.0.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.26.0" },
-    { name = "plotext", specifier = ">=5.2.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
-    { name = "pydantic-settings", specifier = ">=2.1.0" },
-    { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -1132,30 +722,12 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "80.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
-]
-
-[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Complete Phase 4 of the codebase maintainability remediation plan as one phase-level batch:

- Task 21: align documentation with the implemented contracts
- Task 22: expand live and deterministic controlled-boundary integration coverage
- Task 23: remove confirmed dead abstractions and dependencies after migration

This PR documents and validates the behavior delivered by the earlier remediation phases, consolidates stream protection behind one typed guard boundary, and verifies the resulting source and package artifacts.

## What changed

### Documentation and contracts

- Document pre-commit native non-2xx errors versus post-commit in-stream terminals.
- Document capability-aware routing/fallback, provider-qualified model IDs and bare aliases.
- Document option support, rejection, reasoning-effort substitution, request lifecycle, Router leases, and audit ownership.
- Correct stale claims around audit artifacts, beta behavior, custom providers, 1M variants, and reasoning suffixes.
- Keep historical changelog entries intact; new notes are under `Unreleased`.

### Boundary validation

- Add deterministic loopback-upstream coverage through a real Router-Maestro subprocess and transport/codec stack.
- Cover operation/capability routing, option fidelity, fallback identity, protocol-native pre/post-commit failures, and unexpected EOF.
- Expand live coverage for enabled thinking with budget/effort in streaming and non-streaming modes.
- Isolate controlled tests with temporary HOME/XDG state so local credentials and configuration are not used.

### Guard pipeline and cleanup

- Introduce a typed `GuardChain` owned by `RequestPipeline` and built from the request-scoped immutable configuration snapshot.
- Leak-scan `content`, `refusal`, and `thinking` with independent matcher state; only ordinary content participates in `<invoke>` tool recovery.
- Include refusal, thinking, opaque reasoning identifiers/signatures, and tool arguments in runaway accounting.
- For beta-native Anthropic streams, project visible typed fields for leak checks and count each actual emitted raw frame via the exact `opaque_payload` wire string, including future subtype/extension fields, without double accounting.
- Preserve the public compatibility API: `StreamGuard`, `GuardAbortError`, `build_guards`, and `guarded_stream`.
- Preserve legacy custom-guard behavior: only `chunk.content` is passed to `feed_text()`.
- Keep the existing stream-only guard boundary; non-stream guard behavior is not expanded here.
- Remove confirmed dead translation/reasoning helpers and unused dependencies, then regenerate `uv.lock`.

## Deferred work

Decision D remains unresolved and Task 19 remains deferred.

This PR does not separate administrator and inference credentials and does not change administrator authentication behavior. `ROUTER_MAESTRO_API_KEY` continues to protect both inference and `/api/admin/*` until a backward-compatible transition is agreed separately.

## Verification

Exact acceptance commit: `ab88acb7673d9321e069daed856c6f04a2b451c9`

Exact acceptance tree: `ce4cf8668244dd939c56f57efe2501640f0c2c47`

- `uv run pytest tests/ -q`: `3531 passed in 20.13s`
- `uv run ruff check src/ tests/ integration_tests/`: passed
- `uv run ruff format --check src/ tests/ integration_tests/`: `199 files already formatted`
- `uv run python -m compileall -q src/router_maestro`: passed
- `uv lock --check`: passed
- `uv run router-maestro --help`: passed
- `git diff --check`: passed
- `uv build`: built `router_maestro-0.5.4-py3-none-any.whl` and `router_maestro-0.5.4.tar.gz`
- Wheel/sdist contents and removed dependency metadata inspected
- Fresh CPython 3.11.15 environment installed the wheel offline from local cache; installed CLI and public pipeline imports passed from temporary `site-packages`
- Unbounded `make integration-test`: `92 passed, 3 skipped in 1554.31s (25:54)`
  - No model-matrix limiting environment variables were set.
  - The three skips were capability/model-availability conditions; there were no failures.

## Release boundary

This PR does not create a version tag, publish Python artifacts, push a Docker image, create a GitHub release, or otherwise perform a release.
