### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.6.1 (2026-07-15)
+
+### Fixes
+
+- **Transparent passthrough of unmodeled client request options.** The v0.6.0
+  request-option policy rejected any option Router-Maestro does not model as a
+  typed field with an HTTP 400, breaking clients that send such options by
+  default — Claude Code's `context_management` and Codex's `store`. Options are
+  no longer blanket-rejected: verified against the live upstream, GitHub
+  Copilot accepts and applies `context_management` (now forwarded to the native
+  Anthropic transport), while `store` is dropped before the Responses upstream
+  that rejects it. Value-level validation (reasoning effort, temperature/top_p
+  conflicts, `include_usage` type) and provider-capability rejections are
+  retained.
+
 ## v0.6.0 (2026-07-15)
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.6.0"
+version = "0.6.1"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release v0.6.1 — hotfix for the v0.6.0 request-option regression (#132).

Bumps `pyproject.toml`, `__init__.py`, `uv.lock` to 0.6.1 and adds the CHANGELOG `v0.6.1` section.

Restores transparent passthrough of unmodeled client request options (`context_management`, `store`) that v0.6.0 wrongly rejected with HTTP 400. See #132 for root cause and live-backend verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)