### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.7.1 (2026-07-15)
+
+### Changes
+
+- **Provider-bound option policy (round 2).** GitHub Copilot's outbound value
+  policy — reasoning-effort orchestration (previously duplicated across the chat
+  and responses paths), tool filtering, and the operation-specific `temperature`
+  verdict — is consolidated into a single `CopilotOutboundContract`. One provider
+  now has one contract object as the sole authority for what its upstream
+  accepts. OpenAI and Anthropic providers keep their own distinct rules. This is
+  a behavior-preserving refactor: the full live integration matrix passes with no
+  changes to outbound wire payloads.
+
 ## v0.7.0 (2026-07-15)
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.7.0"
+version = "0.7.1"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release v0.7.1 — provider-bound option policy round 2 (#140).

Bumps `pyproject.toml`, `__init__.py`, `uv.lock` to 0.7.1 and adds the CHANGELOG `v0.7.1` section. Behavior-preserving refactor (patch bump).

Verified: full unit suite (3562) + full `make integration-test` matrix (92 passed, 0 failed, zero reconciliations). See #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)