### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.6.2 (2026-07-15)
+
+### Fixes
+
+- **Tolerate unknown reasoning siblings on Responses requests.** Codex sends
+  `reasoning.context` on gpt-5.6, which was rejected as
+  `Invalid request option 'reasoning.context'` (HTTP 400) by a strict reasoning
+  sub-schema. Router-Maestro only consumes `reasoning.effort`; unknown siblings
+  (`context`, `summary`, future extensions) are now ignored and dropped before
+  the upstream request instead of being rejected. The `effort` value is still
+  validated, so an invalid tier is still reported.
+
 ## v0.6.1 (2026-07-15)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.6.1"
+version = "0.6.2"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release v0.6.2 — hotfix for the Codex gpt-5.6 `reasoning.context` 400 (#135).

Bumps `pyproject.toml`, `__init__.py`, `uv.lock` to 0.6.2 and adds the CHANGELOG `v0.6.2` section.

Relaxes the strict reasoning sub-schema so unknown `reasoning` siblings are tolerated and dropped instead of rejected. See #135 for root cause and live-backend verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)