### PR TITLE
fix: restore model catalog and provider config compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ All notable changes to Router-Maestro are documented here.
 
 ### Fixes
 
+- **Consistent application-owned model catalogs.** OpenAI, Anthropic, and Admin
+  model-list endpoints now acquire the active application-owned Router
+  generation under a lease. Catalogs immediately observe generation rebuilds,
+  while an in-flight listing safely retains its old provider resources until
+  completion instead of consulting a stale module singleton.
+- **Backward-compatible custom-provider options.** Preserve unknown legacy
+  `providers.json` option keys across load/save without activating them at
+  runtime. Provider definitions are validated independently, so one invalid,
+  reserved, or case-insensitive duplicate entry is skipped with secret-safe
+  diagnostics instead of hiding every healthy custom provider.
 - **Consistent fallback and provider failure semantics.** Normalize transport,
   authentication, rate-limit, upstream-status, upstream-protocol, unsupported,
   and client-request failures into one typed contract and record every planned

--- a/README.md
+++ b/README.md
@@ -531,6 +531,12 @@ requirements are obtained from the active server, so the same login command
 works for local and remote contexts. Only a local context may fall back to the
 local `providers.json` while its server is unavailable.
 
+The supported runtime options are `api_key_env` and
+`allow_unauthenticated`. Router-Maestro preserves unknown option keys from
+older `providers.json` files when loading and saving, but ignores them at
+runtime. If one provider definition is invalid, it is skipped with a sanitized
+diagnostic while other valid custom providers remain available.
+
 ### Hot-Reload
 
 Configuration files are automatically reloaded every 5 minutes:

--- a/docs/superpowers/plans/2026-07-15-pr128-model-list-provider-config-fix.md
+++ b/docs/superpowers/plans/2026-07-15-pr128-model-list-provider-config-fix.md
@@ -155,7 +155,7 @@ Install the wheel into a fresh CPython 3.11 environment, run CLI help, and
 import the shared server dependency and provider config models from installed
 `site-packages`.
 
-- [ ] **Step 5: Commit, push, and open the PR without merging**
+- [x] **Step 5: Commit, push, and open the PR without merging**
 
 Explicitly stage only reviewed paths, commit, push the fix branch, and create a
 PR against `master` containing the two root causes, compatibility behavior, and

--- a/docs/superpowers/plans/2026-07-15-pr128-model-list-provider-config-fix.md
+++ b/docs/superpowers/plans/2026-07-15-pr128-model-list-provider-config-fix.md
@@ -1,0 +1,163 @@
+# PR #128 Model Listing and Provider Config Compatibility Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the split Router ownership from model listing and restore safe compatibility for existing custom-provider option data.
+
+**Architecture:** FastAPI model-list routes acquire the active application-owned Router through one yield dependency, preserving generation leases and resource retirement. Provider configuration loading retains unknown legacy option data and validates providers independently so one invalid entry cannot erase healthy entries.
+
+**Tech Stack:** Python 3.11+, FastAPI dependency injection, Pydantic v2, pytest/pytest-asyncio, Ruff, uv.
+
+---
+
+### Task 1: Make every server model listing use a RouterOwner lease
+
+**Files:**
+- Create: `src/router_maestro/server/dependencies.py`
+- Modify: `src/router_maestro/server/routes/models.py`
+- Modify: `src/router_maestro/server/routes/anthropic.py`
+- Modify: `src/router_maestro/server/routes/admin.py`
+- Modify: `tests/test_models_route.py`
+- Modify: `tests/test_anthropic_models.py`
+- Modify: `tests/test_admin_routes.py`
+
+- [x] **Step 1: Write failing generation-consistency tests**
+
+Add HTTP-level tests with an application-owned `RouterOwner`. Prime a legacy
+singleton with stale data, assert both public routes return generation A, call
+`owner.rebuild()` with generation B, and assert both routes immediately return
+B while the legacy singleton is never called.
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_models_route.py tests/test_anthropic_models.py -q
+```
+
+Expected: the new tests fail because both public endpoints still call
+`get_router()` and ignore `app.state.router_owner`.
+
+- [x] **Step 3: Add the shared lease dependency and inject it**
+
+Implement `get_router_owner()`, `get_runtime_config_repository()`, and an async
+generator `get_app_router()` that acquires a lease and releases it in `finally`.
+Inject its yielded Router into the OpenAI, Anthropic, and Admin listing routes.
+Keep Admin refresh and mutation operations on the owner itself.
+
+- [x] **Step 4: Add lifecycle/error coverage**
+
+Prove that an old listing blocked on generation A keeps A open while a rebuild
+installs B, a new listing sees B, and A closes exactly once after release. Prove
+that `list_models()` exceptions still release the lease.
+
+- [x] **Step 5: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_models_route.py tests/test_anthropic_models.py tests/test_admin_routes.py tests/test_router_lifecycle.py -q
+```
+
+Expected: all selected tests pass with no singleton use in server listing.
+
+### Task 2: Preserve legacy provider options and isolate invalid providers
+
+**Files:**
+- Modify: `src/router_maestro/config/providers.py`
+- Modify: `src/router_maestro/config/settings.py`
+- Modify: `tests/test_custom_provider_auth.py`
+- Modify: `tests/test_config.py`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [x] **Step 1: Write failing compatibility tests**
+
+Write tests that load two custom providers from disk where one contains an
+unknown option. Assert both load, the unknown key survives `model_dump()` and
+save/reload, and the file is not changed merely by loading. Add a second test
+where one provider has an invalid known field; assert the healthy provider is
+retained and logs contain the provider/field path but not the invalid value.
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_custom_provider_auth.py tests/test_config.py -q
+```
+
+Expected: unknown options raise `extra_forbidden` and a single validation error
+causes `providers={}`.
+
+- [x] **Step 3: Retain compatibility extras**
+
+Set `CustomProviderOptions` to allow and retain extras while continuing to
+validate `api_key_env` and `allow_unauthenticated`. Runtime code must continue
+to consume only the typed fields.
+
+- [x] **Step 4: Add a provider-specific resilient loader**
+
+Implement `load_providers_config()` as a safe per-provider parser. Validate
+top-level structure and provider identifiers, skip only invalid entries, and
+log sanitized field locations/codes. Preserve missing-file creation and corrupt
+JSON fallback behavior without rewriting existing invalid files.
+
+- [x] **Step 5: Document the compatibility contract**
+
+Document that unknown legacy option keys are preserved but ignored at runtime,
+and record both regression fixes under `CHANGELOG.md` `Unreleased`.
+
+- [x] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_custom_provider_auth.py tests/test_config.py tests/test_admin_routes.py tests/test_integration_harness.py -q
+```
+
+Expected: all selected tests pass, including safe diagnostics and round-trip.
+
+### Task 3: Review, full verification, and PR handoff
+
+**Files:**
+- Review all files changed by Tasks 1–2.
+
+- [x] **Step 1: Run independent specification and quality reviews**
+
+Review the complete diff against the design. Fix all Critical/Important issues
+and re-review affected boundaries.
+
+- [x] **Step 2: Run full local gates**
+
+```bash
+uv run pytest tests/ -q
+uv run ruff check src/ tests/ integration_tests/
+uv run ruff format --check src/ tests/ integration_tests/
+uv run python -m compileall -q src/router_maestro
+uv lock --check
+uv run router-maestro --help
+uv build
+git diff --check
+```
+
+- [x] **Step 3: Run controlled end-to-end regression**
+
+Start a real temporary-XDG Router-Maestro app, prime public model listing,
+perform Admin login for a configured custom provider, and prove OpenAI,
+Anthropic, and Admin listings all immediately expose the same model. Verify the
+real user auth file hash is unchanged.
+
+- [x] **Step 4: Verify the built wheel**
+
+Install the wheel into a fresh CPython 3.11 environment, run CLI help, and
+import the shared server dependency and provider config models from installed
+`site-packages`.
+
+- [ ] **Step 5: Commit, push, and open the PR without merging**
+
+Explicitly stage only reviewed paths, commit, push the fix branch, and create a
+PR against `master` containing the two root causes, compatibility behavior, and
+exact verification results. Confirm the PR remains `OPEN`; do not merge, tag,
+publish, or release.

--- a/docs/superpowers/specs/2026-07-15-pr128-model-list-provider-config-design.md
+++ b/docs/superpowers/specs/2026-07-15-pr128-model-list-provider-config-design.md
@@ -1,0 +1,78 @@
+# PR #128 Model Listing and Provider Config Compatibility Design
+
+## Context
+
+PR #128 introduced application-owned `RouterOwner` generations for request
+lifecycle and credential/configuration mutations. Inference requests and Admin
+model listing use those generations, but the public OpenAI and Anthropic model
+listing routes still resolve the legacy module singleton. A successful Admin
+login, logout, priority update, or model refresh therefore leaves those two
+catalogs stale until independent caches expire.
+
+The same PR replaced the previously open-ended custom-provider `options` map
+with two typed fields. Unknown keys in an existing `providers.json` now fail
+whole-document validation; the generic loader then returns the empty default,
+temporarily removing every custom provider from routing and discovery.
+
+## Requirements
+
+1. OpenAI, Anthropic, and Admin model listing must read one application-owned
+   Router generation under a lease and must never consult the module singleton
+   in normal FastAPI operation.
+2. A listing that began before a generation swap may finish on its leased old
+   generation; a listing beginning after the swap must see the new generation.
+   Provider resources close only after the last old lease is released.
+3. Listing success and failure must release the lease exactly once.
+4. Unknown legacy custom-provider option keys must survive load and save without
+   becoming active runtime behavior or silently disappearing.
+5. One invalid custom-provider entry must not erase unrelated valid entries.
+   Diagnostics identify provider and field paths without logging input values.
+6. Existing typed option validation, reserved-name validation, credential
+   precedence, inference behavior, and public response formats remain intact.
+7. The fix lands through a pull request but is not merged as part of this task.
+
+## Design
+
+### Application-owned model catalog dependency
+
+Create a small shared server dependency module. `get_router_owner()` reads the
+owner from `request.app.state`; `get_app_router()` acquires the current Router
+lease and yields its Router, releasing the lease in `finally`. Move the runtime
+configuration dependency there as well so Admin routes do not own a dependency
+needed by other route modules.
+
+Inject this Router into all three model-list endpoints. Do not add model listing
+to `RequestContextMiddleware`: listing is not inference and should not acquire
+inference audit/terminal state. Do not reset the module singleton from
+`RouterOwner.rebuild()`: the singleton has no lease/refcount relationship with
+the application owner and cannot safely retire provider resources.
+
+Keep `get_router()` and `reset_router()` as legacy/standalone compatibility APIs
+for now. Normal server model listing no longer uses their fallback branch.
+
+### Compatible custom-provider loading
+
+Keep `api_key_env` and `allow_unauthenticated` typed, but configure
+`CustomProviderOptions` to retain unknown extras. Runtime credential resolution
+continues to read only the two known fields. Model serialization includes the
+extras, so a future save cannot silently delete legacy data.
+
+Specialize `load_providers_config()` instead of weakening the generic config
+loader used by unrelated files. It reads the top-level document, validates each
+provider independently, skips invalid entries, and returns all healthy entries.
+Warnings contain only provider names, validation locations/codes, and unknown
+option key names—never option values or Pydantic input echoes. Invalid JSON or
+an invalid top-level shape still falls back to the empty default without
+overwriting the source file.
+
+## Verification
+
+- Red/green route tests prove both public catalogs switch from generation A to
+  B immediately and never use `_router_instance`.
+- Concurrency tests prove an old generation remains alive until its listing
+  lease finishes while a new request observes the replacement.
+- Dependency tests prove release on listing exceptions.
+- Config tests prove unknown option round-trip, known-field validation, one bad
+  provider isolation, safe diagnostics, and unchanged source files.
+- Run focused suites, all unit tests, Ruff/format, compile, lock, build, wheel
+  install smoke, and a controlled real-app Admin-login/listing regression.

--- a/src/router_maestro/config/providers.py
+++ b/src/router_maestro/config/providers.py
@@ -27,7 +27,7 @@ class ModelConfig(BaseModel):
 class CustomProviderOptions(BaseModel):
     """Runtime options supported by an OpenAI-compatible custom provider."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
     api_key_env: str | None = Field(
         default=None,

--- a/src/router_maestro/config/settings.py
+++ b/src/router_maestro/config/settings.py
@@ -13,11 +13,31 @@ from pydantic import BaseModel, ValidationError
 from router_maestro.config.contexts import ContextsConfig
 from router_maestro.config.paths import CONTEXTS_FILE, PRIORITIES_FILE, PROVIDERS_FILE
 from router_maestro.config.priorities import PrioritiesConfig
-from router_maestro.config.providers import ProvidersConfig
+from router_maestro.config.providers import (
+    RESERVED_PROVIDER_NAMES,
+    CustomProviderConfig,
+    ProvidersConfig,
+)
+from router_maestro.routing.model_ref import validate_provider_id
 
 T = TypeVar("T", bound=BaseModel)
 
 logger = logging.getLogger("router_maestro.config.settings")
+
+
+def _safe_provider_validation_location(location: tuple[str | int, ...]) -> str:
+    """Format a schema path without exposing dynamic model IDs or control characters."""
+    parts: list[str] = []
+    redact_model_id = False
+    for part in location:
+        if redact_model_id:
+            parts.append("<model-id>")
+            redact_model_id = False
+            continue
+        rendered = str(part)
+        parts.append(rendered if rendered.isidentifier() else repr(rendered))
+        redact_model_id = rendered == "models"
+    return ".".join(parts) or "provider"
 
 
 def write_json_owner_only(path: Path, data: Any) -> None:
@@ -96,8 +116,109 @@ def save_config(path: Path, config: BaseModel) -> None:
 
 
 def load_providers_config() -> ProvidersConfig:
-    """Load providers configuration."""
-    return load_config(PROVIDERS_FILE, ProvidersConfig, ProvidersConfig.get_default)
+    """Load custom providers independently while preserving compatible entries."""
+    if not PROVIDERS_FILE.exists():
+        config = ProvidersConfig.get_default()
+        save_config(PROVIDERS_FILE, config)
+        return config
+
+    try:
+        with open(PROVIDERS_FILE, encoding="utf-8") as f:
+            data = json.load(f)
+    except UnicodeDecodeError:
+        logger.error(
+            "Failed to load providers config from %s (invalid_encoding); falling back to defaults",
+            PROVIDERS_FILE,
+        )
+        return ProvidersConfig.get_default()
+    except json.JSONDecodeError:
+        logger.error(
+            "Failed to load providers config from %s (invalid_json); falling back to defaults",
+            PROVIDERS_FILE,
+        )
+        return ProvidersConfig.get_default()
+    except OSError:
+        logger.error(
+            "Failed to load providers config from %s (os_error); falling back to defaults",
+            PROVIDERS_FILE,
+        )
+        return ProvidersConfig.get_default()
+
+    if not isinstance(data, dict):
+        logger.error(
+            "Failed to validate providers config from %s at root (mapping_type); "
+            "falling back to defaults",
+            PROVIDERS_FILE,
+        )
+        return ProvidersConfig.get_default()
+
+    raw_providers = data.get("providers", {})
+    if not isinstance(raw_providers, dict):
+        logger.error(
+            "Failed to validate providers config from %s at providers (mapping_type); "
+            "falling back to defaults",
+            PROVIDERS_FILE,
+        )
+        return ProvidersConfig.get_default()
+
+    providers: dict[str, CustomProviderConfig] = {}
+    canonical_names: dict[str, str] = {}
+    for provider_name, raw_provider in raw_providers.items():
+        try:
+            validate_provider_id(provider_name)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Skipping custom provider %r: provider_id:invalid_provider_name",
+                provider_name,
+            )
+            continue
+
+        canonical_name = provider_name.casefold()
+        if canonical_name in RESERVED_PROVIDER_NAMES:
+            logger.warning(
+                "Skipping custom provider %r: provider_id:reserved_provider_name",
+                provider_name,
+            )
+            continue
+        duplicate = canonical_names.get(canonical_name)
+        if duplicate is not None:
+            logger.warning(
+                "Skipping custom provider %r: provider_id:duplicate_provider_name "
+                "(already loaded as %r)",
+                provider_name,
+                duplicate,
+            )
+            continue
+
+        try:
+            provider = CustomProviderConfig.model_validate(raw_provider)
+        except ValidationError as error:
+            diagnostics = []
+            for detail in error.errors(
+                include_url=False,
+                include_context=False,
+                include_input=False,
+            ):
+                location = _safe_provider_validation_location(detail["loc"])
+                diagnostics.append(f"{location}:{detail['type']}")
+            logger.warning(
+                "Skipping custom provider %r: validation failed at %s",
+                provider_name,
+                ", ".join(diagnostics),
+            )
+            continue
+
+        providers[provider_name] = provider
+        canonical_names[canonical_name] = provider_name
+        legacy_options = sorted((provider.options.model_extra or {}).keys())
+        if legacy_options:
+            logger.warning(
+                "Custom provider %r retains ignored legacy option keys: %s",
+                provider_name,
+                ", ".join(repr(option) for option in legacy_options),
+            )
+
+    return ProvidersConfig(providers=providers)
 
 
 def save_providers_config(config: ProvidersConfig) -> None:

--- a/src/router_maestro/server/dependencies.py
+++ b/src/router_maestro/server/dependencies.py
@@ -1,0 +1,29 @@
+"""Application-owned dependencies shared by server routes."""
+
+from collections.abc import AsyncIterator
+
+from fastapi import Depends, Request
+
+from router_maestro.config.repository import RuntimeConfigRepository
+from router_maestro.routing.router import Router, RouterOwner
+
+
+def get_router_owner(request: Request) -> RouterOwner:
+    """Return the application-owned Router generation manager."""
+    return request.app.state.router_owner
+
+
+def get_runtime_config_repository(request: Request) -> RuntimeConfigRepository:
+    """Return the application-owned runtime configuration repository."""
+    return request.app.state.runtime_config_repository
+
+
+async def get_app_router(
+    owner: RouterOwner = Depends(get_router_owner),
+) -> AsyncIterator[Router]:
+    """Yield the current app-owned Router generation under a request lease."""
+    lease = await owner.acquire()
+    try:
+        yield lease.router
+    finally:
+        await lease.release()

--- a/src/router_maestro/server/routes/admin.py
+++ b/src/router_maestro/server/routes/admin.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
 
 from router_maestro.auth import (
     ApiKeyCredential,
@@ -28,6 +28,12 @@ from router_maestro.config.repository import (
 )
 from router_maestro.config.settings import load_providers_config
 from router_maestro.routing.model_ref import catalog_model_public_id
+from router_maestro.routing.router import Router
+from router_maestro.server.dependencies import (
+    get_app_router,
+    get_router_owner,
+    get_runtime_config_repository,
+)
 from router_maestro.server.oauth_sessions import oauth_sessions
 from router_maestro.server.schemas.admin import (
     AuthListResponse,
@@ -46,16 +52,6 @@ from router_maestro.server.schemas.admin import (
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
 logger = logging.getLogger("router_maestro.server.routes.admin")
-
-
-def get_runtime_config_repository(request: Request) -> RuntimeConfigRepository:
-    """Return the application-owned runtime configuration repository."""
-    return request.app.state.runtime_config_repository
-
-
-def get_router_owner(request: Request):
-    """Return the application-owned Router generation owner."""
-    return request.app.state.router_owner
 
 
 def _runtime_config_response(snapshot: RuntimeConfigSnapshot) -> PrioritiesResponse:
@@ -387,12 +383,10 @@ async def logout(
 
 
 @router.get("/models", response_model=ModelsResponse)
-async def list_models(router_owner=Depends(get_router_owner)) -> ModelsResponse:
+async def list_models(model_router: Router = Depends(get_app_router)) -> ModelsResponse:
     """List all available models from authenticated providers."""
-    lease = await router_owner.acquire()
-
     try:
-        models = await lease.router.list_models()
+        models = await model_router.list_models()
         model_list = [
             ModelInfo(
                 provider=model.provider,
@@ -412,8 +406,6 @@ async def list_models(router_owner=Depends(get_router_owner)) -> ModelsResponse:
     except Exception:
         logger.error("Failed to list models", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to list models")
-    finally:
-        await lease.release()
 
 
 @router.post("/models/refresh")

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import replace
 from datetime import UTC, datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi import Request as FastAPIRequest
 from fastapi.responses import JSONResponse
 
@@ -30,6 +30,7 @@ from router_maestro.routing import Router, get_router
 from router_maestro.routing.capabilities import CapabilitySupport, Feature
 from router_maestro.routing.model_ref import catalog_model_public_id, qualify_model_id
 from router_maestro.routing.route_plan import RouteCandidate
+from router_maestro.server.dependencies import get_app_router
 from router_maestro.server.protocols import client_error_response, unrepresented_option_error
 from router_maestro.server.protocols.anthropic_reducer import (
     AnthropicReducer,
@@ -818,6 +819,7 @@ async def list_models(
     limit: int = 20,
     after_id: str | None = None,
     before_id: str | None = None,
+    model_router: Router = Depends(get_app_router),
 ) -> AnthropicModelList:
     """List available models in Anthropic format.
 
@@ -826,7 +828,6 @@ async def list_models(
         after_id: Return models after this ID (for forward pagination)
         before_id: Return models before this ID (for backward pagination)
     """
-    model_router = get_router()
     models = await model_router.list_models()
 
     # Generate ISO 8601 timestamp for created_at

--- a/src/router_maestro/server/routes/models.py
+++ b/src/router_maestro/server/routes/models.py
@@ -2,19 +2,19 @@
 
 import time
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from router_maestro.routing import get_router
 from router_maestro.routing.model_ref import catalog_model_public_id
+from router_maestro.routing.router import Router
+from router_maestro.server.dependencies import get_app_router
 from router_maestro.server.schemas import ModelList, ModelObject
 
 router = APIRouter()
 
 
 @router.get("/api/openai/v1/models")
-async def list_models() -> ModelList:
+async def list_models(model_router: Router = Depends(get_app_router)) -> ModelList:
     """List available models."""
-    model_router = get_router()
     models = await model_router.list_models()
 
     return ModelList(

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -584,29 +584,15 @@ async def test_admin_models_returns_unique_provider_qualified_public_ids(monkeyp
                 ProviderModelInfo(id="shared-model", name="Shared", provider="second"),
             ]
 
-    class _Lease:
-        router = _ModelRouter()
-        released = False
+    model_router = _ModelRouter()
 
-        async def release(self):
-            self.released = True
-
-    class _Owner:
-        lease = _Lease()
-
-        async def acquire(self):
-            return self.lease
-
-    owner = _Owner()
-
-    response = await admin.list_models(owner)
+    response = await admin.list_models(model_router)
 
     assert [model.id for model in response.models] == [
         "first/shared-model",
         "second/shared-model",
     ]
     assert [model.provider for model in response.models] == ["first", "second"]
-    assert owner.lease.released is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_anthropic_models.py
+++ b/tests/test_anthropic_models.py
@@ -1,12 +1,13 @@
 """Tests for the Anthropic models endpoint."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from router_maestro.providers.base import ModelInfo
+from router_maestro.server.dependencies import get_app_router
 from router_maestro.server.routes.anthropic import (
     _generate_display_name,
     list_models,
@@ -148,8 +149,7 @@ class TestListModelsEndpoint:
     @pytest.mark.anyio
     async def test_list_models_response_format(self, mock_router):
         """Test that response matches Anthropic format."""
-        with patch("router_maestro.server.routes.anthropic.get_router", return_value=mock_router):
-            response = await list_models()
+        response = await list_models(model_router=mock_router)
 
         assert isinstance(response, AnthropicModelList)
         assert len(response.data) == 3
@@ -160,8 +160,7 @@ class TestListModelsEndpoint:
     @pytest.mark.anyio
     async def test_list_models_model_fields(self, mock_router):
         """Test that each model has required Anthropic fields."""
-        with patch("router_maestro.server.routes.anthropic.get_router", return_value=mock_router):
-            response = await list_models()
+        response = await list_models(model_router=mock_router)
 
         model = response.data[0]
         assert model.id == "github-copilot/claude-sonnet-4"
@@ -174,8 +173,7 @@ class TestListModelsEndpoint:
     @pytest.mark.anyio
     async def test_list_models_pagination_limit(self, mock_router):
         """Test pagination with limit parameter."""
-        with patch("router_maestro.server.routes.anthropic.get_router", return_value=mock_router):
-            response = await list_models(limit=2)
+        response = await list_models(limit=2, model_router=mock_router)
 
         assert len(response.data) == 2
         assert response.has_more is True
@@ -185,8 +183,10 @@ class TestListModelsEndpoint:
     @pytest.mark.anyio
     async def test_list_models_pagination_after_id(self, mock_router):
         """Test pagination with after_id parameter."""
-        with patch("router_maestro.server.routes.anthropic.get_router", return_value=mock_router):
-            response = await list_models(after_id="github-copilot/claude-sonnet-4")
+        response = await list_models(
+            after_id="github-copilot/claude-sonnet-4",
+            model_router=mock_router,
+        )
 
         assert len(response.data) == 2
         assert response.data[0].id == "github-copilot/gpt-4o"
@@ -198,8 +198,7 @@ class TestListModelsEndpoint:
         mock = AsyncMock()
         mock.list_models = AsyncMock(return_value=[])
 
-        with patch("router_maestro.server.routes.anthropic.get_router", return_value=mock):
-            response = await list_models()
+        response = await list_models(model_router=mock)
 
         assert len(response.data) == 0
         assert response.first_id is None
@@ -208,8 +207,8 @@ class TestListModelsEndpoint:
 
     def test_http_endpoint(self, client, mock_router):
         """Test the HTTP endpoint via test client."""
-        with patch("router_maestro.server.routes.anthropic.get_router", return_value=mock_router):
-            response = client.get("/api/anthropic/v1/models")
+        client.app.dependency_overrides[get_app_router] = lambda: mock_router
+        response = client.get("/api/anthropic/v1/models")
 
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,7 @@ from router_maestro.cli.config import (
     _prompt_endpoint_mode,
     _select_model,
 )
+from router_maestro.config import settings
 from router_maestro.config.contexts import ContextConfig, ContextsConfig
 from router_maestro.config.providers import CustomProviderConfig, ModelConfig, ProvidersConfig
 from router_maestro.config.settings import load_config, save_config
@@ -179,6 +180,240 @@ class TestConfigIO:
         assert json.loads(path.read_text()) == {"good": True}
         # No leftover temp files in the directory.
         assert list(tmp_path.glob("*.tmp")) == []
+
+
+class TestProvidersConfigIO:
+    """Compatibility and isolation behavior for on-disk custom providers."""
+
+    @staticmethod
+    def _provider(*, options=None):
+        return {
+            "type": "openai-compatible",
+            "baseURL": "https://example.invalid/v1",
+            "models": {"model": {"name": "Model"}},
+            "options": options or {},
+        }
+
+    @staticmethod
+    def _write(path: Path, providers) -> bytes:
+        path.write_text(json.dumps({"providers": providers}), encoding="utf-8")
+        return path.read_bytes()
+
+    def test_missing_providers_file_creates_default(self, tmp_path, monkeypatch):
+        path = tmp_path / "providers.json"
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        config = settings.load_providers_config()
+
+        assert config.providers == {}
+        assert json.loads(path.read_text(encoding="utf-8")) == {"providers": {}}
+
+    def test_unknown_options_round_trip_without_load_rewriting_source(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        original = self._write(
+            path,
+            {
+                "healthy": self._provider(options={"allow_unauthenticated": True}),
+                "legacy": self._provider(
+                    options={
+                        "api_key_env": "LEGACY_API_KEY",
+                        "request_timeout": 45,
+                        "compatibility": {"mode": "old"},
+                    }
+                ),
+            },
+        )
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert set(loaded.providers) == {"healthy", "legacy"}
+        assert path.read_bytes() == original
+        assert loaded.providers["legacy"].options.model_dump(mode="json") == {
+            "api_key_env": "LEGACY_API_KEY",
+            "allow_unauthenticated": False,
+            "request_timeout": 45,
+            "compatibility": {"mode": "old"},
+        }
+        assert "legacy" in caplog.text
+        assert "compatibility" in caplog.text
+        assert "request_timeout" in caplog.text
+        assert "mode" not in caplog.text
+
+        settings.save_providers_config(loaded)
+        reloaded = settings.load_providers_config()
+
+        assert reloaded.model_dump(mode="json") == loaded.model_dump(mode="json")
+
+    def test_unknown_option_log_escapes_control_characters_without_values(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        legacy_key = "legacy\nFORGED\toption"
+        secret = "sk-secret-legacy-option-value"
+        self._write(
+            path,
+            {
+                "legacy": self._provider(
+                    options={legacy_key: {"nested-secret": secret}},
+                )
+            },
+        )
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert loaded.providers["legacy"].options.model_dump(mode="json")[legacy_key] == {
+            "nested-secret": secret
+        }
+        assert repr(legacy_key) in caplog.text
+        assert "legacy\nFORGED" not in caplog.text
+        assert secret not in caplog.text
+        assert "nested-secret" not in caplog.text
+
+    def test_invalid_known_option_skips_only_that_provider_with_safe_diagnostics(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        secret = "sk-secret-invalid-env-name"
+        original = self._write(
+            path,
+            {
+                "healthy": self._provider(options={"allow_unauthenticated": True}),
+                "broken": self._provider(options={"api_key_env": secret}),
+            },
+        )
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert set(loaded.providers) == {"healthy"}
+        assert path.read_bytes() == original
+        assert "broken" in caplog.text
+        assert "options.api_key_env" in caplog.text
+        assert "string_pattern_mismatch" in caplog.text
+        assert secret not in caplog.text
+        assert "input_value" not in caplog.text
+
+    def test_validation_log_redacts_dynamic_model_id_from_location(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        secret = "sk-secret-model-id"
+        malicious_model_id = f"model\nFORGED\t{secret}"
+        provider = self._provider()
+        provider["models"] = {malicious_model_id: {"name": {"invalid": True}}}
+        self._write(path, {"broken": provider})
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert loaded.providers == {}
+        assert "models.<model-id>.name:string_type" in caplog.text
+        assert malicious_model_id not in caplog.text
+        assert "model\nFORGED" not in caplog.text
+        assert secret not in caplog.text
+        assert "input_value" not in caplog.text
+
+    def test_reserved_and_duplicate_names_are_isolated_deterministically(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        self._write(
+            path,
+            {
+                "healthy": self._provider(),
+                "OpenAI": self._provider(),
+                "First": self._provider(options={"api_key_env": "FIRST_API_KEY"}),
+                "first": self._provider(options={"api_key_env": "SECOND_API_KEY"}),
+                "later": self._provider(),
+            },
+        )
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert list(loaded.providers) == ["healthy", "First", "later"]
+        assert loaded.providers["First"].options.api_key_env == "FIRST_API_KEY"
+        assert "OpenAI" in caplog.text
+        assert "reserved_provider_name" in caplog.text
+        assert "first" in caplog.text
+        assert "duplicate_provider_name" in caplog.text
+
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            "{this is not json",
+            json.dumps(["not", "an", "object"]),
+            json.dumps({"providers": ["not", "a", "mapping"]}),
+        ],
+    )
+    def test_malformed_provider_documents_fall_back_without_rewriting(
+        self,
+        contents,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        path.write_text(contents, encoding="utf-8")
+        original = path.read_bytes()
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert loaded.providers == {}
+        assert path.read_bytes() == original
+        assert contents not in caplog.text
+
+    def test_non_utf8_provider_document_falls_back_without_rewriting(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        path = tmp_path / "providers.json"
+        original = b"\xff\xfeinvalid-provider-config"
+        path.write_bytes(original)
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert loaded.providers == {}
+        assert path.read_bytes() == original
+        assert "invalid_encoding" in caplog.text
+        assert "invalid-provider-config" not in caplog.text
+
+    def test_provider_file_os_error_falls_back_without_replacing_path(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        path = tmp_path / "providers.json"
+        path.mkdir()
+        monkeypatch.setattr(settings, "PROVIDERS_FILE", path)
+
+        loaded = settings.load_providers_config()
+
+        assert loaded.providers == {}
+        assert path.is_dir()
 
 
 class TestSelectModel:

--- a/tests/test_custom_provider_auth.py
+++ b/tests/test_custom_provider_auth.py
@@ -40,9 +40,20 @@ def _config(**options) -> CustomProviderConfig:
     )
 
 
-def test_custom_provider_options_reject_unknown_fields() -> None:
-    with pytest.raises(ValidationError, match="unused"):
-        CustomProviderOptions.model_validate({"unused": True})
+def test_custom_provider_options_preserve_unknown_legacy_fields() -> None:
+    options = CustomProviderOptions.model_validate(
+        {
+            "api_key_env": "LOCAL_LLM_TOKEN",
+            "unused": {"nested": True},
+        }
+    )
+
+    assert options.api_key_env == "LOCAL_LLM_TOKEN"
+    assert options.model_dump(mode="json") == {
+        "api_key_env": "LOCAL_LLM_TOKEN",
+        "allow_unauthenticated": False,
+        "unused": {"nested": True},
+    }
 
 
 @pytest.mark.parametrize("provider", ["github-copilot", "GITHUB-COPILOT", "openai", "Anthropic"])
@@ -140,6 +151,17 @@ def test_required_custom_provider_without_key_is_skipped(tmp_path) -> None:
     provider = create_custom_provider(
         "ollama",
         _config(),
+        credential_repository=CredentialRepository(tmp_path / "auth.json"),
+        environ={},
+    )
+
+    assert provider is None
+
+
+def test_unknown_legacy_option_does_not_enable_runtime_behavior(tmp_path) -> None:
+    provider = create_custom_provider(
+        "ollama",
+        _config(anonymous=True),
         credential_repository=CredentialRepository(tmp_path / "auth.json"),
         environ={},
     )

--- a/tests/test_models_route.py
+++ b/tests/test_models_route.py
@@ -1,8 +1,10 @@
-"""Tests for the OpenAI-compatible models route."""
+"""Tests for server model-listing routes."""
 
-from unittest.mock import patch
+import asyncio
 
+import httpx
 import pytest
+from fastapi import FastAPI
 from rich.console import Console
 
 from router_maestro.cli import model as model_cli
@@ -10,11 +12,221 @@ from router_maestro.config import PrioritiesConfig
 from router_maestro.providers import ChatRequest, ChatResponse, Message, ModelInfo
 from router_maestro.providers.base import BaseProvider
 from router_maestro.routing.capabilities import Operation
-from router_maestro.routing.router import CACHE_TTL_SECONDS, Router
-from router_maestro.server.routes.admin import list_models as list_admin_models
-from router_maestro.server.routes.anthropic import list_models as list_anthropic_models
+from router_maestro.routing.router import CACHE_TTL_SECONDS, Router, RouterOwner
+from router_maestro.server.routes.admin import (
+    list_models as list_admin_models,
+)
+from router_maestro.server.routes.admin import (
+    router as admin_router,
+)
+from router_maestro.server.routes.anthropic import (
+    list_models as list_anthropic_models,
+)
+from router_maestro.server.routes.anthropic import (
+    router as anthropic_router,
+)
 from router_maestro.server.routes.models import list_models
+from router_maestro.server.routes.models import router as openai_models_router
 from router_maestro.utils.cache import TTLCache
+
+
+class _GenerationListingRouter:
+    def __init__(
+        self,
+        generation: str,
+        *,
+        entered: asyncio.Event | None = None,
+        resume: asyncio.Event | None = None,
+        fail: bool = False,
+    ) -> None:
+        self.generation = generation
+        self.entered = entered
+        self.resume = resume
+        self.fail = fail
+        self.close_count = 0
+        self.closed = asyncio.Event()
+
+    async def list_models(self) -> list[ModelInfo]:
+        if self.entered is not None:
+            self.entered.set()
+        if self.resume is not None:
+            await self.resume.wait()
+        if self.fail:
+            raise RuntimeError(f"catalog-{self.generation}-failed")
+        return [
+            ModelInfo(
+                id=f"{self.generation.lower()}-one",
+                name=f"{self.generation} One",
+                provider="controlled",
+            ),
+            ModelInfo(
+                id=f"{self.generation.lower()}-two",
+                name=f"{self.generation} Two",
+                provider="controlled",
+            ),
+        ]
+
+    async def close(self) -> None:
+        self.close_count += 1
+        self.closed.set()
+
+
+class _RecordingRouterOwner(RouterOwner[_GenerationListingRouter]):
+    def __init__(self, factory) -> None:
+        super().__init__(factory)
+        self.acquire_count = 0
+
+    async def acquire(self):
+        self.acquire_count += 1
+        return await super().acquire()
+
+
+class _PoisonedGlobalRouter:
+    async def list_models(self):
+        raise AssertionError("server model listings must not use the global Router singleton")
+
+
+def _model_listing_app(owner: RouterOwner) -> FastAPI:
+    app = FastAPI()
+    app.state.router_owner = owner
+    app.include_router(openai_models_router)
+    app.include_router(anthropic_router)
+    app.include_router(admin_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_all_http_model_lists_switch_owner_generation_and_ignore_global_singleton(
+    monkeypatch,
+):
+    routers: dict[str, _GenerationListingRouter] = {}
+
+    def factory(generation):
+        router = _GenerationListingRouter(generation)
+        routers[generation] = router
+        return router
+
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    monkeypatch.setattr("router_maestro.routing.router._router_instance", _PoisonedGlobalRouter())
+    transport = httpx.ASGITransport(app=_model_listing_app(owner), raise_app_exceptions=False)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            openai_a = await client.get("/api/openai/v1/models")
+            anthropic_a = await client.get("/api/anthropic/v1/models", params={"limit": 1})
+            admin_a = await client.get("/api/admin/models")
+
+            assert openai_a.status_code == anthropic_a.status_code == admin_a.status_code == 200
+            assert [model["id"] for model in openai_a.json()["data"]] == [
+                "controlled/a-one",
+                "controlled/a-two",
+            ]
+            assert anthropic_a.json()["first_id"] == "controlled/a-one"
+            assert anthropic_a.json()["last_id"] == "controlled/a-one"
+            assert anthropic_a.json()["has_more"] is True
+            assert [model["id"] for model in admin_a.json()["models"]] == [
+                "controlled/a-one",
+                "controlled/a-two",
+            ]
+
+            await owner.rebuild("B")
+
+            openai_b = await client.get("/api/openai/v1/models")
+            anthropic_b = await client.get("/api/anthropic/v1/models", params={"limit": 1})
+            admin_b = await client.get("/api/admin/models")
+
+        assert [model["id"] for model in openai_b.json()["data"]] == [
+            "controlled/b-one",
+            "controlled/b-two",
+        ]
+        assert anthropic_b.json()["first_id"] == "controlled/b-one"
+        assert anthropic_b.json()["last_id"] == "controlled/b-one"
+        assert anthropic_b.json()["has_more"] is True
+        assert [model["id"] for model in admin_b.json()["models"]] == [
+            "controlled/b-one",
+            "controlled/b-two",
+        ]
+    finally:
+        await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_http_model_listing_releases_owner_lease_when_catalog_raises(monkeypatch):
+    routers: dict[str, _GenerationListingRouter] = {}
+
+    def factory(generation):
+        router = _GenerationListingRouter(generation, fail=generation == "A")
+        routers[generation] = router
+        return router
+
+    owner = _RecordingRouterOwner(factory)
+    await owner.start("A")
+    monkeypatch.setattr("router_maestro.routing.router._router_instance", _PoisonedGlobalRouter())
+    transport = httpx.ASGITransport(app=_model_listing_app(owner), raise_app_exceptions=False)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/api/openai/v1/models")
+        assert response.status_code == 500
+        assert owner.acquire_count == 1
+
+        await owner.rebuild("B")
+        await asyncio.wait_for(routers["A"].closed.wait(), timeout=1)
+
+        assert routers["A"].close_count == 1
+    finally:
+        await owner.close()
+
+
+@pytest.mark.asyncio
+async def test_inflight_http_model_listing_keeps_old_generation_until_dependency_releases(
+    monkeypatch,
+):
+    entered = asyncio.Event()
+    resume = asyncio.Event()
+    routers: dict[str, _GenerationListingRouter] = {}
+
+    def factory(generation):
+        router = _GenerationListingRouter(
+            generation,
+            entered=entered if generation == "A" else None,
+            resume=resume if generation == "A" else None,
+        )
+        routers[generation] = router
+        return router
+
+    owner = RouterOwner(factory)
+    await owner.start("A")
+    monkeypatch.setattr("router_maestro.routing.router._router_instance", _PoisonedGlobalRouter())
+    transport = httpx.ASGITransport(app=_model_listing_app(owner), raise_app_exceptions=False)
+
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            old_request = asyncio.create_task(client.get("/api/openai/v1/models"))
+            await asyncio.wait_for(entered.wait(), timeout=1)
+
+            await owner.rebuild("B")
+            assert routers["A"].close_count == 0
+
+            new_response = await client.get("/api/openai/v1/models")
+            assert [model["id"] for model in new_response.json()["data"]] == [
+                "controlled/b-one",
+                "controlled/b-two",
+            ]
+            assert routers["A"].close_count == 0
+
+            resume.set()
+            old_response = await old_request
+
+        assert [model["id"] for model in old_response.json()["data"]] == [
+            "controlled/a-one",
+            "controlled/a-two",
+        ]
+        assert routers["A"].close_count == 1
+    finally:
+        resume.set()
+        await owner.close()
 
 
 class _FakeRouter:
@@ -25,30 +237,12 @@ class _FakeRouter:
         ]
 
 
-class _RouterLease:
-    def __init__(self, router):
-        self.router = router
-
-    async def release(self):
-        return None
-
-
-class _RouterOwner:
-    def __init__(self, router):
-        self.router = router
-
-    async def acquire(self):
-        return _RouterLease(self.router)
-
-
 @pytest.mark.anyio
-async def test_openai_models_route_uses_routing_singleton(monkeypatch):
-    """The models route should reuse the routing singleton instead of constructing Router."""
+async def test_openai_models_route_uses_explicitly_injected_router():
+    """A direct handler call reads the injected Router argument."""
     fake_router = _FakeRouter()
 
-    monkeypatch.setattr("router_maestro.routing.router._router_instance", fake_router)
-
-    response = await list_models()
+    response = await list_models(fake_router)
 
     assert [model.id for model in response.data] == [
         "openai/gpt-4o",
@@ -57,18 +251,15 @@ async def test_openai_models_route_uses_routing_singleton(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_public_model_lists_encode_provider_namespaced_upstream_id(monkeypatch):
+async def test_public_model_lists_encode_provider_namespaced_upstream_id():
     class _NamespacedRouter:
         async def list_models(self):
             return [ModelInfo(id="openrouter/auto", name="Auto", provider="openrouter")]
 
     model_router = _NamespacedRouter()
-    monkeypatch.setattr("router_maestro.routing.router._router_instance", model_router)
-
-    openai_response = await list_models()
-    with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
-        anthropic_response = await list_anthropic_models()
-    admin_response = await list_admin_models(_RouterOwner(model_router))
+    openai_response = await list_models(model_router)
+    anthropic_response = await list_anthropic_models(model_router=model_router)
+    admin_response = await list_admin_models(model_router)
 
     expected = ["openrouter/openrouter/auto"]
     assert [model.id for model in openai_response.data] == expected
@@ -77,7 +268,7 @@ async def test_public_model_lists_encode_provider_namespaced_upstream_id(monkeyp
 
 
 @pytest.mark.anyio
-async def test_public_model_lists_do_not_double_prefix_qualified_catalog_ids(monkeypatch):
+async def test_public_model_lists_do_not_double_prefix_qualified_catalog_ids():
     class _QualifiedRouter:
         async def list_models(self):
             return [
@@ -90,12 +281,9 @@ async def test_public_model_lists_do_not_double_prefix_qualified_catalog_ids(mon
             ]
 
     model_router = _QualifiedRouter()
-    monkeypatch.setattr("router_maestro.routing.router._router_instance", model_router)
-
-    openai_response = await list_models()
-    with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
-        anthropic_response = await list_anthropic_models()
-    admin_response = await list_admin_models(_RouterOwner(model_router))
+    openai_response = await list_models(model_router)
+    anthropic_response = await list_anthropic_models(model_router=model_router)
+    admin_response = await list_admin_models(model_router)
 
     assert [model.id for model in openai_response.data] == ["github-copilot/claude-sonnet-4.6"]
     assert [model.id for model in anthropic_response.data] == ["github-copilot/claude-sonnet-4.6"]
@@ -144,14 +332,11 @@ def _round_trip_router() -> Router:
 
 
 @pytest.mark.anyio
-async def test_public_model_lists_round_trip_to_same_provider_with_bare_upstream_id(monkeypatch):
+async def test_public_model_lists_round_trip_to_same_provider_with_bare_upstream_id():
     model_router = _round_trip_router()
-    monkeypatch.setattr("router_maestro.routing.router._router_instance", model_router)
-
-    openai_response = await list_models()
-    with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
-        anthropic_response = await list_anthropic_models()
-    admin_response = await list_admin_models(_RouterOwner(model_router))
+    openai_response = await list_models(model_router)
+    anthropic_response = await list_anthropic_models(model_router=model_router)
+    admin_response = await list_admin_models(model_router)
 
     for public_ids in (
         [model.id for model in openai_response.data],


### PR DESCRIPTION
## Summary

- route OpenAI, Anthropic, and Admin model-list endpoints through a shared application-owned `RouterOwner` lease so credential/config rebuilds are visible immediately without consulting the stale module singleton
- preserve unknown legacy custom-provider option keys across load/save while restricting runtime behavior to the typed `api_key_env` and `allow_unauthenticated` fields
- validate provider definitions independently, retain healthy providers, and emit secret-safe diagnostics for invalid, duplicate, reserved, malformed, or non-UTF-8 configuration entries

## Root causes

PR #128 moved credential mutations to `RouterOwner.rebuild()`, but the two public model-list endpoints still called legacy `get_router()` outside inference request context. Their independent global Router cache could therefore remain stale for up to 300 seconds after login/logout. This PR makes all three listing surfaces acquire the current application generation through one yield dependency; old in-flight listings keep their lease until completion.

PR #128 also made custom-provider options strict. One legacy option caused whole-document validation to fall back to an empty provider set. This PR retains unknown option data without activating it and isolates validation failures per provider so one bad entry cannot hide healthy entries.

## Verification

- `uv run pytest tests/ -q` — **3546 passed**
- `uv run ruff check src/ tests/ integration_tests/` — passed
- `uv run ruff format --check src/ tests/ integration_tests/` — 200 files already formatted
- `uv run python -m compileall -q src/router_maestro` — passed
- `uv lock --check` — passed
- `uv run router-maestro --help` — passed
- `uv build` — sdist and wheel built successfully
- `git diff --check` — passed
- fresh CPython 3.11.15 wheel install — installed from `site-packages`; dependency imports, legacy options, non-UTF-8 fallback, version, and CLI help passed
- controlled temporary-XDG real-app regression with a local fake upstream — before login all three catalogs were empty; immediately after `POST /api/admin/auth/login`, OpenAI, Anthropic, and Admin all returned `fake-local/fresh-model`; real user `auth.json` SHA-256 remained unchanged and all temporary resources were cleaned up
- independent final specification and engineering-quality reviews — Ready, no remaining Critical/Important findings

## Scope

The legacy global `get_router()` / `reset_router()` compatibility APIs remain unchanged. Model-list routes were not added to inference middleware, and this PR does not change the pending authentication-transition decision.

This PR is intentionally left open for review and is not merged by this task.
