### PR TITLE
fix: tolerate unknown reasoning siblings on Responses requests

### DIFF
--- a/src/router_maestro/server/schemas/responses.py
+++ b/src/router_maestro/server/schemas/responses.py
@@ -92,9 +92,16 @@ class ResponsesToolChoiceFunction(BaseModel):
 
 
 class ResponsesReasoningConfig(BaseModel):
-    """Reasoning controls represented by Router-Maestro in Phase 1."""
+    """Reasoning controls Router-Maestro represents.
 
-    model_config = ConfigDict(extra="forbid")
+    Only ``effort`` is consumed; unknown siblings that clients send (e.g. Codex's
+    ``reasoning.context`` on gpt-5.6, or ``reasoning.summary``) are tolerated and
+    dropped rather than rejected — a transparent proxy does not 400 on options it
+    does not model. ``effort`` itself is still validated so an invalid tier is
+    reported instead of forwarded.
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     effort: Literal["minimal", "low", "medium", "high", "xhigh", "max"] | None = None
 

--- a/tests/test_protocol_error_envelopes.py
+++ b/tests/test_protocol_error_envelopes.py
@@ -1727,26 +1727,32 @@ def test_responses_invalid_reasoning_effort_is_native_400(
 
 @pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
 @pytest.mark.parametrize(
-    ("reasoning", "parameter"),
+    "reasoning",
     [
-        pytest.param({"summary": "detailed"}, "reasoning.summary", id="summary-only"),
-        pytest.param(
-            {"effort": "low", "summary": "detailed"},
-            "reasoning.summary",
-            id="effort-and-summary",
-        ),
-        pytest.param({"future": "value"}, "reasoning.future", id="unknown-field"),
+        pytest.param({"summary": "detailed"}, id="summary-only"),
+        pytest.param({"effort": "low", "summary": "detailed"}, id="effort-and-summary"),
+        pytest.param({"future": "value"}, id="unknown-field"),
+        pytest.param({"effort": "low", "context": {"foo": "bar"}}, id="effort-and-context"),
     ],
 )
-def test_responses_unrepresented_reasoning_fields_are_native_400_before_router(
+def test_responses_unrepresented_reasoning_fields_reach_router_not_400(
     client: TestClient,
     stream: bool,
     reasoning: dict,
-    parameter: str,
 ) -> None:
+    """Unknown ``reasoning`` siblings (Codex sends ``reasoning.context`` on gpt-5.6,
+    ``summary``, etc.) must NOT be rejected. Router-Maestro extracts ``effort`` and
+    ignores the rest, so the request reaches routing instead of a native 400."""
+    sentinel = ProviderError(
+        "reached routing sentinel",
+        status_code=503,
+        retryable=False,
+        kind=ProviderFailureKind.UPSTREAM_STATUS,
+    )
     router = MagicMock()
-    router.responses_completion = AsyncMock()
-    router.prepare_responses_completion_stream = AsyncMock()
+    router.responses_completion = AsyncMock(side_effect=sentinel)
+    router.prepare_responses_completion_stream = AsyncMock(side_effect=sentinel)
+    router.responses_completion_stream = AsyncMock(side_effect=sentinel)
     with patch("router_maestro.server.routes.responses.get_router", return_value=router):
         response = client.post(
             "/api/openai/v1/responses",
@@ -1758,12 +1764,9 @@ def test_responses_unrepresented_reasoning_fields_are_native_400_before_router(
             },
         )
 
-    assert response.status_code == 400
-    assert response.headers["content-type"].startswith("application/json")
-    assert response.json()["error"]["param"] == parameter
-    assert "data:" not in response.text
-    router.responses_completion.assert_not_awaited()
-    router.prepare_responses_completion_stream.assert_not_awaited()
+    assert response.status_code != 400, response.text
+    assert "Invalid request option" not in response.text
+    assert "Unsupported request option" not in response.text
 
 
 def test_responses_unsupported_tools_use_native_400(client: TestClient) -> None:


### PR DESCRIPTION
## Problem

Codex on gpt-5.6 fails with:

```
{"error":{"message":"Invalid request option 'reasoning.context'","type":"invalid_request_error","param":"reasoning.context","code":"unsupported_parameter"}}
```

Same class as the v0.6.1 regression, different guard: the `reasoning` object is re-validated by a strict `extra="forbid"` `ResponsesReasoningConfig` that models only `effort`, so Codex's `reasoning.context` sibling is rejected with a 400.

## Root cause

`responses.py` re-validates `request.reasoning` via `ResponsesReasoningConfig.model_validate(...)` purely to reject unknowns — but the route only ever consumes `reasoning.effort`; every other sibling is dropped before the request goes upstream.

## Verified against the live GitHub Copilot backend

Probed `/responses` directly: `reasoning.context` → `400 "failed to parse request"` on gpt-5.6-sol/terra and gpt-5.5; `reasoning.effort`-only → 200. So GHC rejects `context` too — forwarding it would be wrong. The correct behavior is to **extract `effort` and drop the rest** (same shape as the `store` fix).

## Fix

- Relax `ResponsesReasoningConfig` from `extra="forbid"` to `extra="ignore"`. Unknown siblings (`context`, `summary`, future extensions) are tolerated and dropped; `effort` value is still validated (invalid tier still rejected as `reasoning_effort`).
- Reconcile the test that asserted strict reasoning-field rejection into a pass-through assertion; keep invalid-effort-value rejection coverage.

## Verification

- Full suite: **3542 passed**, ruff clean.
- TDD: failing test reproducing `Invalid request option 'reasoning.context'`, turned green.
- **Live end-to-end**: `gpt-5.6-sol` with `reasoning:{effort:low, context:{...}}` → HTTP 200; trace confirms upstream payload was `reasoning:{effort:low, summary:auto}` with `context` dropped.

Target release: v0.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)