### PR TITLE
fix(routing): let scoped primary proceed when thinking is downgraded

### DIFF
--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -1848,7 +1848,24 @@ class Router:
                     kind=ProviderFailureKind.CLIENT_REQUEST,
                 )
 
-            reasoning_drift = plan.features.reasoning and not transformed_features.reasoning
+            # The primary is the only executable route; when the caller scopes
+            # its per-candidate request (via ``candidate_requests``) it owns that
+            # request's reasoning shape. The Anthropic route, for example, runs
+            # ``_apply_thinking_budget`` per candidate and legitimately disables
+            # thinking when the requested ``max_tokens`` leaves no output
+            # headroom for a thinking budget. That server-initiated downgrade is
+            # safe — a non-reasoning request always runs on a reasoning-capable
+            # route — so the primary proceeds instead of 400'ing. Fallbacks that
+            # lose reasoning are still dropped (see ``prevalidate_plan``), and an
+            # unscoped primary still enforces the client's explicit reasoning.
+            primary_scoped = (
+                candidate.model == plan.primary.model and candidate.model in candidate_requests
+            )
+            reasoning_drift = (
+                plan.features.reasoning
+                and not transformed_features.reasoning
+                and not primary_scoped
+            )
             unscoped_reasoning_enhancement = (
                 transformed_features.reasoning
                 and not plan.features.reasoning

--- a/tests/test_thinking_budget_config.py
+++ b/tests/test_thinking_budget_config.py
@@ -1147,6 +1147,55 @@ class TestAnthropicRouteThinkingBudget:
         assert fallback.requests == []
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_scoped_primary_that_loses_thinking_headroom_still_proceeds(
+        self,
+        stream,
+    ):
+        """A scoped primary whose thinking is disabled for lack of output
+        headroom must proceed rather than 400.
+
+        When the requested ``max_tokens`` is too small to fit any thinking
+        budget, ``_apply_thinking_budget`` disables thinking for that candidate.
+        The primary is the only executable route, and a non-reasoning request
+        always runs on a reasoning-capable route, so preparation must succeed.
+        A scoped fallback that loses the same headroom is still dropped.
+        """
+        router, _primary, _fallback, _priorities = _auto_thinking_fallback_router(
+            primary_fail=False,
+            fallback_supports_thinking=True,
+            auto_enable=False,
+        )
+        request = ChatRequest(
+            model="shared",
+            messages=[Message(role="user", content="hi")],
+            max_tokens=200,
+            stream=stream,
+            thinking_budget=8192,
+            thinking_type="enabled",
+        )
+        plan = await router.plan_chat_completion(request, stream=stream)
+        candidate_requests = {
+            candidate.model: await _apply_thinking_budget(
+                router,
+                request,
+                request.model,
+                candidate=candidate,
+            )
+            for candidate in (plan.primary, *plan.prevalidation_fallbacks)
+        }
+
+        prepared = router.prepare_planned_chat_completion(
+            plan,
+            candidate_requests[plan.primary.model],
+            candidate_requests=candidate_requests,
+        )
+
+        assert prepared.plan.fallbacks == ()
+        assert candidate_requests[plan.primary.model].thinking_type is None
+        assert candidate_requests[plan.primary.model].thinking_budget is None
+
+    @pytest.mark.asyncio
     async def test_auto_enabled_primary_keeps_non_reasoning_stream_fallback(self, monkeypatch):
         router, primary, fallback, priorities = _auto_thinking_fallback_router()
         monkeypatch.setattr(anthropic_route, "get_router", lambda: router)


### PR DESCRIPTION
## Summary

Rebased onto latest `master` (`d137453`, v0.6.2). This PR now carries a **single** routing fix.

The `context_management` 400 that this branch originally also fixed is already resolved on `master` by #132 (`fix: stop rejecting unmodeled client request options`), which removes the blanket unmodeled-option gate and forwards `context_management` upstream. That commit of this branch has been dropped to avoid conflicts/duplication.

### `fix(routing): let scoped primary proceed when thinking is downgraded`

`prepare_planned_chat_completion` rejected requests with `400 "Planned Chat features do not match the current request"` whenever the plan was built with reasoning but the transformed **primary** request no longer had it. The Anthropic route runs `_apply_thinking_budget` per candidate and legitimately disables thinking when the requested `max_tokens` leaves no output headroom for a thinking budget (min budget 1024). On a Responses-only model with no fallbacks (e.g. `gpt-5.6-sol`), that server-initiated downgrade tripped the primary's `reasoning_drift` guard and 400'd — even though a non-reasoning request always runs fine on a reasoning-capable route.

- Tolerate reasoning-drift only for the **caller-scoped primary** (the caller owns its per-candidate request), mirroring the existing scoped handling of `unscoped_reasoning_enhancement`. Fallbacks that lose reasoning are still dropped, and an unscoped primary still enforces the client's explicit reasoning request.

## Testing

- `tests/test_thinking_budget_config.py` — new `test_scoped_primary_that_loses_thinking_headroom_still_proceeds` (stream + non-stream) plus existing drift/headroom/reasoning coverage: **41 passed**.
- `ruff check` clean on changed files.
- Live end-to-end against real GitHub Copilot via the Anthropic endpoint: `gpt-5.6-sol` + `thinking budget 32768` + `max_tokens=200` → **200** (previously **400**); regression checks with large `max_tokens` → **200**.

## Notes

- Preserves the intent of `test_explicit_client_reasoning_cannot_be_removed_during_preparation` (unscoped primaries still 400) and `test_explicit_reasoning_skips_fallback_that_loses_thinking_headroom` (fallbacks still dropped).
- Pre-existing, unrelated failures in `tests/test_prepared_stream_routes.py::test_protocol_stream_never_opens_option_incompatible_fallback` (top_p streaming fallback) reproduce on pristine `master` and are out of scope for this PR.
