### PR TITLE
fix: stop rejecting unmodeled client request options

### DIFF
--- a/src/router_maestro/server/protocols/__init__.py
+++ b/src/router_maestro/server/protocols/__init__.py
@@ -7,7 +7,6 @@ from router_maestro.server.protocols.anthropic_reducer import (
 )
 from router_maestro.server.protocols.errors import (
     client_error_response,
-    unrepresented_option_error,
 )
 from router_maestro.server.protocols.responses_reducer import (
     ResponsesReducer,
@@ -21,5 +20,4 @@ __all__ = [
     "build_anthropic_response",
     "build_nonstream_snapshot",
     "client_error_response",
-    "unrepresented_option_error",
 ]

--- a/src/router_maestro/server/protocols/errors.py
+++ b/src/router_maestro/server/protocols/errors.py
@@ -5,7 +5,6 @@ from typing import Literal
 
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from router_maestro.providers import (
@@ -34,52 +33,6 @@ class NormalizedProtocolError:
     parameter: str | None = None
     code: str | None = None
     headers: dict[str, str] | None = None
-
-
-def unrepresented_option_error(request: BaseModel) -> RequestOptionError | None:
-    """Reject retained extras on an explicitly extensible request/config model."""
-    parameter = _first_unrepresented_option(request)
-    if parameter is None:
-        return None
-    return RequestOptionError(
-        f"Unsupported request option '{parameter}'",
-        parameter=parameter,
-    )
-
-
-def _first_unrepresented_option(value: object, prefix: str = "") -> str | None:
-    if isinstance(value, BaseModel):
-        extras = value.model_extra or {}
-        if extras:
-            name = next(iter(extras))
-            return f"{prefix}.{name}" if prefix else name
-
-        for name, field in type(value).model_fields.items():
-            wire_name = field.alias or name
-            nested_prefix = f"{prefix}.{wire_name}" if prefix else wire_name
-            if parameter := _first_unrepresented_option(
-                getattr(value, name, None),
-                nested_prefix,
-            ):
-                return parameter
-        return None
-
-    if isinstance(value, (list, tuple)):
-        for index, item in enumerate(value):
-            nested_prefix = f"{prefix}[{index}]"
-            if parameter := _first_unrepresented_option(item, nested_prefix):
-                return parameter
-        return None
-
-    if isinstance(value, dict):
-        # Plain dictionaries are opaque vendor payloads. Recurse only so a
-        # model nested inside a typed mapping cannot hide retained extras;
-        # dictionary keys themselves are not interpreted as request options.
-        for name, item in value.items():
-            nested_prefix = f"{prefix}.{name}" if prefix else str(name)
-            if parameter := _first_unrepresented_option(item, nested_prefix):
-                return parameter
-    return None
 
 
 def protocol_surface_for_path(path: str) -> ProtocolSurface | None:

--- a/src/router_maestro/server/routes/anthropic.py
+++ b/src/router_maestro/server/routes/anthropic.py
@@ -31,7 +31,7 @@ from router_maestro.routing.capabilities import CapabilitySupport, Feature
 from router_maestro.routing.model_ref import catalog_model_public_id, qualify_model_id
 from router_maestro.routing.route_plan import RouteCandidate
 from router_maestro.server.dependencies import get_app_router
-from router_maestro.server.protocols import client_error_response, unrepresented_option_error
+from router_maestro.server.protocols import client_error_response
 from router_maestro.server.protocols.anthropic_reducer import (
     AnthropicReducer,
     AnthropicStreamProtocolError,
@@ -329,8 +329,6 @@ def _mid_conv_system_rejection_response() -> JSONResponse:
 @router.post("/api/anthropic/v1/messages")
 async def messages(request: AnthropicMessagesRequest, raw_request: FastAPIRequest):
     """Handle Anthropic Messages API requests."""
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "anthropic")
     parsed_thinking = request.thinking.model_dump(exclude_none=True) if request.thinking else None
     effort = request.output_config.effort if request.output_config else None
     raw_thinking = await _raw_body_thinking(raw_request)
@@ -467,8 +465,6 @@ async def count_tokens(request: AnthropicCountTokensRequest):
     token-counting configuration. For native Anthropic, attempts an upstream
     API call for an exact count before falling back to local estimation.
     """
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "anthropic")
     logger.debug("count_tokens request: model=%s, provider=%s", request.model, None)
     provider_name = await _resolve_provider_name(request.model)
     logger.debug("count_tokens resolved provider=%s for model=%s", provider_name, request.model)

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -93,6 +93,11 @@ _COPILOT_ACCEPTED_FIELDS = frozenset(
         "stop_sequences",
         "metadata",
         "output_config",
+        # Forwarded verbatim to the native Anthropic transport. GHC accepts and
+        # applies context_management (verified live: 200 with an applied_edits
+        # echo); the paired anthropic-beta header is already forwarded by the
+        # Copilot transport, so the option only needs to survive body stripping.
+        "context_management",
     }
 )
 
@@ -173,15 +178,18 @@ def _sanitize_output_config(body: dict) -> str | None:
 
 
 def _validate_beta_request_options(body: dict) -> None:
-    """Reject unrepresented beta Messages options before transport selection."""
-    unsupported_fields = sorted(set(body) - _COPILOT_ACCEPTED_FIELDS)
-    if unsupported_fields:
-        parameter = unsupported_fields[0]
-        raise RequestOptionError(
-            f"{parameter} is not supported by the beta Anthropic endpoint",
-            parameter=parameter,
-        )
+    """Validate representable beta Messages options before transport selection.
 
+    Options that Router-Maestro does not model as typed fields (for example
+    ``context_management`` sent by Claude Code) are NOT rejected: a transparent
+    proxy forwards or ignores unknown options rather than returning a 400. The
+    native passthrough path strips anything outside ``_COPILOT_ACCEPTED_FIELDS``
+    before forwarding, so unknown top-level keys are ignored, not echoed upstream.
+
+    Only ``output_config`` is validated here, because Router-Maestro actively
+    consumes it to shape the native reasoning-effort payload; a malformed value
+    cannot be represented and is reported instead of silently mishandled.
+    """
     if "output_config" in body:
         output_config = body["output_config"]
         if not isinstance(output_config, dict):

--- a/src/router_maestro/server/routes/chat.py
+++ b/src/router_maestro/server/routes/chat.py
@@ -25,7 +25,7 @@ from router_maestro.providers import (
 )
 from router_maestro.routing import Router, get_router
 from router_maestro.routing.model_ref import qualify_model_id
-from router_maestro.server.protocols import client_error_response, unrepresented_option_error
+from router_maestro.server.protocols import client_error_response
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
 from router_maestro.server.routes._outcomes import record_chat_response_outcome
 from router_maestro.server.schemas import (
@@ -120,8 +120,6 @@ async def chat_completions(request: ChatCompletionRequest):
             )
         request.stream_options = stream_options
 
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "openai")
     if stream_options is not None and not request.stream:
         return client_error_response(
             RequestOptionError(

--- a/src/router_maestro/server/routes/gemini.py
+++ b/src/router_maestro/server/routes/gemini.py
@@ -22,7 +22,7 @@ from router_maestro.providers import (
 )
 from router_maestro.routing import get_router
 from router_maestro.routing.model_ref import qualify_model_id
-from router_maestro.server.protocols import client_error_response, unrepresented_option_error
+from router_maestro.server.protocols import client_error_response
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
 from router_maestro.server.routes._outcomes import record_chat_response_outcome
 from router_maestro.server.schemas.gemini import (
@@ -103,8 +103,6 @@ async def generate_content(
     """Handle Gemini generateContent (non-streaming) requests."""
     model = _extract_model_from_path(model_method)
     logger.info("Received Gemini generateContent request: model=%s", model)
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "gemini")
 
     # Handle test model
     if model == "test":
@@ -148,8 +146,6 @@ async def stream_generate_content(
     """Handle Gemini streamGenerateContent (streaming) requests."""
     model = _extract_model_from_path(model_method)
     logger.info("Received Gemini streamGenerateContent request: model=%s", model)
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "gemini")
 
     # Handle test model
     if model == "test":
@@ -209,8 +205,6 @@ async def count_tokens(
     request: GeminiGenerateContentRequest,
 ):
     """Handle Gemini countTokens requests."""
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "gemini")
     model = _extract_model_from_path(model_method)
     logger.info("Received Gemini countTokens request: model=%s", model)
 

--- a/src/router_maestro/server/routes/responses.py
+++ b/src/router_maestro/server/routes/responses.py
@@ -25,7 +25,6 @@ from router_maestro.server.protocols import (
     build_nonstream_snapshot,
     client_error_response,
     responses_reducer,
-    unrepresented_option_error,
 )
 from router_maestro.server.protocols.errors import postcommit_error_data, protocol_error_response
 from router_maestro.server.routes._outcomes import record_terminal_outcome
@@ -239,8 +238,6 @@ async def create_response(request: ResponsesRequest):
         request.tools is not None,
         request.reasoning,
     )
-    if error := unrepresented_option_error(request):
-        return client_error_response(error, "openai")
 
     model_router = get_router()
 

--- a/src/router_maestro/server/schemas/openai.py
+++ b/src/router_maestro/server/schemas/openai.py
@@ -50,8 +50,8 @@ class OpenAIThinkingConfig(BaseModel):
 class ChatCompletionStreamOptions(BaseModel):
     """Client-facing encoding options for a Chat Completions stream."""
 
-    # Retain unknown nested options so the route can return an OpenAI-native
-    # 400 through ``unrepresented_option_error`` instead of FastAPI's 422.
+    # Retain unknown nested options rather than raising FastAPI's 422; a
+    # transparent proxy forwards or ignores options it does not model.
     model_config = ConfigDict(extra="allow")
 
     include_usage: Annotated[bool, Field(strict=True)] = False
@@ -60,10 +60,11 @@ class ChatCompletionStreamOptions(BaseModel):
 class ChatCompletionRequest(BaseModel):
     """Request for chat completion."""
 
-    # Preserve unknown top-level options long enough for the route to return an
-    # OpenAI-native 400. Pydantic's default ``extra=ignore`` would silently
-    # discard requested semantics; ``extra=forbid`` would bypass the route with
-    # FastAPI's generic 422 envelope.
+    # Preserve unknown top-level options rather than rejecting them: Router-
+    # Maestro is a transparent proxy, so options it does not model are ignored
+    # (or forwarded by the provider) instead of failing the request. ``extra=
+    # allow`` keeps them addressable; the default ``extra=ignore`` would also
+    # work, while ``extra=forbid`` would wrongly 422 on unknown client options.
     model_config = ConfigDict(extra="allow")
 
     model: str

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -2174,15 +2174,13 @@ class TestBetaMessagesEndpoint:
     @pytest.mark.parametrize(
         ("option_payload", "parameter"),
         [
-            ({"context_management": {"enabled": True}}, "context_management"),
             (
                 {"output_config": {"effort": "low", "format": "text"}},
                 "output_config.format",
             ),
-            ({"service_tier": "standard_only"}, "service_tier"),
         ],
     )
-    def test_beta_rejects_unknown_semantic_options_before_transport_selection(
+    def test_beta_rejects_malformed_output_config_before_transport_selection(
         self,
         client,
         transport,
@@ -2245,6 +2243,43 @@ class TestBetaMessagesEndpoint:
         provider._send_with_auth_retry.assert_not_awaited()
         provider._stream_with_auth_retry.assert_not_called()
 
+    def test_beta_forwards_unmodeled_client_option_to_native_transport(self, client):
+        """Claude Code sends ``context_management`` on the beta endpoint by default.
+
+        Router-Maestro does not model it as a typed field, but it is a legitimate
+        upstream Anthropic option. It must be forwarded to the native transport,
+        not hard-rejected with a 400 before transport selection."""
+        provider = _native_provider()
+        model = ModelInfo(
+            id="claude-options",
+            name="Claude options",
+            provider="github-copilot",
+            operation_capabilities={Operation.NATIVE_ANTHROPIC: True},
+        )
+        model_router = _real_native_router(
+            provider,
+            [model],
+            ["github-copilot/claude-options"],
+        )
+        body = {
+            "model": "github-copilot/claude-options",
+            "max_tokens": 100,
+            "stream": False,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        }
+
+        with patch(
+            "router_maestro.server.routes.anthropic_beta.get_router",
+            return_value=model_router,
+        ):
+            response = client.post("/api/anthropic/beta/v1/messages", json=body)
+
+        assert response.status_code == 200, response.text
+        assert "Unsupported request option" not in response.text
+        assert "not supported by the beta" not in response.text
+        provider._send_with_auth_retry.assert_awaited_once()
+
     @pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
     @pytest.mark.parametrize(
         ("option_payload", "parameter"),
@@ -2257,7 +2292,6 @@ class TestBetaMessagesEndpoint:
                 "output_config.format",
             ),
             ({"temperature": 0.2, "top_p": 0.8}, "top_p"),
-            ({"service_tier": "standard_only"}, "service_tier"),
         ],
     )
     def test_native_rejects_unpreservable_options_before_transport(

--- a/tests/test_chat_route_options.py
+++ b/tests/test_chat_route_options.py
@@ -183,12 +183,6 @@ def test_openai_chat_accepts_typed_stream_options_without_provider_passthrough(
     [
         pytest.param(
             True,
-            {"include_usage": True, "include_obfuscation": True},
-            "stream_options.include_obfuscation",
-            id="unknown-nested-option",
-        ),
-        pytest.param(
-            True,
             {"include_usage": "true"},
             "stream_options.include_usage",
             id="string-include-usage",
@@ -240,6 +234,31 @@ def test_openai_chat_rejects_invalid_stream_options_before_router_calls(
     assert response.json()["error"]["param"] == parameter
     assert "data:" not in response.text
     assert router.request is None
+
+
+def test_openai_chat_unknown_stream_option_passes_through(monkeypatch):
+    """An unknown nested ``stream_options`` field (e.g. OpenAI's ``include_obfuscation``)
+    is forwarded/ignored, not rejected — Router-Maestro is a transparent proxy."""
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app, raise_server_exceptions=False)
+    router = _CapturingRouter()
+    monkeypatch.setattr("router_maestro.server.routes.chat.get_router", lambda: router)
+
+    response = client.post(
+        "/api/openai/v1/chat/completions",
+        json={
+            "model": "openai/gpt-4o",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+            "stream_options": {"include_usage": True, "include_obfuscation": True},
+        },
+    )
+
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
+    # The request reached routing rather than being rejected at the option gate.
+    assert router.request is not None
 
 
 class _RejectingOptionRouter:

--- a/tests/test_protocol_error_envelopes.py
+++ b/tests/test_protocol_error_envelopes.py
@@ -716,7 +716,7 @@ def test_openai_option_rejection_uses_native_envelope(client: TestClient) -> Non
     ],
 )
 @pytest.mark.parametrize("stream", [False, True])
-def test_unrepresented_openai_semantic_option_is_native_400_before_router_or_sse(
+def test_unrepresented_openai_semantic_option_reaches_router_not_400(
     client: TestClient,
     path: str,
     base_payload: dict,
@@ -725,11 +725,22 @@ def test_unrepresented_openai_semantic_option_is_native_400_before_router_or_sse
     router_method: str,
     stream: bool,
 ) -> None:
+    """Options Router-Maestro does not model (``response_format``, ``n``, ``store``,
+    ``include``) are NOT rejected at the route. A transparent proxy forwards or
+    ignores them, so the request reaches routing instead of a native 400."""
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
     model_router = MagicMock()
-    model_router.chat_completion = AsyncMock()
-    model_router.prepare_chat_completion_stream = AsyncMock()
-    model_router.responses_completion = AsyncMock()
-    model_router.prepare_responses_completion_stream = AsyncMock()
+    model_router.chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.prepare_chat_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.chat_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.responses_completion = AsyncMock(side_effect=sentinel)
+    model_router.prepare_responses_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.responses_completion_stream = AsyncMock(side_effect=sentinel)
     patch_target = (
         "router_maestro.server.routes.chat.get_router"
         if router_method == "chat_completion"
@@ -740,21 +751,8 @@ def test_unrepresented_openai_semantic_option_is_native_400_before_router_or_sse
     with patch(patch_target, return_value=model_router):
         response = client.post(path, json=payload)
 
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {
-        "error": {
-            "message": f"Unsupported request option '{parameter}'",
-            "type": "invalid_request_error",
-            "param": parameter,
-            "code": "unsupported_parameter",
-        }
-    }
-    assert "data:" not in response.text
-    model_router.chat_completion.assert_not_awaited()
-    model_router.prepare_chat_completion_stream.assert_not_awaited()
-    model_router.responses_completion.assert_not_awaited()
-    model_router.prepare_responses_completion_stream.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
 def test_anthropic_option_rejection_uses_native_envelope(client: TestClient) -> None:
@@ -827,15 +825,23 @@ def test_gemini_option_rejection_uses_native_envelope(client: TestClient) -> Non
         ),
     ],
 )
-def test_unrepresented_gemini_option_is_native_400_before_router_or_sse(
+def test_unrepresented_gemini_option_reaches_router_not_400(
     client: TestClient,
     path: str,
     parameter: str,
     payload_option: dict,
 ) -> None:
+    """Unknown Gemini options are forwarded/ignored, not rejected at the route."""
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
     model_router = MagicMock()
-    model_router.chat_completion = AsyncMock()
-    model_router.prepare_chat_completion_stream = AsyncMock()
+    model_router.chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.prepare_chat_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.chat_completion_stream = AsyncMock(side_effect=sentinel)
     payload = {
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
         **payload_option,
@@ -844,22 +850,12 @@ def test_unrepresented_gemini_option_is_native_400_before_router_or_sse(
     with patch("router_maestro.server.routes.gemini.get_router", return_value=model_router):
         response = client.post(path, json=payload)
 
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {
-        "error": {
-            "code": 400,
-            "message": f"Unsupported request option '{parameter}'",
-            "status": "INVALID_ARGUMENT",
-            "details": [{"reason": "unsupported_parameter", "parameter": parameter}],
-        }
-    }
-    assert "data:" not in response.text
-    model_router.chat_completion.assert_not_awaited()
-    model_router.prepare_chat_completion_stream.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
-def test_unrepresented_gemini_count_tokens_option_is_native_400(client: TestClient) -> None:
+def test_unrepresented_gemini_count_tokens_option_is_ignored_not_400(client: TestClient) -> None:
+    """count_tokens estimates locally; an unknown option must not 400 the request."""
     response = client.post(
         "/api/gemini/v1beta/models/m:countTokens",
         json={
@@ -868,13 +864,8 @@ def test_unrepresented_gemini_count_tokens_option_is_native_400(client: TestClie
         },
     )
 
-    assert response.status_code == 400
-    assert response.json()["error"]["details"] == [
-        {
-            "reason": "unsupported_parameter",
-            "parameter": "generationConfig.unknownOption",
-        }
-    ]
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
 @pytest.mark.parametrize(
@@ -919,15 +910,24 @@ def test_unrepresented_gemini_count_tokens_option_is_native_400(client: TestClie
         ),
     ],
 )
-def test_nested_unrepresented_gemini_option_is_native_400_before_provider_io(
+def test_nested_unrepresented_gemini_option_reaches_router_not_400(
     client: TestClient,
     path: str,
     payload_option: dict,
     parameter: str,
 ) -> None:
+    """Nested Gemini fields Router-Maestro does not model (``allowedFunctionNames``,
+    ``fileData``) are forwarded/ignored rather than rejected at the route."""
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
     model_router = MagicMock()
-    model_router.chat_completion = AsyncMock()
-    model_router.prepare_chat_completion_stream = AsyncMock()
+    model_router.chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.prepare_chat_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.chat_completion_stream = AsyncMock(side_effect=sentinel)
     payload = {
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
         **payload_option,
@@ -936,19 +936,8 @@ def test_nested_unrepresented_gemini_option_is_native_400_before_provider_io(
     with patch("router_maestro.server.routes.gemini.get_router", return_value=model_router):
         response = client.post(path, json=payload)
 
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {
-        "error": {
-            "code": 400,
-            "message": f"Unsupported request option '{parameter}'",
-            "status": "INVALID_ARGUMENT",
-            "details": [{"reason": "unsupported_parameter", "parameter": parameter}],
-        }
-    }
-    assert "data:" not in response.text
-    model_router.chat_completion.assert_not_awaited()
-    model_router.prepare_chat_completion_stream.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
 @pytest.mark.parametrize("stream", [False, True])
@@ -959,14 +948,26 @@ def test_nested_unrepresented_gemini_option_is_native_400_before_provider_io(
         ("output_config.format", {"output_config": {"format": {"type": "json_schema"}}}),
     ],
 )
-def test_unrepresented_anthropic_option_is_native_400_before_router_or_sse(
+def test_unrepresented_anthropic_option_reaches_router_not_400(
     client: TestClient,
     stream: bool,
     parameter: str,
     payload_option: dict,
 ) -> None:
+    """Unknown options on the standard Anthropic route are forwarded/ignored,
+    not rejected. The request reaches routing instead of a native 400."""
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
     model_router = MagicMock()
-    model_router.plan_chat_completion = AsyncMock()
+    model_router.get_model_info = AsyncMock(return_value=None)
+    model_router.chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.plan_chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.prepare_chat_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.chat_completion_stream = AsyncMock(side_effect=sentinel)
     payload = {
         "model": "m",
         "max_tokens": 32,
@@ -978,26 +979,28 @@ def test_unrepresented_anthropic_option_is_native_400_before_router_or_sse(
     with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
         response = client.post("/v1/messages", json=payload)
 
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {
-        "type": "error",
-        "error": {
-            "type": "invalid_request_error",
-            "message": f"Unsupported request option '{parameter}'",
-        },
-    }
-    assert "event:" not in response.text
-    model_router.plan_chat_completion.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
 @pytest.mark.parametrize("stream", [False, True])
-def test_nested_unrepresented_anthropic_tool_choice_is_native_400_before_provider_io(
+def test_nested_unrepresented_anthropic_tool_choice_reaches_router_not_400(
     client: TestClient,
     stream: bool,
 ) -> None:
+    """A nested unmodeled tool_choice field is forwarded/ignored, not rejected."""
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
     model_router = MagicMock()
-    model_router.plan_chat_completion = AsyncMock()
+    model_router.get_model_info = AsyncMock(return_value=None)
+    model_router.chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.plan_chat_completion = AsyncMock(side_effect=sentinel)
+    model_router.prepare_chat_completion_stream = AsyncMock(side_effect=sentinel)
+    model_router.chat_completion_stream = AsyncMock(side_effect=sentinel)
     payload = {
         "model": "m",
         "max_tokens": 32,
@@ -1009,23 +1012,14 @@ def test_nested_unrepresented_anthropic_tool_choice_is_native_400_before_provide
     with patch("router_maestro.server.routes.anthropic.get_router", return_value=model_router):
         response = client.post("/v1/messages", json=payload)
 
-    parameter = "tool_choice.disable_parallel_tool_use"
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {
-        "type": "error",
-        "error": {
-            "type": "invalid_request_error",
-            "message": f"Unsupported request option '{parameter}'",
-        },
-    }
-    assert "event:" not in response.text
-    model_router.plan_chat_completion.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
-def test_nested_unrepresented_anthropic_count_tokens_option_is_native_400_before_io(
+def test_nested_unrepresented_anthropic_count_tokens_option_is_ignored_not_400(
     client: TestClient,
 ) -> None:
+    """count_tokens tolerates an unmodeled nested field instead of returning 400."""
     payload = {
         "model": "m",
         "messages": [{"role": "user", "content": "hi"}],
@@ -1041,20 +1035,12 @@ def test_nested_unrepresented_anthropic_count_tokens_option_is_native_400_before
     with patch(
         "router_maestro.server.routes.anthropic._resolve_provider_name",
         new_callable=AsyncMock,
-    ) as resolve_provider:
+        return_value="github-copilot",
+    ):
         response = client.post("/v1/messages/count_tokens", json=payload)
 
-    parameter = "tools[0].strict"
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {
-        "type": "error",
-        "error": {
-            "type": "invalid_request_error",
-            "message": f"Unsupported request option '{parameter}'",
-        },
-    }
-    resolve_provider.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Unsupported request option" not in response.text
 
 
 def test_anthropic_content_vendor_payload_is_not_treated_as_request_option(
@@ -1082,6 +1068,84 @@ def test_anthropic_content_vendor_payload_is_not_treated_as_request_option(
 
     assert response.status_code == 200
     assert response.json()["type"] == "message"
+
+
+def _reaches_routing_router() -> MagicMock:
+    """A router that raises a sentinel as soon as the route reaches provider work.
+
+    The test asserts the request got PAST the option gate (no 400 option error).
+    Any downstream call short-circuits with a distinct sentinel so we can prove
+    routing was reached without reproducing the full response-encoding path.
+    """
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
+    model_router = MagicMock()
+    model_router.get_model_info = AsyncMock(return_value=None)
+    for method in (
+        "chat_completion",
+        "plan_chat_completion",
+        "prepare_chat_completion_stream",
+        "chat_completion_stream",
+        "responses_completion",
+        "prepare_responses_completion_stream",
+        "responses_completion_stream",
+    ):
+        setattr(model_router, method, AsyncMock(side_effect=sentinel))
+    return model_router
+
+
+@pytest.mark.parametrize(
+    ("path", "base_payload", "option", "patch_target"),
+    [
+        (
+            "/api/openai/v1/chat/completions",
+            {"model": "m", "messages": [{"role": "user", "content": "hi"}]},
+            {"context_management": {"enabled": True}},
+            "router_maestro.server.routes.chat.get_router",
+        ),
+        (
+            "/v1/messages",
+            {
+                "model": "m",
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            {"context_management": {"edits": []}},
+            "router_maestro.server.routes.anthropic.get_router",
+        ),
+        (
+            "/api/openai/v1/responses",
+            {"model": "m", "input": "hi"},
+            {"store": True},
+            "router_maestro.server.routes.responses.get_router",
+        ),
+    ],
+)
+def test_unmodeled_client_option_passes_through_instead_of_400(
+    client: TestClient,
+    path: str,
+    base_payload: dict,
+    option: dict,
+    patch_target: str,
+) -> None:
+    """Options Router-Maestro does not model as typed fields (e.g. ``context_management``
+    from Claude Code, ``store`` from Codex) must NOT be hard-rejected. A transparent
+    proxy forwards or ignores them; it does not 400 on an unknown top-level key."""
+    model_router = _reaches_routing_router()
+    payload = {**base_payload, **option}
+
+    with patch(patch_target, return_value=model_router):
+        response = client.post(path, json=payload)
+
+    # The request must reach routing, not be short-circuited by an option-gate 400.
+    assert "Unsupported request option" not in response.text
+    assert "is not supported by the beta" not in response.text
+    # It got past the gate and hit the sentinel provider failure (502/503), not a 400.
+    assert response.status_code != 400, response.text
 
 
 def _routing_error(

--- a/tests/test_responses_reducer.py
+++ b/tests/test_responses_reducer.py
@@ -56,7 +56,6 @@ def test_protocol_package_exports_only_cross_module_production_api() -> None:
         "build_anthropic_response",
         "build_nonstream_snapshot",
         "client_error_response",
-        "unrepresented_option_error",
     ]
 
 


### PR DESCRIPTION
## Problem

v0.6.0's "Explicit request-option policy" hard-rejected any request option Router-Maestro does not model as a typed field, returning HTTP 400. This broke the two primary clients in production:

- **Claude Code** → `API Error: 400 Unsupported request option 'context_management'`
- **Codex** → `{"error":{"message":"Unsupported request option 'store'","code":"unsupported_parameter"}}`

Both `context_management` (Anthropic beta) and `store` (OpenAI Responses) are legitimate options these clients send by default.

## Root cause

The blanket `unrepresented_option_error` guard (introduced in the #126 hardening series, `f2ae12a`, shipped v0.6.0) walked each request and 400'd on the first field that landed in `model_extra`. Every inference route gated on it; the beta route had its own allowlist rejection.

## Verified against the live GitHub Copilot backend

The two cases have **opposite** correct behaviors (probed directly, bypassing RM):

| Option | Endpoint | GHC verdict | Fix |
|---|---|---|---|
| `context_management` | `/v1/messages` | **200, applied** (echoes `applied_edits`) | **forward upstream** |
| `store: true` | `/responses` | **400 `store is not supported`** | **drop, then proceed** |

## Changes

- Remove the blanket `unrepresented_option_error` gate from the chat / anthropic / responses / gemini routes; delete the now-dead helper + export.
- Add `context_management` to the beta route's `_COPILOT_ACCEPTED_FIELDS` so it survives pre-passthrough stripping and reaches the native transport (the paired `anthropic-beta` header is already forwarded).
- `store` and other unmodeled Responses extras are naturally dropped (internal request built from named fields only).
- **Preserve** all value-level validation (`output_config.effort`, `temperature`+`top_p` conflict, `include_usage` type) and provider-capability rejections.
- Reconcile tests that asserted the removed blanket rejection into pass-through assertions; keep value/capability rejection coverage.

## Verification

- Full suite: **3540 passed**, ruff clean.
- TDD: failing tests reproducing both production errors, turned green.
- **Live end-to-end** against real GHC via a local server + audit trace:
  - `context_management` → HTTP 200, trace confirms it was **forwarded upstream** and GHC applied it.
  - `store` → HTTP 200, trace confirms it was **stripped** from the upstream payload.

Fixes the v0.6.0 regression. Target release: v0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)