### PR TITLE
refactor: provider-bound option policy (round 1) + inbound permissiveness

### DIFF
--- a/integration_tests/test_live_anthropic_beta.py
+++ b/integration_tests/test_live_anthropic_beta.py
@@ -84,22 +84,23 @@ def test_beta_non_streaming_compat_fields(client: httpx.Client, chat_model: str)
 @pytest.mark.parametrize(
     ("option_payload", "parameter"),
     [
-        ({"context_management": {"enabled": True}}, "context_management"),
         (
             {"output_config": {"effort": "low", "format": "text"}},
             "output_config.format",
         ),
-        ({"service_tier": "standard_only"}, "service_tier"),
     ],
 )
-def test_beta_rejects_unknown_semantic_options(
+def test_beta_rejects_malformed_output_config(
     client: httpx.Client,
     chat_model: str,
     stream: bool,
     option_payload: dict[str, Any],
     parameter: str,
 ):
-    """Beta Messages rejects unrepresented options before SSE/provider commitment."""
+    """Beta Messages rejects a malformed output_config value (a consumed field)
+    before SSE/provider commitment. Unknown/unmodeled options are NOT rejected —
+    they are forwarded or stripped per the provider outbound contract (see
+    test_beta_forwards_unmodeled_options)."""
     payload = anthropic_payload(chat_model, stream=stream)
     payload.update(option_payload)
 
@@ -112,6 +113,46 @@ def test_beta_rejects_unknown_semantic_options(
     assert error["error"]["type"] == "invalid_request_error"
     assert parameter in error["error"]["message"]
     assert "event:" not in response.text
+
+
+def test_beta_strips_unmodeled_service_tier(client: httpx.Client, chat_model: str):
+    """service_tier is unmodeled on the native path; Router-Maestro strips it and
+    the request completes normally rather than being rejected."""
+    payload = anthropic_payload(chat_model, stream=False)
+    payload["service_tier"] = "standard_only"
+
+    response = client.post(BETA, json=payload, timeout=180.0)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["type"] == "message"
+
+
+def test_beta_forwards_context_management_without_local_rejection(
+    client: httpx.Client, chat_model: str
+):
+    """Router-Maestro forwards context_management to the native transport rather
+    than rejecting it locally.
+
+    GHC load-balances a given model id across upstream backends (Bedrock/Vertex/…)
+    and only some accept the context-management beta, so the upstream verdict is
+    non-deterministic and NOT Router-Maestro's to assert. What we assert is what
+    RM controls: the option is not rejected by RM's own request-option gate. A
+    success (GHC applied it) or an upstream passthrough error are both acceptable;
+    RM's local ``invalid_request_error`` naming the option is not."""
+    payload = anthropic_payload(chat_model, stream=False)
+    payload["context_management"] = {"edits": [{"type": "clear_tool_uses_20250919"}]}
+
+    response = client.post(BETA, json=payload, timeout=180.0)
+
+    if response.status_code == 200:
+        assert response.json()["type"] == "message"
+        return
+    # If GHC's chosen backend rejected it, the error is the upstream's, not RM's
+    # local option gate — RM must not have short-circuited it before forwarding.
+    body = response.json()
+    message = body.get("error", {}).get("message", "")
+    assert "is not supported by the native Anthropic transport" not in message
+    assert "output_config" not in message
 
 
 def test_beta_streaming(client: httpx.Client, chat_model: str):

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -9,6 +9,10 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, Self
 
 import httpx
 
+from router_maestro.providers.outbound_contract import (
+    OutboundContract,
+    PermissiveOutboundContract,
+)
 from router_maestro.routing.capabilities import Operation, ProviderCapabilities
 
 if TYPE_CHECKING:
@@ -643,6 +647,13 @@ class BaseProvider(ABC):
     """Abstract base class for model providers."""
 
     name: str = "base"
+
+    _default_outbound_contract: OutboundContract = PermissiveOutboundContract()
+
+    @property
+    def outbound_contract(self) -> OutboundContract:
+        """The provider's upstream wire contract (see OutboundContract)."""
+        return self._default_outbound_contract
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -32,7 +32,6 @@ from router_maestro.providers.base import (
 )
 from router_maestro.providers.copilot_support.auth_session import CopilotAuthSession
 from router_maestro.providers.copilot_support.catalog import CopilotCatalog
-from router_maestro.providers.outbound_contract import OutboundContract
 from router_maestro.providers.copilot_support.catalog import (
     normalize_supported_endpoints as _catalog_normalize_supported_endpoints,
 )
@@ -42,6 +41,7 @@ from router_maestro.providers.copilot_support.catalog import (
 from router_maestro.providers.copilot_support.chat_codec import CopilotChatCodec
 from router_maestro.providers.copilot_support.responses_codec import CopilotResponsesCodec
 from router_maestro.providers.copilot_support.transport import CopilotTransport
+from router_maestro.providers.outbound_contract import OutboundContract
 from router_maestro.routing.capabilities import Operation, ProviderCapabilities
 from router_maestro.utils import get_logger
 from router_maestro.utils.reasoning import (

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -32,6 +32,7 @@ from router_maestro.providers.base import (
 )
 from router_maestro.providers.copilot_support.auth_session import CopilotAuthSession
 from router_maestro.providers.copilot_support.catalog import CopilotCatalog
+from router_maestro.providers.outbound_contract import OutboundContract
 from router_maestro.providers.copilot_support.catalog import (
     normalize_supported_endpoints as _catalog_normalize_supported_endpoints,
 )
@@ -252,10 +253,55 @@ def _extract_reasoning_from_chunk(part: dict | None) -> tuple[str, str | None]:
     return CopilotChatCodec.extract_reasoning(part)
 
 
+_COPILOT_NATIVE_ANTHROPIC_FORWARD_FIELDS = frozenset(
+    {
+        "model",
+        "messages",
+        "max_tokens",
+        "stream",
+        "system",
+        "thinking",
+        "tools",
+        "tool_choice",
+        "temperature",
+        "top_p",
+        "top_k",
+        "stop_sequences",
+        "metadata",
+        "output_config",
+        # Forwarded verbatim: GHC accepts and applies context_management
+        # (verified live, echoes applied_edits). The paired anthropic-beta header
+        # is forwarded by the Copilot transport, so the option only needs to
+        # survive body stripping.
+        "context_management",
+    }
+)
+
+
+class CopilotOutboundContract(OutboundContract):
+    """Copilot upstream wire contract.
+
+    Round 1: the native Anthropic passthrough forward allowlist. Fields outside
+    this set are stripped before the raw body is sent to GitHub Copilot, which
+    rejects unknown top-level fields (e.g. mcp_servers, container).
+    """
+
+    def forwardable_fields(self, operation: Operation) -> frozenset[str] | None:
+        if operation is Operation.NATIVE_ANTHROPIC:
+            return _COPILOT_NATIVE_ANTHROPIC_FORWARD_FIELDS
+        return None
+
+
 class CopilotProvider(BaseProvider):
     """GitHub Copilot provider."""
 
     name = "github-copilot"
+
+    _copilot_outbound_contract = CopilotOutboundContract()
+
+    @property
+    def outbound_contract(self) -> OutboundContract:
+        return self._copilot_outbound_contract
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/src/router_maestro/providers/outbound_contract.py
+++ b/src/router_maestro/providers/outbound_contract.py
@@ -1,0 +1,33 @@
+"""Provider-bound knowledge of what an upstream will accept on the wire.
+
+Round 1 governs only the raw-passthrough forward path (currently the beta
+native Anthropic route): which top-level fields survive the strip before the
+body is sent upstream. Round 2 will grow this contract with per-option value
+reconciliation (downgrade/drop/reject) and tool filtering, migrating the rules
+currently scattered across each provider's ``_build_payload``.
+"""
+
+from abc import ABC
+
+from router_maestro.routing.capabilities import Operation
+
+
+class OutboundContract(ABC):
+    """What a provider's upstream accepts. Subclass per provider."""
+
+    def forwardable_fields(self, operation: Operation) -> frozenset[str] | None:
+        """Top-level fields allowed through on a raw-passthrough forward.
+
+        ``None`` means forward everything (no strip). A provider whose upstream
+        rejects unknown top-level fields returns an explicit allowlist.
+        """
+        return None
+
+
+class PermissiveOutboundContract(OutboundContract):
+    """Default contract: forward everything.
+
+    Used by providers that build their upstream payload from typed fields
+    (Path 1), where unknown options are already absent and there is nothing to
+    strip.
+    """

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -1177,9 +1177,7 @@ async def beta_messages(raw_request: FastAPIRequest):
 
     # Defense in depth for fields introduced by internal transformations. Raw
     # client options have already passed the shallow beta option gate above.
-    forwardable = copilot_provider.outbound_contract.forwardable_fields(
-        Operation.NATIVE_ANTHROPIC
-    )
+    forwardable = copilot_provider.outbound_contract.forwardable_fields(Operation.NATIVE_ANTHROPIC)
     if forwardable is not None:
         unknown = set(body.keys()) - forwardable
         if unknown:

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -74,33 +74,6 @@ _ANTHROPIC_SSE_EVENTS = frozenset(
     }
 )
 
-# Top-level Messages fields whose semantics Router-Maestro represents on the
-# beta endpoint. Nested message/content payloads remain forward-compatible and
-# are deliberately outside this shallow request-option gate.
-_COPILOT_ACCEPTED_FIELDS = frozenset(
-    {
-        "model",
-        "messages",
-        "max_tokens",
-        "stream",
-        "system",
-        "thinking",
-        "tools",
-        "tool_choice",
-        "temperature",
-        "top_p",
-        "top_k",
-        "stop_sequences",
-        "metadata",
-        "output_config",
-        # Forwarded verbatim to the native Anthropic transport. GHC accepts and
-        # applies context_management (verified live: 200 with an applied_edits
-        # echo); the paired anthropic-beta header is already forwarded by the
-        # Copilot transport, so the option only needs to survive body stripping.
-        "context_management",
-    }
-)
-
 
 @dataclass(frozen=True, slots=True)
 class _ResolvedModel:
@@ -183,7 +156,8 @@ def _validate_beta_request_options(body: dict) -> None:
     Options that Router-Maestro does not model as typed fields (for example
     ``context_management`` sent by Claude Code) are NOT rejected: a transparent
     proxy forwards or ignores unknown options rather than returning a 400. The
-    native passthrough path strips anything outside ``_COPILOT_ACCEPTED_FIELDS``
+    native passthrough path strips anything outside the Copilot provider's
+    outbound contract (``CopilotOutboundContract.forwardable_fields``)
     before forwarding, so unknown top-level keys are ignored, not echoed upstream.
 
     Only ``output_config`` is validated here, because Router-Maestro actively
@@ -1203,11 +1177,15 @@ async def beta_messages(raw_request: FastAPIRequest):
 
     # Defense in depth for fields introduced by internal transformations. Raw
     # client options have already passed the shallow beta option gate above.
-    unknown = set(body.keys()) - _COPILOT_ACCEPTED_FIELDS
-    if unknown:
-        logger.debug("Stripping unknown fields before passthrough: %s", unknown)
-        for key in unknown:
-            del body[key]
+    forwardable = copilot_provider.outbound_contract.forwardable_fields(
+        Operation.NATIVE_ANTHROPIC
+    )
+    if forwardable is not None:
+        unknown = set(body.keys()) - forwardable
+        if unknown:
+            logger.debug("Stripping unknown fields before passthrough: %s", unknown)
+            for key in unknown:
+                del body[key]
 
     # Legacy test/integration hooks may still return a resolution without a plan.
     # Real native routing always executes the immutable plan below.

--- a/src/router_maestro/server/schemas/anthropic.py
+++ b/src/router_maestro/server/schemas/anthropic.py
@@ -109,9 +109,15 @@ class AnthropicThinkingBlock(BaseModel):
 
 
 AnthropicUserContentBlock = (
-    AnthropicTextBlock | AnthropicImageBlock | AnthropicDocumentBlock | AnthropicToolResultBlock
+    AnthropicTextBlock
+    | AnthropicImageBlock
+    | AnthropicDocumentBlock
+    | AnthropicToolResultBlock
+    | dict[str, Any]
 )
-AnthropicAssistantContentBlock = AnthropicTextBlock | AnthropicToolUseBlock | AnthropicThinkingBlock
+AnthropicAssistantContentBlock = (
+    AnthropicTextBlock | AnthropicToolUseBlock | AnthropicThinkingBlock | dict[str, Any]
+)
 
 
 class AnthropicUserMessage(BaseModel):
@@ -142,7 +148,7 @@ class AnthropicTool(BaseModel):
 
     name: str
     description: str | None = None
-    input_schema: dict
+    input_schema: dict | None = None
     cache_control: dict[str, Any] | None = None
 
 

--- a/src/router_maestro/server/schemas/openai.py
+++ b/src/router_maestro/server/schemas/openai.py
@@ -31,9 +31,14 @@ class ChatMessage(BaseModel):
 
 
 class OpenAIThinkingConfig(BaseModel):
-    """Strict Anthropic-style thinking extension accepted by Chat Completions."""
+    """Anthropic-style thinking extension accepted by Chat Completions.
 
-    model_config = ConfigDict(extra="forbid")
+    Only ``type`` and ``budget_tokens`` are consumed; unknown siblings a client
+    sends (e.g. Anthropic's ``display``) are tolerated and dropped rather than
+    rejected. The two consumed fields are still value-validated.
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     type: Literal["enabled", "adaptive", "disabled"]
     budget_tokens: Annotated[int, Field(strict=True, gt=0)] | None = None

--- a/tests/test_chat_route_options.py
+++ b/tests/test_chat_route_options.py
@@ -615,7 +615,6 @@ def test_openai_thinking_invalid_budget_still_rejected():
         OpenAIThinkingConfig.model_validate({"type": "enabled", "budget_tokens": -1})
 
 
-
 @pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
 @pytest.mark.parametrize(
     ("thinking", "expected_type", "expected_budget"),

--- a/tests/test_chat_route_options.py
+++ b/tests/test_chat_route_options.py
@@ -565,11 +565,6 @@ def test_openai_chat_preserves_minimal_reasoning_effort(monkeypatch, stream):
             "thinking.budget_tokens",
             id="disabled-string-budget",
         ),
-        pytest.param(
-            {"type": "enabled", "vendor_option": True},
-            "thinking.vendor_option",
-            id="unknown-field",
-        ),
     ],
 )
 def test_openai_chat_rejects_malformed_thinking_before_router_calls(
@@ -601,6 +596,24 @@ def test_openai_chat_rejects_malformed_thinking_before_router_calls(
     router.chat_completion.assert_not_awaited()
     router.prepare_chat_completion_stream.assert_not_awaited()
     router.chat_completion_stream.assert_not_awaited()
+
+
+def test_openai_thinking_with_unknown_sibling_is_accepted():
+    from router_maestro.server.schemas.openai import OpenAIThinkingConfig
+
+    # Anthropic's `display` sibling (summarized/omitted) is sent by real clients.
+    cfg = OpenAIThinkingConfig.model_validate({"type": "adaptive", "display": "summarized"})
+    assert cfg.type == "adaptive"
+
+
+def test_openai_thinking_invalid_budget_still_rejected():
+    from pydantic import ValidationError
+
+    from router_maestro.server.schemas.openai import OpenAIThinkingConfig
+
+    with pytest.raises(ValidationError):
+        OpenAIThinkingConfig.model_validate({"type": "enabled", "budget_tokens": -1})
+
 
 
 @pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -1,0 +1,23 @@
+from router_maestro.providers.outbound_contract import (
+    OutboundContract,
+    PermissiveOutboundContract,
+)
+from router_maestro.routing.capabilities import Operation
+
+
+def test_permissive_contract_forwards_everything():
+    contract = PermissiveOutboundContract()
+    assert contract.forwardable_fields(Operation.NATIVE_ANTHROPIC) is None
+
+
+def test_permissive_is_an_outbound_contract():
+    assert isinstance(PermissiveOutboundContract(), OutboundContract)
+
+
+def test_base_provider_default_contract_is_permissive():
+    from router_maestro.providers.anthropic import AnthropicProvider
+
+    # A Path-1 provider inherits the permissive default (nothing to strip).
+    contract = AnthropicProvider().outbound_contract
+    assert isinstance(contract, OutboundContract)
+    assert contract.forwardable_fields(Operation.NATIVE_ANTHROPIC) is None

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -21,3 +21,25 @@ def test_base_provider_default_contract_is_permissive():
     contract = AnthropicProvider().outbound_contract
     assert isinstance(contract, OutboundContract)
     assert contract.forwardable_fields(Operation.NATIVE_ANTHROPIC) is None
+
+
+def test_copilot_contract_forwards_native_anthropic_allowlist():
+    from router_maestro.providers.copilot import CopilotProvider
+
+    contract = CopilotProvider().outbound_contract
+    fields = contract.forwardable_fields(Operation.NATIVE_ANTHROPIC)
+    assert fields is not None
+    # Forwarded (verified live: GHC applies context_management).
+    assert "context_management" in fields
+    assert "messages" in fields
+    assert "thinking" in fields
+    # Not in the allowlist -> stripped (GHC 400s these).
+    assert "mcp_servers" not in fields
+    assert "container" not in fields
+
+
+def test_copilot_contract_is_permissive_for_other_operations():
+    from router_maestro.providers.copilot import CopilotProvider
+
+    contract = CopilotProvider().outbound_contract
+    assert contract.forwardable_fields(Operation.CHAT) is None

--- a/tests/test_request_schema_permissiveness.py
+++ b/tests/test_request_schema_permissiveness.py
@@ -1,0 +1,102 @@
+"""Guard: inference request schemas must never reject unknown client options.
+
+Clients evolve faster than Router-Maestro models them. Any Pydantic model
+reachable from an inference request body must tolerate unknown fields
+(extra != "forbid"), so an unmodeled option is ignored, not 400'd. Admin/config
+request roots are intentionally excluded — rejecting a typo'd config key there
+is correct.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from pydantic import BaseModel
+
+from router_maestro.server.schemas.anthropic import (
+    AnthropicCountTokensRequest,
+    AnthropicMessagesRequest,
+)
+from router_maestro.server.schemas.gemini import GeminiGenerateContentRequest
+from router_maestro.server.schemas.openai import (
+    ChatCompletionRequest,
+    ChatCompletionStreamOptions,
+    OpenAIThinkingConfig,
+)
+from router_maestro.server.schemas.responses import (
+    ResponsesReasoningConfig,
+    ResponsesRequest,
+)
+
+# Roots whose full nested field graph is validated by FastAPI on the request body.
+INFERENCE_REQUEST_ROOTS = [
+    ChatCompletionRequest,
+    AnthropicMessagesRequest,
+    AnthropicCountTokensRequest,
+    GeminiGenerateContentRequest,
+    ResponsesRequest,
+]
+
+# Request sub-schemas the routes re-validate manually via ``model_validate`` on a
+# field typed ``Any`` (so they are NOT reachable by walking annotations). These
+# are exactly the surface that produced the F1 (thinking) and v0.6.2 (reasoning)
+# regressions, so the guard must cover them explicitly.
+ROUTE_REVALIDATED_REQUEST_SCHEMAS = [
+    ChatCompletionStreamOptions,
+    OpenAIThinkingConfig,
+    ResponsesReasoningConfig,
+]
+
+
+def _iter_model_types(annotation: object) -> typing.Iterator[type[BaseModel]]:
+    """Yield BaseModel subclasses nested anywhere in a type annotation."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        yield annotation
+        return
+    for arg in typing.get_args(annotation):
+        yield from _iter_model_types(arg)
+
+
+def _reachable_models(root: type[BaseModel]) -> set[type[BaseModel]]:
+    """Collect every BaseModel reachable through root's field annotations."""
+    seen: set[type[BaseModel]] = set()
+    stack: list[type[BaseModel]] = [root]
+    while stack:
+        model = stack.pop()
+        if model in seen:
+            continue
+        seen.add(model)
+        for field in model.model_fields.values():
+            for annotated in _iter_model_types(field.annotation):
+                if annotated not in seen:
+                    stack.append(annotated)
+    return seen
+
+
+def test_no_inference_request_schema_forbids_extra():
+    roots = INFERENCE_REQUEST_ROOTS + ROUTE_REVALIDATED_REQUEST_SCHEMAS
+    offenders = []
+    for root in roots:
+        for model in _reachable_models(root):
+            if model.model_config.get("extra") == "forbid":
+                offenders.append(f"{model.__module__}.{model.__qualname__}")
+    assert not offenders, (
+        "Inference request schemas must not use extra='forbid' "
+        f"(clients send unmodeled options): {sorted(offenders)}"
+    )
+
+
+def test_guard_covers_the_route_revalidated_schemas():
+    """Regression guard for the guard itself: the F1/v0.6.2 schemas are typed
+    ``Any`` on their request roots, so annotation-walking alone misses them.
+    This asserts they are explicitly covered so a future extra='forbid' on them
+    fails CI."""
+    assert OpenAIThinkingConfig in ROUTE_REVALIDATED_REQUEST_SCHEMAS
+    assert ResponsesReasoningConfig in ROUTE_REVALIDATED_REQUEST_SCHEMAS
+    # And prove they are NOT otherwise reachable (why the explicit list is needed).
+    reachable = set()
+    for root in INFERENCE_REQUEST_ROOTS:
+        reachable |= _reachable_models(root)
+    assert OpenAIThinkingConfig not in reachable
+    assert ResponsesReasoningConfig not in reachable
+

--- a/tests/test_request_schema_permissiveness.py
+++ b/tests/test_request_schema_permissiveness.py
@@ -99,4 +99,3 @@ def test_guard_covers_the_route_revalidated_schemas():
         reachable |= _reachable_models(root)
     assert OpenAIThinkingConfig not in reachable
     assert ResponsesReasoningConfig not in reachable
-

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -284,3 +284,50 @@ class TestToolResultWithToolReference:
         assert len(tool_messages) == 1
         assert tool_messages[0].content == ""
         assert tool_messages[0].tool_call_id == "toolu_456"
+
+
+class TestPermissiveRequestParsing:
+    """Inbound permissiveness: clients send options RM doesn't model (F2, F3)."""
+
+    def test_builtin_tool_without_input_schema_is_accepted(self):
+        # Anthropic built-in/server tools carry no input_schema (F2).
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-sonnet-4.5",
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [{"type": "web_search_20250305", "name": "web_search"}],
+            }
+        )
+        assert req.tools[0].name == "web_search"
+
+    def test_redacted_thinking_block_is_accepted(self):
+        # Extended thinking is default-on for opus-4.8; redacted blocks replay (F3).
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-opus-4.8",
+                "max_tokens": 64,
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "redacted_thinking", "data": "xyz"}],
+                    },
+                    {"role": "user", "content": "continue"},
+                ],
+            }
+        )
+        assert len(req.messages) == 3
+
+    def test_unknown_user_content_block_is_accepted(self):
+        # A future/unmodeled user content block must not 422 (F3).
+        req = AnthropicMessagesRequest.model_validate(
+            {
+                "model": "claude-sonnet-4.5",
+                "max_tokens": 64,
+                "messages": [
+                    {"role": "user", "content": [{"type": "future_block_2026", "payload": {"k": 1}}]},
+                ],
+            }
+        )
+        assert len(req.messages) == 1

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -326,7 +326,10 @@ class TestPermissiveRequestParsing:
                 "model": "claude-sonnet-4.5",
                 "max_tokens": 64,
                 "messages": [
-                    {"role": "user", "content": [{"type": "future_block_2026", "payload": {"k": 1}}]},
+                    {
+                        "role": "user",
+                        "content": [{"type": "future_block_2026", "payload": {"k": 1}}],
+                    },
                 ],
             }
         )


### PR DESCRIPTION
Round 1 of 2. Addresses the architectural root cause behind the v0.6.0–v0.6.2 hotfix series: option accept/reject policy was scattered with no single source of truth, and strictness lived on the fast-moving *client* side instead of the controlled *provider upstream* side.

## Principles
- **Inbound (client → RM): permissive.** Never 400 a client for an option RM doesn't model. Parse what we consume, ignore the rest.
- **Outbound (RM → provider): filter, bound to the provider.** Each provider owns what its upstream accepts.

## Part A — inbound permissiveness
Fixes three confirmed strict-schema bugs found by audit (all reproduced live):
- **F1** `OpenAIThinkingConfig` `extra="forbid"` → `ignore`: `thinking.display` (Anthropic's 3rd thinking key) no longer 400s on the chat endpoint. Value validation (`type`, `budget_tokens`) retained.
- **F2** `AnthropicTool.input_schema` made optional: Anthropic built-in/server tools (`web_search_20250305`, `bash_*`, `text_editor_*`, `computer_*`) no longer 422.
- **F3** content-block unions get a `dict[str, Any]` tail: replayed `redacted_thinking` / `server_tool_use` / unknown blocks no longer 422.
- **Guard test** (`test_request_schema_permissiveness.py`): asserts no inference request schema (incl. the route-revalidated `thinking`/`reasoning`/`stream_options` sub-schemas) is `extra="forbid"`, so instance #7 fails CI, not production. Admin/config roots deliberately excluded.

## Part B — provider-bound outbound contract
- New `OutboundContract` abstraction on `BaseProvider` (permissive default).
- `CopilotOutboundContract` owns the native-Anthropic forward allowlist (formerly `_COPILOT_ACCEPTED_FIELDS`, hardcoded in the beta route).
- Beta route reads the allowlist from `provider.outbound_contract.forwardable_fields(...)`. Behavior-preserving; the frozenset is gone from the route.

## Verification
- Full unit suite: **3552 passed**, ruff clean.
- Live end-to-end: F1/F2/F3 → 200 (were 400/422); `context_management` regression → still forwarded (200, `applied_edits`).
- **Full `make integration-test` matrix: 90 passed, 3 skipped, 0 failed** (complete Copilot matrix, the hard gate). Reconciled the stale beta option-rejection integration tests to the permissive policy; made the `context_management` assertion robust to GHC's non-deterministic Bedrock/Vertex backend routing (documented).

Round 2 (separate spec + release) migrates Path-1 value reconciliation (effort downgrade, `_reject_option`, tool filtering) into `OutboundContract`.

Codex review skipped (Codex currently unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)