### PR TITLE
refactor: unify Copilot outbound policy into OutboundContract (round 2)

### DIFF
--- a/integration_tests/test_controlled_boundaries.py
+++ b/integration_tests/test_controlled_boundaries.py
@@ -787,3 +787,63 @@ def test_standard_anthropic_enabled_budget_effort_payload_is_exact_in_both_modes
         if stream:
             expected["stream_options"] = {"include_usage": True}
         assert_exact_outbound_payload(request.payload, expected)
+
+
+def test_chat_reasoning_effort_downgraded_to_catalog_tier(tmp_path: Path):
+    """Round 2: the unified CopilotOutboundContract.resolve_reasoning downgrades an
+    above-catalog effort to the highest advertised tier on the Chat wire payload."""
+
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("chat-model", endpoints=["/chat/completions"]))
+        if request.path == "/chat/completions":
+            return _chat_success(request.payload["model"])
+        return _json_reply(500, {"error": "wrong operation"})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/chat-model"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/chat/completions",
+            json={
+                "model": "router-maestro",
+                "messages": [{"role": "user", "content": "ping"}],
+                "reasoning_effort": "max",  # catalog advertises only up to high
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    request = select_recorded_request(upstream.requests, method="POST", path="/chat/completions")
+    assert request.payload["reasoning_effort"] == "high"
+
+
+def test_responses_reasoning_effort_downgraded_to_catalog_tier(tmp_path: Path):
+    """Round 2: the same contract method downgrades effort on the Responses wire
+    payload — proving chat and responses now share one effort rule."""
+
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("responses-model", endpoints=["/responses"]))
+        if request.path == "/responses":
+            return _responses_success(request.payload["model"])
+        return _json_reply(500, {"error": "wrong operation"})
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/responses-model"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/openai/v1/responses",
+            json={
+                "model": "router-maestro",
+                "input": "ping",
+                "reasoning": {"effort": "max"},  # catalog advertises only up to high
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    request = select_recorded_request(upstream.requests, method="POST", path="/responses")
+    assert request.payload["reasoning"]["effort"] == "high"

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -1088,7 +1088,7 @@ class CopilotProvider(BaseProvider):
             provider_name=self.name,
             validate_extensions=self._validate_provider_extensions,
             catalog_effort_values=self._catalog_effort_values(request.model),
-            known_reasoning_support=_known_reasoning_support(request.model),
+            resolve_reasoning=self.outbound_contract.resolve_reasoning,
         )
 
     def validate_responses_request(self, request: ResponsesRequest) -> None:

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -41,11 +41,12 @@ from router_maestro.providers.copilot_support.catalog import (
 from router_maestro.providers.copilot_support.chat_codec import CopilotChatCodec
 from router_maestro.providers.copilot_support.responses_codec import CopilotResponsesCodec
 from router_maestro.providers.copilot_support.transport import CopilotTransport
-from router_maestro.providers.outbound_contract import OutboundContract
+from router_maestro.providers.outbound_contract import OutboundContract, ReasoningResolution
 from router_maestro.routing.capabilities import Operation, ProviderCapabilities
 from router_maestro.utils import get_logger
 from router_maestro.utils.reasoning import (
     budget_to_effort,
+    downgrade_for_upstream,
     pick_closest_effort,
 )
 
@@ -149,84 +150,20 @@ def apply_copilot_chat_reasoning(
 ) -> None:
     """Inject reasoning fields into a Copilot ``/chat/completions`` payload.
 
-    When ``catalog_effort_values`` is provided (from the model's
-    ``capabilities.supports.reasoning_effort`` advertisement), it is the
-    authoritative allowlist — we map the desired effort onto the catalog's
-    enum and send it. This means we automatically pick up new tiers (e.g.
-    if Copilot opens ``high`` on opus-4.7) without a code change.
-
-    When the catalog says nothing (``None``), we fall back to the hardcoded
-    per-family heuristic:
-
-    * ``claude-opus-4.6+`` / ``claude-sonnet-4.6`` accept ``low``/``medium``/``high``
-      (and tolerate ``max`` being downgraded into the same set).
-    * Older Claudes (4.5 / sonnet-4 / haiku) take no reasoning field.
-    * ``gpt-5*`` / ``o1`` / ``o3`` / ``o4`` accept ``low``/``medium``/``high``/``xhigh``
-      (``max`` is downgraded to ``xhigh``).
-    * ``gpt-4*``, ``gemini-*`` take no reasoning field.
-
-    For ``gpt-5.4*`` the gateway also requires ``max_completion_tokens`` instead
-    of ``max_tokens``; this function performs that rewrite when present.
+    Thin adapter over ``CopilotOutboundContract.resolve_reasoning`` (the single
+    source of Copilot's effort rule). Applies the resolved effort and the gpt-5.4
+    ``max_tokens`` -> ``max_completion_tokens`` rewrite to ``payload`` in place.
     """
-    bare = model.split("/", 1)[1] if "/" in model else model
-    bare_lower = bare.lower()
-
-    known_reasoning_support = _known_reasoning_support(model)
-
-    def unsupported_reasoning() -> NoReturn:
-        parameter = "reasoning_effort" if reasoning_effort is not None else "thinking_budget"
-        raise RequestOptionError(
-            "GitHub Copilot does not support the requested reasoning option for this model",
-            provider="github-copilot",
-            model=model,
-            parameter=parameter,
-        )
-
-    # Catalog-driven path: trust whatever Copilot advertises.
-    if catalog_effort_values is not None:
-        if not catalog_effort_values:
-            if reasoning_effort is not None or thinking_budget is not None:
-                unsupported_reasoning()
-        else:
-            desired = reasoning_effort or budget_to_effort(thinking_budget)
-            if desired is None and thinking_budget is not None:
-                unsupported_reasoning()
-            if desired is not None:
-                picked = pick_closest_effort(desired, catalog_effort_values)
-                if picked is None:
-                    raise RequestOptionError(
-                        "GitHub Copilot has no reasoning tier at or below the requested tier",
-                        provider="github-copilot",
-                        model=model,
-                        parameter=(
-                            "reasoning_effort"
-                            if reasoning_effort is not None
-                            else "thinking_budget"
-                        ),
-                    )
-                payload["reasoning_effort"] = picked
-        if bare_lower.startswith("gpt-5.4") and "max_tokens" in payload:
-            payload["max_completion_tokens"] = payload.pop("max_tokens")
-        return
-
-    # Hardcoded fallback when the catalog hasn't been fetched yet.
-    if known_reasoning_support is False:
-        if reasoning_effort is not None or thinking_budget is not None:
-            unsupported_reasoning()
-    elif known_reasoning_support is True or known_reasoning_support is None:
-        effort = reasoning_effort or budget_to_effort(thinking_budget)
-        if bare_lower.startswith("claude-") and effort in ("xhigh", "max"):
-            effort = "high"
-        elif effort == "max":
-            effort = "xhigh"
-        elif known_reasoning_support is None and effort == "xhigh":
-            effort = "high"
-        if effort is None and thinking_budget is not None:
-            unsupported_reasoning()
-        if effort in ("minimal", "low", "medium", "high", "xhigh"):
-            payload["reasoning_effort"] = effort
-
-    if bare_lower.startswith("gpt-5.4") and "max_tokens" in payload:
+    resolution = CopilotOutboundContract().resolve_reasoning(
+        model=model,
+        reasoning_effort=reasoning_effort,
+        thinking_budget=thinking_budget,
+        catalog_effort_values=catalog_effort_values,
+        operation=Operation.CHAT,
+    )
+    if resolution.effort is not None:
+        payload["reasoning_effort"] = resolution.effort
+    if resolution.rewrite_max_tokens_to_completion and "max_tokens" in payload:
         payload["max_completion_tokens"] = payload.pop("max_tokens")
 
 
@@ -290,6 +227,153 @@ class CopilotOutboundContract(OutboundContract):
         if operation is Operation.NATIVE_ANTHROPIC:
             return _COPILOT_NATIVE_ANTHROPIC_FORWARD_FIELDS
         return None
+
+    def resolve_reasoning(
+        self,
+        *,
+        model: str,
+        reasoning_effort: str | None,
+        thinking_budget: int | None,
+        catalog_effort_values: list[str] | None,
+        operation: Operation,
+    ) -> ReasoningResolution:
+        """The single Copilot effort rule: catalog-first, family-fallback.
+
+        Reproduces the previously-scattered logic in ``apply_copilot_chat_reasoning``
+        (chat) and ``responses_codec.build_payload`` (responses). The two operations
+        differ only in the cold-catalog path and the gpt-5.4 max_tokens rewrite, both
+        preserved here.
+        """
+        if operation in (Operation.RESPONSES, Operation.RESPONSES_STREAM):
+            return self._resolve_reasoning_responses(
+                model=model,
+                reasoning_effort=reasoning_effort,
+                catalog_effort_values=catalog_effort_values,
+            )
+        return self._resolve_reasoning_chat(
+            model=model,
+            reasoning_effort=reasoning_effort,
+            thinking_budget=thinking_budget,
+            catalog_effort_values=catalog_effort_values,
+        )
+
+    @staticmethod
+    def _resolve_reasoning_chat(
+        *,
+        model: str,
+        reasoning_effort: str | None,
+        thinking_budget: int | None,
+        catalog_effort_values: list[str] | None,
+    ) -> ReasoningResolution:
+        bare_lower = (model.split("/", 1)[1] if "/" in model else model).lower()
+        rewrite = bare_lower.startswith("gpt-5.4")
+        known_reasoning_support = _known_reasoning_support(model)
+
+        def unsupported_reasoning() -> NoReturn:
+            parameter = "reasoning_effort" if reasoning_effort is not None else "thinking_budget"
+            raise RequestOptionError(
+                "GitHub Copilot does not support the requested reasoning option for this model",
+                provider="github-copilot",
+                model=model,
+                parameter=parameter,
+            )
+
+        # Catalog-driven path: trust whatever Copilot advertises.
+        if catalog_effort_values is not None:
+            if not catalog_effort_values:
+                if reasoning_effort is not None or thinking_budget is not None:
+                    unsupported_reasoning()
+                return ReasoningResolution(effort=None, rewrite_max_tokens_to_completion=rewrite)
+            desired = reasoning_effort or budget_to_effort(thinking_budget)
+            if desired is None and thinking_budget is not None:
+                unsupported_reasoning()
+            if desired is None:
+                return ReasoningResolution(effort=None, rewrite_max_tokens_to_completion=rewrite)
+            picked = pick_closest_effort(desired, catalog_effort_values)
+            if picked is None:
+                raise RequestOptionError(
+                    "GitHub Copilot has no reasoning tier at or below the requested tier",
+                    provider="github-copilot",
+                    model=model,
+                    parameter=(
+                        "reasoning_effort" if reasoning_effort is not None else "thinking_budget"
+                    ),
+                )
+            return ReasoningResolution(effort=picked, rewrite_max_tokens_to_completion=rewrite)
+
+        # Hardcoded fallback when the catalog hasn't been fetched yet.
+        if known_reasoning_support is False:
+            if reasoning_effort is not None or thinking_budget is not None:
+                unsupported_reasoning()
+            return ReasoningResolution(effort=None, rewrite_max_tokens_to_completion=rewrite)
+
+        effort = reasoning_effort or budget_to_effort(thinking_budget)
+        if bare_lower.startswith("claude-") and effort in ("xhigh", "max"):
+            effort = "high"
+        elif effort == "max":
+            effort = "xhigh"
+        elif known_reasoning_support is None and effort == "xhigh":
+            effort = "high"
+        if effort is None and thinking_budget is not None:
+            unsupported_reasoning()
+        if effort in ("minimal", "low", "medium", "high", "xhigh"):
+            return ReasoningResolution(effort=effort, rewrite_max_tokens_to_completion=rewrite)
+        return ReasoningResolution(effort=None, rewrite_max_tokens_to_completion=rewrite)
+
+    @staticmethod
+    def _resolve_reasoning_responses(
+        *,
+        model: str,
+        reasoning_effort: str | None,
+        catalog_effort_values: list[str] | None,
+    ) -> ReasoningResolution:
+        known_reasoning_support = _known_reasoning_support(model)
+        if catalog_effort_values is not None:
+            if not catalog_effort_values:
+                if reasoning_effort is not None:
+                    raise RequestOptionError(
+                        "GitHub Copilot does not support reasoning for this model",
+                        provider="github-copilot",
+                        model=model,
+                        parameter="reasoning_effort",
+                    )
+                return ReasoningResolution(effort=None)
+            if reasoning_effort is None:
+                return ReasoningResolution(effort=None)
+            upstream_effort = pick_closest_effort(reasoning_effort, catalog_effort_values)
+            if upstream_effort is None:
+                raise RequestOptionError(
+                    "GitHub Copilot has no reasoning tier at or below the requested tier",
+                    provider="github-copilot",
+                    model=model,
+                    parameter="reasoning_effort",
+                )
+            return ReasoningResolution(effort=upstream_effort)
+
+        if reasoning_effort is not None and known_reasoning_support is False:
+            raise RequestOptionError(
+                "GitHub Copilot does not support reasoning for this model",
+                provider="github-copilot",
+                model=model,
+                parameter="reasoning_effort",
+            )
+        upstream_effort = (
+            reasoning_effort
+            if known_reasoning_support is True
+            else downgrade_for_upstream(reasoning_effort)
+        )
+        if (
+            known_reasoning_support is None
+            and reasoning_effort in ("xhigh", "max")
+            and upstream_effort == "high"
+        ):
+            logger.warning(
+                "Copilot Responses catalog cold for %s; "
+                "downgrading reasoning_effort=%s to high as a precaution",
+                model,
+                reasoning_effort,
+            )
+        return ReasoningResolution(effort=upstream_effort)
 
 
 class CopilotProvider(BaseProvider):

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -375,6 +375,51 @@ class CopilotOutboundContract(OutboundContract):
             )
         return ReasoningResolution(effort=upstream_effort)
 
+    _RESPONSES_UNSUPPORTED_TOOL_TYPES = frozenset(
+        {"web_search", "web_search_preview", "code_interpreter"}
+    )
+
+    def filter_tools(
+        self,
+        tools: list[dict] | None,
+        *,
+        operation: Operation,
+        model: str | None = None,
+    ) -> list[dict] | None:
+        """Drop/reject tool types Copilot Responses cannot express."""
+        if not tools:
+            return None
+        validated = []
+        for tool in tools:
+            tool_type = tool.get("type", "function")
+            if tool_type == "function":
+                validated.append(tool)
+            elif tool_type == "namespace":
+                inner = tool.get("tools")
+                if isinstance(inner, list) and inner:
+                    validated.append(tool)
+                else:
+                    raise RequestOptionError(
+                        "GitHub Copilot requires namespace tools to contain a non-empty tools list",
+                        provider="github-copilot",
+                        model=model,
+                        parameter="tools",
+                    )
+            elif tool_type not in self._RESPONSES_UNSUPPORTED_TOOL_TYPES:
+                validated.append(tool)
+            else:
+                raise RequestOptionError(
+                    f"GitHub Copilot does not support Responses tool type '{tool_type}'",
+                    provider="github-copilot",
+                    model=model,
+                    parameter="tools",
+                )
+        return validated or None
+
+    def allows_temperature(self, operation: Operation) -> bool:
+        """Copilot Responses rejects explicit temperature; Chat forwards it."""
+        return operation not in (Operation.RESPONSES, Operation.RESPONSES_STREAM)
+
 
 class CopilotProvider(BaseProvider):
     """GitHub Copilot provider."""
@@ -1062,15 +1107,12 @@ class CopilotProvider(BaseProvider):
     ) -> list[dict] | None:
         """Validate and preserve tools supported by the Copilot Responses API.
 
-        Args:
-            tools: List of tool definitions
-
-        Returns:
-            Validated list of tools, or None if empty
+        Delegates to the provider's outbound contract (the single source of the
+        Copilot tool-filter rule).
         """
-        return self._responses_codec.filter_unsupported_tools(
+        return self.outbound_contract.filter_tools(
             tools,
-            provider_name=self.name,
+            operation=Operation.RESPONSES,
             model=model,
         )
 
@@ -1089,6 +1131,8 @@ class CopilotProvider(BaseProvider):
             validate_extensions=self._validate_provider_extensions,
             catalog_effort_values=self._catalog_effort_values(request.model),
             resolve_reasoning=self.outbound_contract.resolve_reasoning,
+            allows_temperature=self.outbound_contract.allows_temperature,
+            filter_tools=self.outbound_contract.filter_tools,
         )
 
     def validate_responses_request(self, request: ResponsesRequest) -> None:

--- a/src/router_maestro/providers/copilot_support/responses_codec.py
+++ b/src/router_maestro/providers/copilot_support/responses_codec.py
@@ -19,7 +19,6 @@ from router_maestro.providers.base import (
     resolve_terminal_outcome,
 )
 from router_maestro.utils import get_logger
-from router_maestro.utils.reasoning import downgrade_for_upstream, pick_closest_effort
 
 logger = get_logger("providers.copilot.responses_codec")
 
@@ -105,7 +104,7 @@ class CopilotResponsesCodec:
         provider_name: str,
         validate_extensions: Callable[[ResponsesRequest], None],
         catalog_effort_values: list[str] | None,
-        known_reasoning_support: bool | None,
+        resolve_reasoning: Callable[..., Any],
     ) -> dict:
         validate_extensions(request)
         if request.temperature is not None:
@@ -143,56 +142,17 @@ class CopilotResponsesCodec:
             if value is not None:
                 payload[key] = value
 
-        if catalog_effort_values is not None:
-            if not catalog_effort_values:
-                if request.reasoning_effort is not None:
-                    raise RequestOptionError(
-                        "GitHub Copilot does not support reasoning for this model",
-                        provider=provider_name,
-                        model=request.model,
-                        parameter="reasoning_effort",
-                    )
-                upstream_effort = None
-            elif request.reasoning_effort is None:
-                upstream_effort = None
-            else:
-                upstream_effort = pick_closest_effort(
-                    request.reasoning_effort,
-                    catalog_effort_values,
-                )
-                if upstream_effort is None:
-                    raise RequestOptionError(
-                        "GitHub Copilot has no reasoning tier at or below the requested tier",
-                        provider=provider_name,
-                        model=request.model,
-                        parameter="reasoning_effort",
-                    )
-        else:
-            if request.reasoning_effort is not None and known_reasoning_support is False:
-                raise RequestOptionError(
-                    "GitHub Copilot does not support reasoning for this model",
-                    provider=provider_name,
-                    model=request.model,
-                    parameter="reasoning_effort",
-                )
-            upstream_effort = (
-                request.reasoning_effort
-                if known_reasoning_support is True
-                else downgrade_for_upstream(request.reasoning_effort)
-            )
-            if (
-                known_reasoning_support is None
-                and request.reasoning_effort in ("xhigh", "max")
-                and upstream_effort == "high"
-            ):
-                logger.warning(
-                    "Copilot Responses catalog cold for %s; "
-                    "downgrading reasoning_effort=%s to high as a precaution",
-                    request.model,
-                    request.reasoning_effort,
-                )
-        if upstream_effort is not None:
-            payload["reasoning"] = {"effort": upstream_effort, "summary": "auto"}
+        from router_maestro.routing.capabilities import Operation
+
+        resolution = resolve_reasoning(
+            model=request.model,
+            reasoning_effort=request.reasoning_effort,
+            thinking_budget=None,
+            catalog_effort_values=catalog_effort_values,
+            operation=Operation.RESPONSES,
+        )
+        if resolution.effort is not None:
+            payload["reasoning"] = {"effort": resolution.effort, "summary": "auto"}
             payload["include"] = ["reasoning.encrypted_content"]
         return payload
 

--- a/src/router_maestro/providers/copilot_support/responses_codec.py
+++ b/src/router_maestro/providers/copilot_support/responses_codec.py
@@ -41,8 +41,6 @@ class CopilotResponsesCodec:
 
     name = "github-copilot"
 
-    unsupported_tool_types = frozenset({"web_search", "web_search_preview", "code_interpreter"})
-
     @staticmethod
     def input_has_vision(value: Any, depth: int = 0) -> bool:
         if depth > 32 or value is None:

--- a/src/router_maestro/providers/copilot_support/responses_codec.py
+++ b/src/router_maestro/providers/copilot_support/responses_codec.py
@@ -61,42 +61,6 @@ class CopilotResponsesCodec:
             return any(CopilotResponsesCodec.input_has_vision(item, depth + 1) for item in content)
         return False
 
-    def filter_unsupported_tools(
-        self,
-        tools: list[dict] | None,
-        *,
-        provider_name: str,
-        model: str | None = None,
-    ) -> list[dict] | None:
-        if not tools:
-            return None
-        validated = []
-        for tool in tools:
-            tool_type = tool.get("type", "function")
-            if tool_type == "function":
-                validated.append(tool)
-            elif tool_type == "namespace":
-                inner = tool.get("tools")
-                if isinstance(inner, list) and inner:
-                    validated.append(tool)
-                else:
-                    raise RequestOptionError(
-                        "GitHub Copilot requires namespace tools to contain a non-empty tools list",
-                        provider=provider_name,
-                        model=model,
-                        parameter="tools",
-                    )
-            elif tool_type not in self.unsupported_tool_types:
-                validated.append(tool)
-            else:
-                raise RequestOptionError(
-                    f"GitHub Copilot does not support Responses tool type '{tool_type}'",
-                    provider=provider_name,
-                    model=model,
-                    parameter="tools",
-                )
-        return validated or None
-
     def build_payload(
         self,
         request: ResponsesRequest,
@@ -105,9 +69,13 @@ class CopilotResponsesCodec:
         validate_extensions: Callable[[ResponsesRequest], None],
         catalog_effort_values: list[str] | None,
         resolve_reasoning: Callable[..., Any],
+        allows_temperature: Callable[..., bool],
+        filter_tools: Callable[..., list[dict] | None],
     ) -> dict:
+        from router_maestro.routing.capabilities import Operation
+
         validate_extensions(request)
-        if request.temperature is not None:
+        if request.temperature is not None and not allows_temperature(Operation.RESPONSES):
             raise RequestOptionError(
                 "GitHub Copilot Responses does not support request option 'temperature'",
                 provider=provider_name,
@@ -123,9 +91,9 @@ class CopilotResponsesCodec:
             payload["instructions"] = request.instructions
         if request.max_output_tokens:
             payload["max_output_tokens"] = request.max_output_tokens
-        filtered_tools = self.filter_unsupported_tools(
+        filtered_tools = filter_tools(
             request.tools,
-            provider_name=provider_name,
+            operation=Operation.RESPONSES,
             model=request.model,
         )
         if filtered_tools:
@@ -141,8 +109,6 @@ class CopilotResponsesCodec:
         }.items():
             if value is not None:
                 payload[key] = value
-
-        from router_maestro.routing.capabilities import Operation
 
         resolution = resolve_reasoning(
             model=request.model,

--- a/src/router_maestro/providers/outbound_contract.py
+++ b/src/router_maestro/providers/outbound_contract.py
@@ -8,8 +8,22 @@ currently scattered across each provider's ``_build_payload``.
 """
 
 from abc import ABC
+from dataclasses import dataclass
 
 from router_maestro.routing.capabilities import Operation
+
+
+@dataclass(frozen=True, slots=True)
+class ReasoningResolution:
+    """Outcome of a provider's reasoning-effort resolution.
+
+    ``effort`` is the upstream effort to send (``None`` to omit reasoning).
+    ``rewrite_max_tokens_to_completion`` requests the Copilot gpt-5.4 payload-key
+    rewrite (``max_tokens`` -> ``max_completion_tokens``).
+    """
+
+    effort: str | None
+    rewrite_max_tokens_to_completion: bool = False
 
 
 class OutboundContract(ABC):
@@ -22,6 +36,22 @@ class OutboundContract(ABC):
         rejects unknown top-level fields returns an explicit allowlist.
         """
         return None
+
+    def resolve_reasoning(
+        self,
+        *,
+        model: str,
+        reasoning_effort: str | None,
+        thinking_budget: int | None,
+        catalog_effort_values: list[str] | None,
+        operation: Operation,
+    ) -> ReasoningResolution:
+        """Resolve the upstream reasoning effort for this provider/operation.
+
+        Default: forward the requested effort unchanged with no rewrite.
+        Providers whose upstream downgrades or rejects tiers override this.
+        """
+        return ReasoningResolution(effort=reasoning_effort)
 
 
 class PermissiveOutboundContract(OutboundContract):

--- a/src/router_maestro/providers/outbound_contract.py
+++ b/src/router_maestro/providers/outbound_contract.py
@@ -53,6 +53,20 @@ class OutboundContract(ABC):
         """
         return ReasoningResolution(effort=reasoning_effort)
 
+    def filter_tools(
+        self,
+        tools: list[dict] | None,
+        *,
+        operation: Operation,
+        model: str | None = None,
+    ) -> list[dict] | None:
+        """Filter tools this upstream cannot express. Default: pass through."""
+        return tools
+
+    def allows_temperature(self, operation: Operation) -> bool:
+        """Whether the upstream accepts explicit ``temperature``. Default: yes."""
+        return True
+
 
 class PermissiveOutboundContract(OutboundContract):
     """Default contract: forward everything.

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -206,7 +206,15 @@ def _resolve_native_effort(
     provider: str | None = None,
     model: str | None = None,
 ) -> str:
-    """Resolve a native effort exactly or downward, preserving unknown catalogs."""
+    """Resolve a native effort exactly or downward, preserving unknown catalogs.
+
+    The native passthrough resolves ``output_config.effort`` with its own
+    catalog-or-passthrough rule (distinct error surface and no family fallback),
+    so it is intentionally NOT routed through
+    ``CopilotOutboundContract.resolve_reasoning`` (the chat/responses orchestration).
+    Both share the ``pick_closest_effort`` primitive as the single source of the
+    downgrade math.
+    """
     if allowed is None:
         return effort
     mapped_effort = pick_closest_effort(effort, list(allowed))

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -43,3 +43,46 @@ def test_copilot_contract_is_permissive_for_other_operations():
 
     contract = CopilotProvider().outbound_contract
     assert contract.forwardable_fields(Operation.CHAT) is None
+
+
+# --- Round 2: reasoning resolution ---
+
+
+def _copilot_contract():
+    from router_maestro.providers.copilot import CopilotProvider
+
+    return CopilotProvider().outbound_contract
+
+
+def test_copilot_resolve_reasoning_catalog_warm_picks_closest():
+    r = _copilot_contract().resolve_reasoning(
+        model="github-copilot/claude-sonnet-4.6",
+        reasoning_effort="max",
+        thinking_budget=None,
+        catalog_effort_values=["low", "medium", "high"],
+        operation=Operation.CHAT,
+    )
+    assert r.effort == "high"  # pick_closest_effort(max, [low,medium,high])
+
+
+def test_copilot_resolve_reasoning_cold_claude_downgrades_xhigh():
+    r = _copilot_contract().resolve_reasoning(
+        model="github-copilot/claude-opus-4.8",
+        reasoning_effort="xhigh",
+        thinking_budget=None,
+        catalog_effort_values=None,  # cold
+        operation=Operation.CHAT,
+    )
+    assert r.effort == "high"
+
+
+def test_copilot_resolve_reasoning_gpt54_rewrites_max_tokens_flag():
+    r = _copilot_contract().resolve_reasoning(
+        model="github-copilot/gpt-5.4",
+        reasoning_effort="high",
+        thinking_budget=None,
+        catalog_effort_values=["low", "medium", "high"],
+        operation=Operation.CHAT,
+    )
+    assert r.rewrite_max_tokens_to_completion is True
+    assert r.effort == "high"

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -125,3 +125,57 @@ def test_copilot_resolve_reasoning_responses_unsupported_model_rejects():
             catalog_effort_values=None,
             operation=Operation.RESPONSES,
         )
+
+
+# --- Round 2: tool filtering + temperature verdict ---
+
+
+def test_copilot_filter_tools_keeps_function_rejects_web_search():
+    import pytest
+
+    from router_maestro.providers import RequestOptionError
+
+    c = _copilot_contract()
+    # A function tool and an unknown/other type are kept; a known-unsupported
+    # type raises (behavior preserved from filter_unsupported_tools).
+    kept = c.filter_tools(
+        [{"type": "function", "name": "echo"}, {"type": "custom_future"}],
+        operation=Operation.RESPONSES,
+        model="github-copilot/gpt-5.5",
+    )
+    assert kept == [{"type": "function", "name": "echo"}, {"type": "custom_future"}]
+    with pytest.raises(RequestOptionError):
+        c.filter_tools(
+            [{"type": "web_search"}],
+            operation=Operation.RESPONSES,
+            model="github-copilot/gpt-5.5",
+        )
+
+
+def test_copilot_filter_tools_rejects_empty_namespace():
+    import pytest
+
+    from router_maestro.providers import RequestOptionError
+
+    c = _copilot_contract()
+    with pytest.raises(RequestOptionError):
+        c.filter_tools(
+            [{"type": "namespace", "tools": []}],
+            operation=Operation.RESPONSES,
+            model="github-copilot/gpt-5.5",
+        )
+
+
+def test_copilot_allows_temperature_chat_but_not_responses():
+    c = _copilot_contract()
+    assert c.allows_temperature(Operation.CHAT) is True
+    assert c.allows_temperature(Operation.RESPONSES) is False
+
+
+def test_permissive_defaults_for_tools_and_temperature():
+    from router_maestro.providers.outbound_contract import PermissiveOutboundContract
+
+    c = PermissiveOutboundContract()
+    tools = [{"type": "anything"}]
+    assert c.filter_tools(tools, operation=Operation.CHAT, model="m") == tools
+    assert c.allows_temperature(Operation.RESPONSES) is True

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -86,3 +86,42 @@ def test_copilot_resolve_reasoning_gpt54_rewrites_max_tokens_flag():
     )
     assert r.rewrite_max_tokens_to_completion is True
     assert r.effort == "high"
+
+
+def test_copilot_resolve_reasoning_responses_catalog_warm():
+    r = _copilot_contract().resolve_reasoning(
+        model="github-copilot/gpt-5.5",
+        reasoning_effort="max",
+        thinking_budget=None,
+        catalog_effort_values=["low", "medium", "high", "xhigh"],
+        operation=Operation.RESPONSES,
+    )
+    assert r.effort == "xhigh"  # pick_closest_effort(max, [...xhigh])
+    assert r.rewrite_max_tokens_to_completion is False  # responses never rewrites
+
+
+def test_copilot_resolve_reasoning_responses_cold_downgrades_via_upstream():
+    r = _copilot_contract().resolve_reasoning(
+        model="github-copilot/gpt-5.5",
+        reasoning_effort="max",
+        thinking_budget=None,
+        catalog_effort_values=None,  # cold; known_reasoning_support True for gpt-5
+        operation=Operation.RESPONSES,
+    )
+    # gpt-5 known-supported: cold path forwards verbatim (known_reasoning_support is True)
+    assert r.effort == "max"
+
+
+def test_copilot_resolve_reasoning_responses_unsupported_model_rejects():
+    import pytest
+
+    from router_maestro.providers import RequestOptionError
+
+    with pytest.raises(RequestOptionError):
+        _copilot_contract().resolve_reasoning(
+            model="github-copilot/gpt-4o",  # known_reasoning_support False
+            reasoning_effort="high",
+            thinking_budget=None,
+            catalog_effort_values=None,
+            operation=Operation.RESPONSES,
+        )


### PR DESCRIPTION
Round 2 of 2 (Round 1 shipped as v0.7.0). Consolidates GitHub Copilot's scattered outbound value policy into `CopilotOutboundContract`, so one provider = one contract object. **Behavior-preserving.**

## What moved into the contract
- **Reasoning-effort orchestration** — the catalog-first / family-fallback rule that had **three copies** (chat `apply_copilot_chat_reasoning`, responses-codec inline branch, and referenced by the native path) is now one method `resolve_reasoning(model, reasoning_effort, thinking_budget, catalog_effort_values, operation)` returning a `ReasoningResolution`. `apply_copilot_chat_reasoning` is now a thin adapter; the responses codec calls the contract via its existing injected-callback seam.
- **Tool filtering** → `CopilotOutboundContract.filter_tools`.
- **`temperature` verdict** (Chat forwards, Responses rejects) → `allows_temperature(operation)`.
- Dead codec `filter_unsupported_tools` / `unsupported_tool_types` removed.

## Deliberately NOT forced
- **OpenAI / Anthropic providers** keep their own `_build_payload` rules (genuinely different — OpenAI has no catalog, Anthropic forwards effort verbatim). They inherit the permissive Round-2 defaults. Contracts are per-provider and need not agree.
- **Native-Anthropic effort** (`anthropic_beta._resolve_native_effort`) stays on the shared `pick_closest_effort` primitive — it targets `output_config` with a distinct error surface; forcing it through `resolve_reasoning` would be lossy. A cross-reference comment marks the shared primitive as the single source of the downgrade math.

## Architecture review (per requirement: one contract per provider, no cross-provider sharing)
- Contracts: `OutboundContract` (base) + `PermissiveOutboundContract` (default) + `CopilotOutboundContract`. Copilot is the only provider needing a custom one.
- OpenAI/Anthropic providers reference NO contract (inherit the default). No provider imports another's contract. Every outbound-policy consumer reaches `provider.outbound_contract.*`.

## Verification
- Full unit suite: **3562 passed**, ruff clean, **zero existing-assertion edits** (behavior-preservation proof).
- New deterministic controlled tests pin the unified effort downgrade (`max`→catalog `high`) on both chat and responses wire payloads.
- **Full `make integration-test` matrix: 92 passed, 3 skipped, 0 failed** — zero reconciliations needed (unlike Round 1), confirming the refactor is behavior-neutral.

Codex review skipped (Codex currently unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)