### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
-## Unreleased
+## v0.6.0 (2026-07-15)
 
 ### Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.5.4"
+version = "0.6.0"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.5.4"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release v0.6.0.

Bumps `pyproject.toml`, `__init__.py`, and `uv.lock` to 0.6.0, and promotes the CHANGELOG `Unreleased` section to `v0.6.0 (2026-07-15)`.

This release rolls up the full #126–#130 hardening series since v0.5.4 (22+ commits): capability-aware route planning with stable model identity, explicit typed request-option policy, Anthropic beta transport adaptation, normalized fallback/provider-failure semantics, and the #130 model-catalog + backward-compatible custom-provider-options fix. See the CHANGELOG for the complete list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)