### PR TITLE
refactor: extract per-client config generation into ClientConfig abstraction

### DIFF
--- a/src/router_maestro/cli/client_configs/__init__.py
+++ b/src/router_maestro/cli/client_configs/__init__.py
@@ -1,0 +1,21 @@
+"""Per-client config generation for `router-maestro config`."""
+
+from router_maestro.cli.client_configs.base import (
+    ClientConfig,
+    GenerateContext,
+    IdStyle,
+)
+from router_maestro.cli.client_configs.registry import (
+    CLIENT_CONFIGS,
+    get_client,
+    list_clients,
+)
+
+__all__ = [
+    "CLIENT_CONFIGS",
+    "ClientConfig",
+    "GenerateContext",
+    "IdStyle",
+    "get_client",
+    "list_clients",
+]

--- a/src/router_maestro/cli/client_configs/base.py
+++ b/src/router_maestro/cli/client_configs/base.py
@@ -1,0 +1,278 @@
+"""Shared foundation for per-client config generation.
+
+Each external client (Claude Code, Codex, Gemini CLI) subclasses
+:class:`ClientConfig` and owns its *entire* generation flow via the template
+method :meth:`ClientConfig.generate`. This module holds the pieces every client
+shares: model fetch/display/selection, the backup prompt, the level picker, the
+base-URL/auth resolvers, and the model-id-style resolution.
+
+Dependency rule: ``cli/config.py`` imports from this package; nothing in this
+package imports ``cli/config.py`` (one-way, no circular import).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
+
+from router_maestro.cli.client import ServerNotRunningError, get_admin_client
+from router_maestro.config.server import get_current_context_api_key
+from router_maestro.routing.model_ref import qualify_model_id
+
+console = Console()
+
+
+class IdStyle(StrEnum):
+    """How a selected model is spelled in the generated config.
+
+    ``QUALIFIED`` writes the internal ``provider/upstream-id`` (the default,
+    unambiguous across providers). ``OFFICIAL`` writes the vendor's native id
+    (recognized directly by the client/TUI). Official conversion is wired up in
+    Part B; Part A always resolves to ``QUALIFIED``.
+    """
+
+    QUALIFIED = "qualified"
+    OFFICIAL = "official"
+
+
+@dataclass
+class GenerateContext:
+    """Everything a client's ``write``/``render_success`` needs beyond paths.
+
+    ``extras`` carries client-specific prompt results (Claude Code uses
+    ``auto_compact_window`` and ``use_beta_endpoint``).
+    """
+
+    id_style: IdStyle
+    selected_dicts: list[dict | None]
+    extras: dict = field(default_factory=dict)
+
+
+def _backup_if_exists(path: Path) -> None:
+    """Prompt to backup an existing config file before overwriting."""
+    if not path.exists():
+        return
+    console.print(f"\n[yellow]{path.name} already exists at {path}[/yellow]")
+    if Confirm.ask("Backup existing file?", default=True):
+        backup_path = path.with_suffix(
+            f"{path.suffix}.backup.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        )
+        shutil.copy(path, backup_path)
+        console.print(f"[green]Backed up to {backup_path}[/green]")
+
+
+def _fetch_models() -> list[dict]:
+    """Fetch models from the server.
+
+    Exits the CLI if the server is unreachable or no models are available.
+    """
+    try:
+        client = get_admin_client()
+        models = asyncio.run(client.list_models())
+    except ServerNotRunningError as e:
+        console.print(f"[red]{e}[/red]")
+        console.print("[dim]Tip: Start router-maestro server first.[/dim]")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not models:
+        console.print("[red]No models available. Please authenticate first.[/red]")
+        raise typer.Exit(1)
+
+    return models
+
+
+def _display_models(models: list[dict]) -> None:
+    """Display models in a Rich table."""
+    console.print("\n[bold]Available models:[/bold]")
+    table = Table()
+    table.add_column("#", style="dim")
+    table.add_column("Model Key", style="green")
+    table.add_column("Name", style="white")
+    for i, model in enumerate(models, 1):
+        key = model.get("display_key", _model_key(model))
+        table.add_row(str(i), key, model["name"])
+    console.print(table)
+
+
+def _fetch_and_display_models() -> list[dict]:
+    """Fetch models from the server and display them in a table."""
+    models = _fetch_models()
+    _display_models(models)
+    return models
+
+
+def _select_model(models: list[dict], prompt: str, default: str = "0") -> str:
+    """Prompt the user to select a model from the list.
+
+    Returns the ``provider/id`` model key, or ``"router-maestro"`` for
+    auto-routing (choice ``0``).
+    """
+    selected = _select_model_dict(models, prompt, default=default)
+    return _model_key(selected) if selected else "router-maestro"
+
+
+def _select_model_dict(models: list[dict], prompt: str, default: str = "0") -> dict | None:
+    """Prompt the user to select a model and return the model dict.
+
+    Returns ``None`` for the auto-routing choice (``0`` or invalid input).
+    """
+    choice = Prompt.ask(prompt, default=default)
+    if choice != "0" and choice.isdigit():
+        idx = int(choice) - 1
+        if 0 <= idx < len(models):
+            return models[idx]
+        console.print(f"[yellow]Invalid selection '{choice}', using auto-routing.[/yellow]")
+    return None
+
+
+def _model_key(model: dict) -> str:
+    """Resolve the wire model key for a model dict from the CLI's model list."""
+    if "wire_key" in model:
+        return model["wire_key"]
+    if "custom_key" in model:
+        return model["custom_key"]
+    return qualify_model_id(model["provider"], model["id"])
+
+
+def _bare_upstream_model_id(model: dict) -> str:
+    """Return the upstream ID from qualified server or legacy bare model entries."""
+    provider = model.get("provider", "")
+    model_id = model.get("id", "")
+    prefix = f"{provider}/"
+    return model_id[len(prefix) :] if provider and model_id.startswith(prefix) else model_id
+
+
+def _upstream_context_window(model: dict) -> int | None:
+    """Compute the displayed upstream context window for a Copilot model.
+
+    Mirrors what VS Code's Copilot model picker shows: prompt + output, which
+    matches the catalog's advertised window in most cases. Falls back to the
+    server-reported ``max_context_window_tokens`` if either component is
+    missing.
+    """
+    prompt = model.get("max_prompt_tokens")
+    output = model.get("max_output_tokens")
+    if isinstance(prompt, int) and prompt > 0 and isinstance(output, int) and output > 0:
+        return prompt + output
+    ctx = model.get("max_context_window_tokens")
+    if isinstance(ctx, int) and ctx > 0:
+        return ctx
+    return None
+
+
+class ClientConfig(ABC):
+    """A supported client whose config Router-Maestro can generate.
+
+    Subclasses declare their identity (``key``/``display_name``/``description``),
+    their file paths and level menu, and how they write/announce config. The
+    base owns the whole :meth:`generate` orchestration and the shared prompts.
+    """
+
+    #: Registry key and ``config <key>`` subcommand name (e.g. ``"codex"``).
+    key: str
+    #: Human name shown in the interactive tool picker.
+    display_name: str
+    #: One-line description shown in the interactive tool picker.
+    description: str
+
+    # ---- per-client structure (abstract) -------------------------------
+
+    @abstractmethod
+    def paths(self) -> dict[str, Path]:
+        """Return ``{"user": Path, "project": Path}`` config targets."""
+
+    @abstractmethod
+    def level_menu(self) -> tuple[str, str]:
+        """Return the ``(user_label, project_label)`` shown in Step 1."""
+
+    @abstractmethod
+    def write(self, *, level: str, path: Path, models: list[str], ctx: GenerateContext) -> None:
+        """Persist the generated config to ``path``."""
+
+    @abstractmethod
+    def render_success(
+        self, *, level: str, path: Path, models: list[str], ctx: GenerateContext
+    ) -> None:
+        """Print the post-generation success panel."""
+
+    # ---- overridable hooks (single-model, no injection, no extras) ------
+
+    def load_models(self) -> list[dict]:
+        """Fetch and display the model list. Claude Code overrides to inject 1M."""
+        return _fetch_and_display_models()
+
+    def select_models(self, models: list[dict]) -> list[dict | None]:
+        """Prompt for the model(s) this client writes (default: one)."""
+        console.print("\n[bold]Step 2: Select model[/bold]")
+        return [_select_model_dict(models, "Enter number (or 0 for auto-routing)")]
+
+    def prompt_extras(self, selected_dicts: list[dict | None]) -> dict:
+        """Prompt for any client-specific options (default: none)."""
+        return {}
+
+    # ---- id-style resolution (base-owned; Part B extends) ---------------
+
+    def resolve_id_style(self, id_style: IdStyle | None, selected: list[dict | None]) -> IdStyle:
+        """Resolve the effective id style. Part A: always ``QUALIFIED``."""
+        return id_style or IdStyle.QUALIFIED
+
+    def resolve_model_string(self, model: dict | None, id_style: IdStyle) -> str:
+        """Resolve one selected model dict to the string written into config.
+
+        Part A always produces the provider-qualified wire key (or the
+        auto-routing sentinel). Part B adds official-id conversion here.
+        """
+        if model is None:
+            return "router-maestro"
+        return _model_key(model)
+
+    # ---- shared resolvers ----------------------------------------------
+
+    def _base_url(self) -> str:
+        """Router-Maestro server base URL (from the admin client endpoint)."""
+        client = get_admin_client()
+        return (
+            client.endpoint.rstrip("/") if hasattr(client, "endpoint") else "http://localhost:8080"
+        )
+
+    def _auth_token(self) -> str:
+        """API key for the active context, or the ``router-maestro`` fallback."""
+        return get_current_context_api_key() or "router-maestro"
+
+    def _select_level_and_path(self) -> tuple[str, Path]:
+        """Step 1: prompt user vs project level, return ``(level, path)``."""
+        user_label, project_label = self.level_menu()
+        console.print("\n[bold]Step 1: Select configuration level[/bold]")
+        console.print(f"  1. {user_label}")
+        console.print(f"  2. {project_label}")
+        choice = Prompt.ask("Select", choices=["1", "2"], default="1")
+        level = "user" if choice == "1" else "project"
+        return level, self.paths()[level]
+
+    # ---- template method (owns the whole flow) -------------------------
+
+    def generate(self, *, id_style: IdStyle | None = None) -> None:
+        """Run the full interactive config-generation flow for this client."""
+        level, path = self._select_level_and_path()
+        _backup_if_exists(path)
+        models = self.load_models()
+        selected = self.select_models(models)
+        id_style = self.resolve_id_style(id_style, selected)
+        extras = self.prompt_extras(selected)
+        model_strings = [self.resolve_model_string(d, id_style) for d in selected]
+        ctx = GenerateContext(id_style=id_style, selected_dicts=selected, extras=extras)
+        self.write(level=level, path=path, models=model_strings, ctx=ctx)
+        self.render_success(level=level, path=path, models=model_strings, ctx=ctx)

--- a/src/router_maestro/cli/client_configs/claude_code.py
+++ b/src/router_maestro/cli/client_configs/claude_code.py
@@ -1,0 +1,328 @@
+"""Claude Code (`~/.claude/settings.json`) config generation.
+
+Claude Code is the only client that selects two models (main + small/fast),
+injects synthetic 1M-context variants, and offers the auto-compact-window and
+beta-endpoint prompts. All of that lives here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rich.panel import Panel
+from rich.prompt import Prompt
+
+from router_maestro.cli.client_configs.base import (
+    ClientConfig,
+    GenerateContext,
+    _bare_upstream_model_id,
+    _model_key,
+    _select_model_dict,
+    _upstream_context_window,
+    console,
+)
+from router_maestro.routing.model_ref import qualify_model_id
+
+# Claude Code native model IDs for 1M context variants.
+# Copilot no longer ships dedicated `-1m` / `-1m-internal` Opus variants — the
+# base catalog entries for Opus 4.6/4.7/4.8, Sonnet 4.6, and Sonnet 5 already advertise
+# max_context_window_tokens=1000000, so every native key maps straight to the
+# base id. The `[1m]` suffix here only exists so Claude Code raises its
+# auto-compact threshold to ~1M instead of clamping at the default 200K.
+_OPUS_1M_NATIVE_KEY = "claude-opus-4-6[1m]"
+_OPUS_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.6"
+_OPUS_47_1M_NATIVE_KEY = "claude-opus-4-7[1m]"
+_OPUS_47_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.7"
+_OPUS_48_1M_NATIVE_KEY = "claude-opus-4-8[1m]"
+_OPUS_48_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.8"
+_SONNET_46_1M_NATIVE_KEY = "claude-sonnet-4-6[1m]"
+_SONNET_46_1M_SOURCE_MODEL = "github-copilot/claude-sonnet-4.6"
+_SONNET_5_1M_NATIVE_KEY = "claude-sonnet-5[1m]"
+_SONNET_5_1M_SOURCE_MODEL = "github-copilot/claude-sonnet-5"
+
+_INJECTABLE_1M_VARIANTS: tuple[tuple[str, str, str, str], ...] = (
+    # (source_model, native_key, bare_id, display_name)
+    (
+        _OPUS_1M_SOURCE_MODEL,
+        _OPUS_1M_NATIVE_KEY,
+        "claude-opus-4.6",
+        "Opus 4.6 1M (Auto-activated)",
+    ),
+    (
+        _OPUS_47_1M_SOURCE_MODEL,
+        _OPUS_47_1M_NATIVE_KEY,
+        "claude-opus-4.7",
+        "Opus 4.7 1M (Auto-activated)",
+    ),
+    (
+        _OPUS_48_1M_SOURCE_MODEL,
+        _OPUS_48_1M_NATIVE_KEY,
+        "claude-opus-4.8",
+        "Opus 4.8 1M (Auto-activated)",
+    ),
+    (
+        _SONNET_46_1M_SOURCE_MODEL,
+        _SONNET_46_1M_NATIVE_KEY,
+        "claude-sonnet-4.6",
+        "Sonnet 4.6 1M (Auto-activated)",
+    ),
+    (
+        _SONNET_5_1M_SOURCE_MODEL,
+        _SONNET_5_1M_NATIVE_KEY,
+        "claude-sonnet-5",
+        "Sonnet 5 1M (Auto-activated)",
+    ),
+)
+
+# Claude Code recognizes 1M context windows natively for these model keys (the
+# ones we inject via `_maybe_inject_opus_1m`) — the prompt offers a 1M default
+# for them instead of the upstream-value option.
+_CLAUDE_CODE_NATIVE_1M_KEYS: frozenset[str] = frozenset(
+    {
+        _OPUS_1M_NATIVE_KEY,
+        _OPUS_47_1M_NATIVE_KEY,
+        _OPUS_48_1M_NATIVE_KEY,
+        _SONNET_46_1M_NATIVE_KEY,
+        _SONNET_5_1M_NATIVE_KEY,
+    }
+)
+
+# Default CLAUDE_CODE_AUTO_COMPACT_WINDOW for non-Claude models. Matches
+# Claude Code's built-in window for Claude Opus / Sonnet (200K).
+_CLAUDE_CODE_DEFAULT_AUTO_COMPACT_WINDOW = 200_000
+
+
+def get_claude_code_paths() -> dict[str, Path]:
+    """Get Claude Code settings paths."""
+    return {
+        "user": Path.home() / ".claude" / "settings.json",
+        "project": Path.cwd() / ".claude" / "settings.json",
+    }
+
+
+def _maybe_inject_opus_1m(models: list[dict]) -> list[dict]:
+    """Prepend Claude Code-native 1M context options for any source models present.
+
+    Returns a new list (never mutates the input).
+    """
+    models_by_key = {_model_key(model): model for model in models}
+    injected: list[dict] = []
+    for source_model, native_key, bare_id, display_name in _INJECTABLE_1M_VARIANTS:
+        source = models_by_key.get(source_model)
+        if source is not None and (_upstream_context_window(source) or 0) >= 1_000_000:
+            injected.append(
+                {
+                    "provider": "github-copilot",
+                    "id": bare_id,
+                    "name": display_name,
+                    "display_key": native_key,
+                    "wire_key": qualify_model_id("github-copilot", native_key),
+                }
+            )
+    if not injected:
+        return models
+    return [*injected, *models]
+
+
+def _prompt_endpoint_mode(model: dict | None) -> bool:
+    """Prompt whether to use the beta native passthrough endpoint.
+
+    Only offered when the selected model is a Claude model on GitHub Copilot.
+    Returns True to use the beta endpoint, False for standard.
+    """
+    if model is None:
+        return False
+    provider = model.get("provider", "")
+    model_id = _bare_upstream_model_id(model)
+    if provider != "github-copilot" or not model_id.lower().startswith("claude-"):
+        return False
+
+    console.print("\n[bold]Endpoint mode[/bold]")
+    console.print("  1. Standard (translation-based, battle-tested)")
+    console.print("  2. Beta (native Copilot Anthropic passthrough — full thinking/cache fidelity)")
+    choice = Prompt.ask("Select", choices=["1", "2"], default="2")
+    return choice == "2"
+
+
+def _prompt_auto_compact_window(model: dict | None) -> int | None:
+    """Prompt the user whether to set CLAUDE_CODE_AUTO_COMPACT_WINDOW.
+
+    Returns the chosen token count to write, or ``None`` to skip the env var.
+
+    In Claude Code 2.1.162+, auto-compact's threshold check is short-circuited
+    in interactive mode when the window source is "auto" — only ``env`` or
+    ``settings`` source actually arms the trigger. So setting this env var is
+    what turns the feature on at all; the exact value is secondary.
+
+    For Claude Code-native 1M model keys (e.g. ``claude-opus-4-7[1m]``), the
+    default offered is 1M and the upstream-value option is dropped — Copilot's
+    real prompt cap on the 1M variant is below 1M but matching Claude Code's
+    own view of the window is the more useful default here.
+
+    For everything else, the prompt offers:
+      * ``y`` — use the upstream context window (``max_prompt_tokens`` +
+        ``max_output_tokens``, matching what Copilot's own model picker shows)
+      * ``n`` — skip; do not set the env var
+      * ``d`` — set the default 200K (matches Claude Opus/Sonnet's window)
+    """
+    if model is None:
+        return None
+    model_key = _model_key(model)
+    native_key = model.get("display_key", model_key)
+    is_native_1m = native_key in _CLAUDE_CODE_NATIVE_1M_KEYS
+
+    upstream = _upstream_context_window(model)
+    default_value = 1_000_000 if is_native_1m else _CLAUDE_CODE_DEFAULT_AUTO_COMPACT_WINDOW
+
+    console.print()
+    if is_native_1m:
+        console.print(
+            "[bold]Set CLAUDE_CODE_AUTO_COMPACT_WINDOW?[/bold]\n"
+            f"  Selected: {model_key}\n"
+            f"  [dim]Claude Code's interactive auto-compact only arms when this env var\n"
+            f"  (or settings.autoCompactWindow) is set. Without it, the trigger is\n"
+            f"  short-circuited regardless of model. Default ({default_value}) matches\n"
+            f"  Claude Code's native 1M window for this model.[/dim]"
+        )
+        choices = ["n", "d"]
+        prompt_text = f"n = skip / d = default: {default_value}"
+    else:
+        upstream_line = (
+            f"  Upstream context window: {upstream}"
+            if upstream is not None
+            else "  Upstream context window: (unknown)"
+        )
+        console.print(
+            "[bold]Set CLAUDE_CODE_AUTO_COMPACT_WINDOW?[/bold]\n"
+            f"  Selected: {model_key}\n"
+            f"{upstream_line}\n"
+            f"  [dim]Claude Code's interactive auto-compact only arms when this env var\n"
+            f"  (or settings.autoCompactWindow) is set. Without it, the trigger is\n"
+            f"  short-circuited regardless of model. Default ({default_value}) matches\n"
+            f"  Claude Opus/Sonnet's 200K window.[/dim]"
+        )
+        can_use_upstream = upstream is not None
+        if can_use_upstream:
+            choices = ["y", "n", "d"]
+            prompt_text = f"y = upstream: {upstream} / n = skip / d = default: {default_value}"
+        else:
+            choices = ["n", "d"]
+            prompt_text = f"n = skip / d = default: {default_value}"
+
+    choice = Prompt.ask(prompt_text, choices=choices, default="d").lower()
+
+    if choice == "n":
+        return None
+    if choice == "y" and not is_native_1m and upstream is not None:
+        return int(upstream)
+    return default_value
+
+
+class ClaudeCodeConfig(ClientConfig):
+    """Generate Claude Code CLI settings.json for router-maestro."""
+
+    key = "claude-code"
+    display_name = "Claude Code"
+    description = "Generate settings.json for Claude Code CLI"
+
+    def paths(self) -> dict[str, Path]:
+        return get_claude_code_paths()
+
+    def level_menu(self) -> tuple[str, str]:
+        return (
+            "User-level (~/.claude/settings.json)",
+            "Project-level (./.claude/settings.json)",
+        )
+
+    def load_models(self) -> list[dict]:
+        # Import from base's module namespace so tests that patch
+        # ``base._fetch_models`` are observed here.
+        from router_maestro.cli.client_configs import base
+
+        models = base._fetch_models()
+        # If the 1M variant is available, offer the Claude Code-native model key
+        # as an extra option. Claude Code sends the extended-context beta header
+        # when this key is used, and the router resolves it automatically.
+        models = _maybe_inject_opus_1m(models)
+        base._display_models(models)
+        return models
+
+    def select_models(self, models: list[dict]) -> list[dict | None]:
+        console.print("\n[bold]Step 3: Select main model[/bold]")
+        main_model_dict = _select_model_dict(models, "Enter number (or 0 for auto-routing)")
+        console.print("\n[bold]Step 4: Select small/fast model[/bold]")
+        fast_model_dict = _select_model_dict(models, "Enter number", default="1")
+        return [main_model_dict, fast_model_dict]
+
+    def prompt_extras(self, selected_dicts: list[dict | None]) -> dict:
+        main_model_dict = selected_dicts[0] if selected_dicts else None
+        return {
+            "auto_compact_window": _prompt_auto_compact_window(main_model_dict),
+            "use_beta_endpoint": _prompt_endpoint_mode(main_model_dict),
+        }
+
+    def _anthropic_url(self, ctx: GenerateContext) -> str:
+        path = "/api/anthropic/beta" if ctx.extras.get("use_beta_endpoint") else "/api/anthropic"
+        return f"{self._base_url()}{path}"
+
+    def write(self, *, level: str, path: Path, models: list[str], ctx: GenerateContext) -> None:
+        main_model, fast_model = models[0], models[1]
+        auth_token = self._auth_token()
+        anthropic_url = self._anthropic_url(ctx)
+        auto_compact_window = ctx.extras.get("auto_compact_window")
+
+        env_config = {
+            "ANTHROPIC_BASE_URL": anthropic_url,
+            "ANTHROPIC_AUTH_TOKEN": auth_token,
+            "ANTHROPIC_MODEL": main_model,
+            "ANTHROPIC_SMALL_FAST_MODEL": fast_model,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "CLAUDE_CODE_ENABLE_LSP": "1",
+        }
+        if auto_compact_window is not None:
+            env_config["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(auto_compact_window)
+
+        # Load existing settings to preserve other sections (e.g., MCP servers)
+        existing_config: dict = {}
+        if path.exists():
+            try:
+                with open(path, encoding="utf-8") as f:
+                    existing_config = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass  # If file is corrupted, start fresh
+
+        # Merge: update env variables while preserving existing ones
+        existing_env = existing_config.get("env", {})
+        if not isinstance(existing_env, dict):
+            existing_env = {}
+        existing_config["env"] = {**existing_env, **env_config}
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(existing_config, f, indent=2)
+
+    def render_success(
+        self, *, level: str, path: Path, models: list[str], ctx: GenerateContext
+    ) -> None:
+        main_model, fast_model = models[0], models[1]
+        anthropic_url = self._anthropic_url(ctx)
+        auto_compact_window = ctx.extras.get("auto_compact_window")
+        auto_compact_line = (
+            f"Auto-compact window: {auto_compact_window} tokens\n\n"
+            if auto_compact_window is not None
+            else ""
+        )
+        console.print(
+            Panel(
+                f"[green]Created {path}[/green]\n\n"
+                f"Main model: {main_model}\n"
+                f"Fast model: {fast_model}\n\n"
+                f"{auto_compact_line}"
+                f"Endpoint: {anthropic_url}\n\n"
+                "[dim]Start router-maestro server before using Claude Code:[/dim]\n"
+                "  router-maestro server start",
+                title="Success",
+                border_style="green",
+            )
+        )

--- a/src/router_maestro/cli/client_configs/codex.py
+++ b/src/router_maestro/cli/client_configs/codex.py
@@ -1,0 +1,136 @@
+"""OpenAI Codex (`~/.codex/config.toml`) config generation."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import tomlkit
+from rich.panel import Panel
+
+from router_maestro.cli.client_configs.base import (
+    ClientConfig,
+    GenerateContext,
+    console,
+)
+
+
+def get_codex_paths() -> dict[str, Path]:
+    """Get Codex config paths."""
+    return {
+        "user": Path.home() / ".codex" / "config.toml",
+        "project": Path.cwd() / ".codex" / "config.toml",
+    }
+
+
+def _build_router_maestro_provider_table(openai_url: str) -> tomlkit.items.Table:
+    """Build the `[model_providers.router-maestro]` TOML table for Codex user config."""
+    table = tomlkit.table()
+    table["name"] = "Router Maestro"
+    table["base_url"] = openai_url
+    table["env_key"] = "ROUTER_MAESTRO_API_KEY"
+    table["wire_api"] = "responses"
+    return table
+
+
+def _user_codex_has_router_maestro_provider(user_config_path: Path) -> bool:
+    """Return True iff the user-level Codex config sets `model_provider = "router-maestro"`."""
+    if not user_config_path.exists():
+        return False
+    try:
+        with open(user_config_path, "rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError):
+        return False
+    return data.get("model_provider") == "router-maestro"
+
+
+class CodexConfig(ClientConfig):
+    """Generate OpenAI Codex CLI config.toml for router-maestro."""
+
+    key = "codex"
+    display_name = "OpenAI Codex"
+    description = "Generate config.toml for OpenAI Codex CLI"
+
+    def paths(self) -> dict[str, Path]:
+        return get_codex_paths()
+
+    def level_menu(self) -> tuple[str, str]:
+        return (
+            "User-level (~/.codex/config.toml)",
+            "Project-level (./.codex/config.toml)",
+        )
+
+    def write(self, *, level: str, path: Path, models: list[str], ctx: GenerateContext) -> None:
+        selected_model = models[0]
+        openai_url = f"{self._base_url()}/api/openai/v1"
+
+        # Load existing config to preserve other sections
+        existing_config: tomlkit.TOMLDocument = tomlkit.document()
+        if path.exists():
+            try:
+                with open(path, "rb") as f:
+                    existing_config = tomlkit.load(f)
+            except (tomllib.TOMLDecodeError, OSError):
+                pass  # If file is corrupted, start fresh
+
+        # Update configuration
+        existing_config["model"] = selected_model
+
+        if level == "user":
+            existing_config["model_provider"] = "router-maestro"
+            if "model_providers" not in existing_config:
+                existing_config["model_providers"] = tomlkit.table()
+            existing_config["model_providers"]["router-maestro"] = (
+                _build_router_maestro_provider_table(openai_url)
+            )
+        else:
+            # Codex CLI 0.130+ rejects model_provider/model_providers at project scope.
+            # Strip the keys this command wrote in older releases so the file stops
+            # tripping the "Ignored unsupported project-local config keys" warning.
+            existing_config.pop("model_provider", None)
+            providers = existing_config.get("model_providers")
+            if providers is not None:
+                providers.pop("router-maestro", None)
+                if len(providers) == 0:
+                    existing_config.pop("model_providers", None)
+
+        # Write config
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(tomlkit.dumps(existing_config))
+
+    def render_success(
+        self, *, level: str, path: Path, models: list[str], ctx: GenerateContext
+    ) -> None:
+        selected_model = models[0]
+        openai_url = f"{self._base_url()}/api/openai/v1"
+
+        if level == "user":
+            body = (
+                f"[green]Created {path}[/green]\n\n"
+                f"Model: {selected_model}\n\n"
+                f"Endpoint: {openai_url}\n\n"
+                "[dim]Start router-maestro server before using Codex:[/dim]\n"
+                "  router-maestro server start\n\n"
+                "[dim]Set API key environment variable (optional):[/dim]\n"
+                "  export ROUTER_MAESTRO_API_KEY=your-key"
+            )
+        else:
+            if _user_codex_has_router_maestro_provider(self.paths()["user"]):
+                inheritance_line = f"[dim]Inheriting provider from {self.paths()['user']}.[/dim]"
+            else:
+                inheritance_line = (
+                    "[yellow]User-level Router-Maestro config not found.[/yellow]\n"
+                    "Run [bold]router-maestro config codex[/bold] and pick option 1 first,\n"
+                    "otherwise Codex won't know how to reach the server."
+                )
+            body = f"[green]Created {path}[/green]\n\nModel: {selected_model}\n\n{inheritance_line}"
+
+        console.print(
+            Panel(
+                body,
+                title="Success",
+                border_style="green",
+            )
+        )

--- a/src/router_maestro/cli/client_configs/gemini.py
+++ b/src/router_maestro/cli/client_configs/gemini.py
@@ -1,0 +1,99 @@
+"""Gemini CLI (`~/.gemini/.env`) config generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.panel import Panel
+
+from router_maestro.cli.client_configs.base import (
+    ClientConfig,
+    GenerateContext,
+    console,
+)
+
+
+def get_gemini_cli_paths() -> dict[str, Path]:
+    """Get Gemini CLI config paths."""
+    return {
+        "user": Path.home() / ".gemini" / ".env",
+        "project": Path.cwd() / ".gemini" / ".env",
+    }
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a .env file into a dict, preserving order."""
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, _, value = line.partition("=")
+                env[key.strip()] = value.strip()
+    except OSError:
+        pass
+    return env
+
+
+def _write_env_file(path: Path, env: dict[str, str]) -> None:
+    """Write a dict as a .env file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{k}={v}" for k, v in env.items()]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+class GeminiConfig(ClientConfig):
+    """Generate Gemini CLI .env for router-maestro."""
+
+    key = "gemini"
+    display_name = "Gemini CLI"
+    description = "Generate .env for Gemini CLI"
+
+    def paths(self) -> dict[str, Path]:
+        return get_gemini_cli_paths()
+
+    def level_menu(self) -> tuple[str, str]:
+        return (
+            "User-level (~/.gemini/.env)",
+            "Project-level (./.gemini/.env)",
+        )
+
+    def write(self, *, level: str, path: Path, models: list[str], ctx: GenerateContext) -> None:
+        model_name = models[0]
+        gemini_url = f"{self._base_url()}/api/gemini"
+
+        # Load existing .env to preserve other variables
+        existing_env = _parse_env_file(path)
+
+        # Router-Maestro's Gemini path converter accepts the provider-qualified public
+        # ID, preserving an unambiguous selection when providers share an upstream ID.
+        existing_env["GOOGLE_GEMINI_BASE_URL"] = gemini_url
+        existing_env["GEMINI_API_KEY"] = self._auth_token()
+        existing_env["GEMINI_MODEL"] = model_name
+        existing_env["GEMINI_TELEMETRY_ENABLED"] = "false"
+
+        _write_env_file(path, existing_env)
+
+    def render_success(
+        self, *, level: str, path: Path, models: list[str], ctx: GenerateContext
+    ) -> None:
+        model_name = models[0]
+        gemini_url = f"{self._base_url()}/api/gemini"
+        console.print(
+            Panel(
+                f"[green]Created {path}[/green]\n\n"
+                f"Model: {model_name}\n"
+                f"Backend URL: {gemini_url}\n"
+                f"Telemetry: disabled\n\n"
+                "[dim]Start router-maestro server before using Gemini CLI:[/dim]\n"
+                "  router-maestro server start\n\n"
+                "[dim]Then run Gemini CLI normally:[/dim]\n"
+                "  gemini",
+                title="Success",
+                border_style="green",
+            )
+        )

--- a/src/router_maestro/cli/client_configs/registry.py
+++ b/src/router_maestro/cli/client_configs/registry.py
@@ -1,0 +1,31 @@
+"""Ordered registry of supported clients for `router-maestro config`.
+
+Drives both the interactive tool picker and the ``config <key>`` dispatch.
+Adding a client is one line here plus its module.
+"""
+
+from __future__ import annotations
+
+from router_maestro.cli.client_configs.base import ClientConfig
+from router_maestro.cli.client_configs.claude_code import ClaudeCodeConfig
+from router_maestro.cli.client_configs.codex import CodexConfig
+from router_maestro.cli.client_configs.gemini import GeminiConfig
+
+# Insertion order defines the menu order (claude-code, codex, gemini).
+_CLIENT_CLASSES: tuple[type[ClientConfig], ...] = (
+    ClaudeCodeConfig,
+    CodexConfig,
+    GeminiConfig,
+)
+
+CLIENT_CONFIGS: dict[str, type[ClientConfig]] = {cls.key: cls for cls in _CLIENT_CLASSES}
+
+
+def list_clients() -> list[type[ClientConfig]]:
+    """Return the client classes in registry (menu) order."""
+    return list(_CLIENT_CLASSES)
+
+
+def get_client(key: str) -> type[ClientConfig]:
+    """Return the client class for ``key`` (e.g. ``"codex"``)."""
+    return CLIENT_CONFIGS[key]

--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -1,389 +1,19 @@
-"""Configuration management commands."""
+"""`router-maestro config` — generate config files for external CLI clients.
 
-import asyncio
-import json
-import shutil
-import tomllib
-from datetime import datetime
+The per-client generation logic lives in :mod:`router_maestro.cli.client_configs`.
+This module is the Typer surface: the command bindings, the interactive tool
+picker, and a small back-compat re-export block.
+"""
+
 from pathlib import Path
 
-import tomlkit
 import typer
-from rich.console import Console
-from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
-from rich.table import Table
 
-from router_maestro.cli.client import ServerNotRunningError, get_admin_client
-from router_maestro.config.server import get_current_context_api_key
-from router_maestro.routing.model_ref import qualify_model_id
+from router_maestro.cli.client_configs import get_client, list_clients
+from router_maestro.cli.client_configs.base import console
 
 app = typer.Typer(invoke_without_command=True)
-console = Console()
-
-# Available CLI tools for configuration
-CLI_TOOLS = {
-    "claude-code": {
-        "name": "Claude Code",
-        "description": "Generate settings.json for Claude Code CLI",
-    },
-    "codex": {
-        "name": "OpenAI Codex",
-        "description": "Generate config.toml for OpenAI Codex CLI",
-    },
-    "gemini": {
-        "name": "Gemini CLI",
-        "description": "Generate .env for Gemini CLI",
-    },
-}
-
-# Claude Code native model IDs for 1M context variants.
-# Copilot no longer ships dedicated `-1m` / `-1m-internal` Opus variants — the
-# base catalog entries for Opus 4.6/4.7/4.8, Sonnet 4.6, and Sonnet 5 already advertise
-# max_context_window_tokens=1000000, so every native key maps straight to the
-# base id. The `[1m]` suffix here only exists so Claude Code raises its
-# auto-compact threshold to ~1M instead of clamping at the default 200K.
-_OPUS_1M_NATIVE_KEY = "claude-opus-4-6[1m]"
-_OPUS_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.6"
-_OPUS_47_1M_NATIVE_KEY = "claude-opus-4-7[1m]"
-_OPUS_47_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.7"
-_OPUS_48_1M_NATIVE_KEY = "claude-opus-4-8[1m]"
-_OPUS_48_1M_SOURCE_MODEL = "github-copilot/claude-opus-4.8"
-_SONNET_46_1M_NATIVE_KEY = "claude-sonnet-4-6[1m]"
-_SONNET_46_1M_SOURCE_MODEL = "github-copilot/claude-sonnet-4.6"
-_SONNET_5_1M_NATIVE_KEY = "claude-sonnet-5[1m]"
-_SONNET_5_1M_SOURCE_MODEL = "github-copilot/claude-sonnet-5"
-
-_INJECTABLE_1M_VARIANTS: tuple[tuple[str, str, str, str], ...] = (
-    # (source_model, native_key, bare_id, display_name)
-    (
-        _OPUS_1M_SOURCE_MODEL,
-        _OPUS_1M_NATIVE_KEY,
-        "claude-opus-4.6",
-        "Opus 4.6 1M (Auto-activated)",
-    ),
-    (
-        _OPUS_47_1M_SOURCE_MODEL,
-        _OPUS_47_1M_NATIVE_KEY,
-        "claude-opus-4.7",
-        "Opus 4.7 1M (Auto-activated)",
-    ),
-    (
-        _OPUS_48_1M_SOURCE_MODEL,
-        _OPUS_48_1M_NATIVE_KEY,
-        "claude-opus-4.8",
-        "Opus 4.8 1M (Auto-activated)",
-    ),
-    (
-        _SONNET_46_1M_SOURCE_MODEL,
-        _SONNET_46_1M_NATIVE_KEY,
-        "claude-sonnet-4.6",
-        "Sonnet 4.6 1M (Auto-activated)",
-    ),
-    (
-        _SONNET_5_1M_SOURCE_MODEL,
-        _SONNET_5_1M_NATIVE_KEY,
-        "claude-sonnet-5",
-        "Sonnet 5 1M (Auto-activated)",
-    ),
-)
-
-
-def get_claude_code_paths() -> dict[str, Path]:
-    """Get Claude Code settings paths."""
-    return {
-        "user": Path.home() / ".claude" / "settings.json",
-        "project": Path.cwd() / ".claude" / "settings.json",
-    }
-
-
-def get_codex_paths() -> dict[str, Path]:
-    """Get Codex config paths."""
-    return {
-        "user": Path.home() / ".codex" / "config.toml",
-        "project": Path.cwd() / ".codex" / "config.toml",
-    }
-
-
-def get_gemini_cli_paths() -> dict[str, Path]:
-    """Get Gemini CLI config paths."""
-    return {
-        "user": Path.home() / ".gemini" / ".env",
-        "project": Path.cwd() / ".gemini" / ".env",
-    }
-
-
-def _build_router_maestro_provider_table(openai_url: str) -> tomlkit.items.Table:
-    """Build the `[model_providers.router-maestro]` TOML table for Codex user config."""
-    table = tomlkit.table()
-    table["name"] = "Router Maestro"
-    table["base_url"] = openai_url
-    table["env_key"] = "ROUTER_MAESTRO_API_KEY"
-    table["wire_api"] = "responses"
-    return table
-
-
-def _user_codex_has_router_maestro_provider(user_config_path: Path) -> bool:
-    """Return True iff the user-level Codex config sets `model_provider = "router-maestro"`."""
-    if not user_config_path.exists():
-        return False
-    try:
-        with open(user_config_path, "rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, OSError):
-        return False
-    return data.get("model_provider") == "router-maestro"
-
-
-def _backup_if_exists(path: Path) -> None:
-    """Prompt to backup an existing config file before overwriting."""
-    if not path.exists():
-        return
-    console.print(f"\n[yellow]{path.name} already exists at {path}[/yellow]")
-    if Confirm.ask("Backup existing file?", default=True):
-        backup_path = path.with_suffix(
-            f"{path.suffix}.backup.{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-        )
-        shutil.copy(path, backup_path)
-        console.print(f"[green]Backed up to {backup_path}[/green]")
-
-
-def _fetch_models() -> list[dict]:
-    """Fetch models from the server.
-
-    Exits the CLI if the server is unreachable or no models are available.
-    """
-    try:
-        client = get_admin_client()
-        models = asyncio.run(client.list_models())
-    except ServerNotRunningError as e:
-        console.print(f"[red]{e}[/red]")
-        console.print("[dim]Tip: Start router-maestro server first.[/dim]")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1)
-
-    if not models:
-        console.print("[red]No models available. Please authenticate first.[/red]")
-        raise typer.Exit(1)
-
-    return models
-
-
-def _display_models(models: list[dict]) -> None:
-    """Display models in a Rich table."""
-    console.print("\n[bold]Available models:[/bold]")
-    table = Table()
-    table.add_column("#", style="dim")
-    table.add_column("Model Key", style="green")
-    table.add_column("Name", style="white")
-    for i, model in enumerate(models, 1):
-        key = model.get("display_key", _model_key(model))
-        table.add_row(str(i), key, model["name"])
-    console.print(table)
-
-
-def _fetch_and_display_models() -> list[dict]:
-    """Fetch models from the server and display them in a table."""
-    models = _fetch_models()
-    _display_models(models)
-    return models
-
-
-def _maybe_inject_opus_1m(models: list[dict]) -> list[dict]:
-    """Prepend Claude Code-native 1M context options for any source models present.
-
-    Returns a new list (never mutates the input).
-    """
-    models_by_key = {_model_key(model): model for model in models}
-    injected: list[dict] = []
-    for source_model, native_key, bare_id, display_name in _INJECTABLE_1M_VARIANTS:
-        source = models_by_key.get(source_model)
-        if source is not None and (_upstream_context_window(source) or 0) >= 1_000_000:
-            injected.append(
-                {
-                    "provider": "github-copilot",
-                    "id": bare_id,
-                    "name": display_name,
-                    "display_key": native_key,
-                    "wire_key": qualify_model_id("github-copilot", native_key),
-                }
-            )
-    if not injected:
-        return models
-    return [*injected, *models]
-
-
-def _select_model(models: list[dict], prompt: str, default: str = "0") -> str:
-    """Prompt the user to select a model from the list.
-
-    Returns the ``provider/id`` model key, or ``"router-maestro"`` for
-    auto-routing (choice ``0``).
-    """
-    selected = _select_model_dict(models, prompt, default=default)
-    return _model_key(selected) if selected else "router-maestro"
-
-
-def _select_model_dict(models: list[dict], prompt: str, default: str = "0") -> dict | None:
-    """Prompt the user to select a model and return the model dict.
-
-    Returns ``None`` for the auto-routing choice (``0`` or invalid input).
-    """
-    choice = Prompt.ask(prompt, default=default)
-    if choice != "0" and choice.isdigit():
-        idx = int(choice) - 1
-        if 0 <= idx < len(models):
-            return models[idx]
-        console.print(f"[yellow]Invalid selection '{choice}', using auto-routing.[/yellow]")
-    return None
-
-
-def _model_key(model: dict) -> str:
-    """Resolve the wire model key for a model dict from the CLI's model list."""
-    if "wire_key" in model:
-        return model["wire_key"]
-    if "custom_key" in model:
-        return model["custom_key"]
-    return qualify_model_id(model["provider"], model["id"])
-
-
-def _bare_upstream_model_id(model: dict) -> str:
-    """Return the upstream ID from qualified server or legacy bare model entries."""
-    provider = model.get("provider", "")
-    model_id = model.get("id", "")
-    prefix = f"{provider}/"
-    return model_id[len(prefix) :] if provider and model_id.startswith(prefix) else model_id
-
-
-# Claude Code recognizes 1M context windows natively for these model keys (the
-# ones we inject via `_maybe_inject_opus_1m`) — the prompt offers a 1M default
-# for them instead of the upstream-value option.
-_CLAUDE_CODE_NATIVE_1M_KEYS: frozenset[str] = frozenset(
-    {
-        _OPUS_1M_NATIVE_KEY,
-        _OPUS_47_1M_NATIVE_KEY,
-        _OPUS_48_1M_NATIVE_KEY,
-        _SONNET_46_1M_NATIVE_KEY,
-        _SONNET_5_1M_NATIVE_KEY,
-    }
-)
-
-# Default CLAUDE_CODE_AUTO_COMPACT_WINDOW for non-Claude models. Matches
-# Claude Code's built-in window for Claude Opus / Sonnet (200K).
-_CLAUDE_CODE_DEFAULT_AUTO_COMPACT_WINDOW = 200_000
-
-
-def _prompt_endpoint_mode(model: dict | None) -> bool:
-    """Prompt whether to use the beta native passthrough endpoint.
-
-    Only offered when the selected model is a Claude model on GitHub Copilot.
-    Returns True to use the beta endpoint, False for standard.
-    """
-    if model is None:
-        return False
-    provider = model.get("provider", "")
-    model_id = _bare_upstream_model_id(model)
-    if provider != "github-copilot" or not model_id.lower().startswith("claude-"):
-        return False
-
-    console.print("\n[bold]Endpoint mode[/bold]")
-    console.print("  1. Standard (translation-based, battle-tested)")
-    console.print("  2. Beta (native Copilot Anthropic passthrough — full thinking/cache fidelity)")
-    choice = Prompt.ask("Select", choices=["1", "2"], default="2")
-    return choice == "2"
-
-
-def _prompt_auto_compact_window(model: dict | None) -> int | None:
-    """Prompt the user whether to set CLAUDE_CODE_AUTO_COMPACT_WINDOW.
-
-    Returns the chosen token count to write, or ``None`` to skip the env var.
-
-    In Claude Code 2.1.162+, auto-compact's threshold check is short-circuited
-    in interactive mode when the window source is "auto" — only ``env`` or
-    ``settings`` source actually arms the trigger. So setting this env var is
-    what turns the feature on at all; the exact value is secondary.
-
-    For Claude Code-native 1M model keys (e.g. ``claude-opus-4-7[1m]``), the
-    default offered is 1M and the upstream-value option is dropped — Copilot's
-    real prompt cap on the 1M variant is below 1M but matching Claude Code's
-    own view of the window is the more useful default here.
-
-    For everything else, the prompt offers:
-      * ``y`` — use the upstream context window (``max_prompt_tokens`` +
-        ``max_output_tokens``, matching what Copilot's own model picker shows)
-      * ``n`` — skip; do not set the env var
-      * ``d`` — set the default 200K (matches Claude Opus/Sonnet's window)
-    """
-    if model is None:
-        return None
-    model_key = _model_key(model)
-    native_key = model.get("display_key", model_key)
-    is_native_1m = native_key in _CLAUDE_CODE_NATIVE_1M_KEYS
-
-    upstream = _upstream_context_window(model)
-    default_value = 1_000_000 if is_native_1m else _CLAUDE_CODE_DEFAULT_AUTO_COMPACT_WINDOW
-
-    console.print()
-    if is_native_1m:
-        console.print(
-            "[bold]Set CLAUDE_CODE_AUTO_COMPACT_WINDOW?[/bold]\n"
-            f"  Selected: {model_key}\n"
-            f"  [dim]Claude Code's interactive auto-compact only arms when this env var\n"
-            f"  (or settings.autoCompactWindow) is set. Without it, the trigger is\n"
-            f"  short-circuited regardless of model. Default ({default_value}) matches\n"
-            f"  Claude Code's native 1M window for this model.[/dim]"
-        )
-        choices = ["n", "d"]
-        prompt_text = f"n = skip / d = default: {default_value}"
-    else:
-        upstream_line = (
-            f"  Upstream context window: {upstream}"
-            if upstream is not None
-            else "  Upstream context window: (unknown)"
-        )
-        console.print(
-            "[bold]Set CLAUDE_CODE_AUTO_COMPACT_WINDOW?[/bold]\n"
-            f"  Selected: {model_key}\n"
-            f"{upstream_line}\n"
-            f"  [dim]Claude Code's interactive auto-compact only arms when this env var\n"
-            f"  (or settings.autoCompactWindow) is set. Without it, the trigger is\n"
-            f"  short-circuited regardless of model. Default ({default_value}) matches\n"
-            f"  Claude Opus/Sonnet's 200K window.[/dim]"
-        )
-        can_use_upstream = upstream is not None
-        if can_use_upstream:
-            choices = ["y", "n", "d"]
-            prompt_text = f"y = upstream: {upstream} / n = skip / d = default: {default_value}"
-        else:
-            choices = ["n", "d"]
-            prompt_text = f"n = skip / d = default: {default_value}"
-
-    choice = Prompt.ask(prompt_text, choices=choices, default="d").lower()
-
-    if choice == "n":
-        return None
-    if choice == "y" and not is_native_1m and upstream is not None:
-        return int(upstream)
-    return default_value
-
-
-def _upstream_context_window(model: dict) -> int | None:
-    """Compute the displayed upstream context window for a Copilot model.
-
-    Mirrors what VS Code's Copilot model picker shows: prompt + output, which
-    matches the catalog's advertised window in most cases. Falls back to the
-    server-reported ``max_context_window_tokens`` if either component is
-    missing.
-    """
-    prompt = model.get("max_prompt_tokens")
-    output = model.get("max_output_tokens")
-    if isinstance(prompt, int) and prompt > 0 and isinstance(output, int) and output > 0:
-        return prompt + output
-    ctx = model.get("max_context_window_tokens")
-    if isinstance(ctx, int) and ctx > 0:
-        return ctx
-    return None
 
 
 @app.callback(invoke_without_command=True)
@@ -394,307 +24,90 @@ def config_callback(ctx: typer.Context) -> None:
 
     # Interactive selection
     console.print("\n[bold]Available CLI tools:[/bold]")
-    tools = list(CLI_TOOLS.items())
-    for i, (key, info) in enumerate(tools, 1):
-        console.print(f"  {i}. {info['name']} - {info['description']}")
+    clients = list_clients()
+    for i, client in enumerate(clients, 1):
+        console.print(f"  {i}. {client.display_name} - {client.description}")
 
     console.print()
     choice = Prompt.ask(
         "Select tool to configure",
-        choices=[str(i) for i in range(1, len(tools) + 1)],
+        choices=[str(i) for i in range(1, len(clients) + 1)],
         default="1",
     )
 
     idx = int(choice) - 1
-    tool_key = tools[idx][0]
-
-    # Dispatch to the appropriate command
-    if tool_key == "claude-code":
-        claude_code_config()
-    elif tool_key == "codex":
-        codex_config()
-    elif tool_key == "gemini":
-        gemini_cli_config()
+    clients[idx]().generate()
 
 
 @app.command(name="claude-code")
 def claude_code_config() -> None:
     """Generate Claude Code CLI settings.json for router-maestro."""
-    # Step 1: Select level
-    console.print("\n[bold]Step 1: Select configuration level[/bold]")
-    console.print("  1. User-level (~/.claude/settings.json)")
-    console.print("  2. Project-level (./.claude/settings.json)")
-    choice = Prompt.ask("Select", choices=["1", "2"], default="1")
-
-    paths = get_claude_code_paths()
-    level = "user" if choice == "1" else "project"
-    settings_path = paths[level]
-
-    # Step 2: Backup if exists
-    _backup_if_exists(settings_path)
-
-    # Step 3 & 4: Select models from server
-    models = _fetch_models()
-
-    # If the 1M variant is available, offer the Claude Code-native model key
-    # as an extra option. Claude Code sends the extended-context beta header
-    # when this key is used, and the router resolves it automatically.
-    models = _maybe_inject_opus_1m(models)
-
-    _display_models(models)
-
-    console.print("\n[bold]Step 3: Select main model[/bold]")
-    main_model_dict = _select_model_dict(models, "Enter number (or 0 for auto-routing)")
-    main_model = _model_key(main_model_dict) if main_model_dict else "router-maestro"
-
-    console.print("\n[bold]Step 4: Select small/fast model[/bold]")
-    fast_model = _select_model(models, "Enter number", default="1")
-
-    # Step 4b: Optional auto-compact window override (Claude Code only)
-    auto_compact_window = _prompt_auto_compact_window(main_model_dict)
-
-    # Step 4c: Endpoint mode — offer beta passthrough for Claude models on Copilot
-    use_beta_endpoint = _prompt_endpoint_mode(main_model_dict)
-
-    # Step 5: Generate config
-    auth_token = get_current_context_api_key() or "router-maestro"
-    client = get_admin_client()
-    base_url = (
-        client.endpoint.rstrip("/") if hasattr(client, "endpoint") else "http://localhost:8080"
-    )
-    anthropic_path = "/api/anthropic/beta" if use_beta_endpoint else "/api/anthropic"
-    anthropic_url = f"{base_url}{anthropic_path}"
-
-    env_config = {
-        "ANTHROPIC_BASE_URL": anthropic_url,
-        "ANTHROPIC_AUTH_TOKEN": auth_token,
-        "ANTHROPIC_MODEL": main_model,
-        "ANTHROPIC_SMALL_FAST_MODEL": fast_model,
-        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
-        "CLAUDE_CODE_ENABLE_LSP": "1",
-    }
-    if auto_compact_window is not None:
-        env_config["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(auto_compact_window)
-
-    # Load existing settings to preserve other sections (e.g., MCP servers)
-    existing_config: dict = {}
-    if settings_path.exists():
-        try:
-            with open(settings_path, encoding="utf-8") as f:
-                existing_config = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            pass  # If file is corrupted, start fresh
-
-    # Merge: update env variables while preserving existing ones
-    existing_env = existing_config.get("env", {})
-    if not isinstance(existing_env, dict):
-        existing_env = {}
-    existing_config["env"] = {**existing_env, **env_config}
-
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(settings_path, "w", encoding="utf-8") as f:
-        json.dump(existing_config, f, indent=2)
-
-    auto_compact_line = (
-        f"Auto-compact window: {auto_compact_window} tokens\n\n"
-        if auto_compact_window is not None
-        else ""
-    )
-    console.print(
-        Panel(
-            f"[green]Created {settings_path}[/green]\n\n"
-            f"Main model: {main_model}\n"
-            f"Fast model: {fast_model}\n\n"
-            f"{auto_compact_line}"
-            f"Endpoint: {anthropic_url}\n\n"
-            "[dim]Start router-maestro server before using Claude Code:[/dim]\n"
-            "  router-maestro server start",
-            title="Success",
-            border_style="green",
-        )
-    )
+    get_client("claude-code")().generate()
 
 
 @app.command(name="codex")
 def codex_config() -> None:
     """Generate OpenAI Codex CLI config.toml for router-maestro."""
-    # Step 1: Select level
-    console.print("\n[bold]Step 1: Select configuration level[/bold]")
-    console.print("  1. User-level (~/.codex/config.toml)")
-    console.print("  2. Project-level (./.codex/config.toml)")
-    choice = Prompt.ask("Select", choices=["1", "2"], default="1")
-
-    paths = get_codex_paths()
-    level = "user" if choice == "1" else "project"
-    config_path = paths[level]
-
-    # Step 2: Backup if exists
-    _backup_if_exists(config_path)
-
-    # Step 3: Get models from server
-    models = _fetch_and_display_models()
-
-    # Select model
-    console.print("\n[bold]Step 2: Select model[/bold]")
-    selected_model_dict = _select_model_dict(models, "Enter number (or 0 for auto-routing)")
-    selected_model = _model_key(selected_model_dict) if selected_model_dict else "router-maestro"
-
-    # Step 4: Generate config
-    client = get_admin_client()
-    base_url = (
-        client.endpoint.rstrip("/") if hasattr(client, "endpoint") else "http://localhost:8080"
-    )
-    openai_url = f"{base_url}/api/openai/v1"
-
-    # Load existing config to preserve other sections
-    existing_config: tomlkit.TOMLDocument = tomlkit.document()
-    if config_path.exists():
-        try:
-            with open(config_path, "rb") as f:
-                existing_config = tomlkit.load(f)
-        except (tomllib.TOMLDecodeError, OSError):
-            pass  # If file is corrupted, start fresh
-
-    # Update configuration
-    existing_config["model"] = selected_model
-
-    if level == "user":
-        existing_config["model_provider"] = "router-maestro"
-        if "model_providers" not in existing_config:
-            existing_config["model_providers"] = tomlkit.table()
-        existing_config["model_providers"]["router-maestro"] = _build_router_maestro_provider_table(
-            openai_url
-        )
-    else:
-        # Codex CLI 0.130+ rejects model_provider/model_providers at project scope.
-        # Strip the keys this command wrote in older releases so the file stops
-        # tripping the "Ignored unsupported project-local config keys" warning.
-        existing_config.pop("model_provider", None)
-        providers = existing_config.get("model_providers")
-        if providers is not None:
-            providers.pop("router-maestro", None)
-            if len(providers) == 0:
-                existing_config.pop("model_providers", None)
-
-    # Write config
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(config_path, "w", encoding="utf-8") as f:
-        f.write(tomlkit.dumps(existing_config))
-
-    if level == "user":
-        body = (
-            f"[green]Created {config_path}[/green]\n\n"
-            f"Model: {selected_model}\n\n"
-            f"Endpoint: {openai_url}\n\n"
-            "[dim]Start router-maestro server before using Codex:[/dim]\n"
-            "  router-maestro server start\n\n"
-            "[dim]Set API key environment variable (optional):[/dim]\n"
-            "  export ROUTER_MAESTRO_API_KEY=your-key"
-        )
-    else:
-        if _user_codex_has_router_maestro_provider(paths["user"]):
-            inheritance_line = f"[dim]Inheriting provider from {paths['user']}.[/dim]"
-        else:
-            inheritance_line = (
-                "[yellow]User-level Router-Maestro config not found.[/yellow]\n"
-                "Run [bold]router-maestro config codex[/bold] and pick option 1 first,\n"
-                "otherwise Codex won't know how to reach the server."
-            )
-        body = (
-            f"[green]Created {config_path}[/green]\n\nModel: {selected_model}\n\n{inheritance_line}"
-        )
-
-    console.print(
-        Panel(
-            body,
-            title="Success",
-            border_style="green",
-        )
-    )
-
-
-def _parse_env_file(path: Path) -> dict[str, str]:
-    """Parse a .env file into a dict, preserving order."""
-    env: dict[str, str] = {}
-    if not path.exists():
-        return env
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                key, _, value = line.partition("=")
-                env[key.strip()] = value.strip()
-    except OSError:
-        pass
-    return env
-
-
-def _write_env_file(path: Path, env: dict[str, str]) -> None:
-    """Write a dict as a .env file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lines = [f"{k}={v}" for k, v in env.items()]
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    get_client("codex")().generate()
 
 
 @app.command(name="gemini")
 def gemini_cli_config() -> None:
     """Generate Gemini CLI .env for router-maestro."""
-    # Step 1: Select level
-    console.print("\n[bold]Step 1: Select configuration level[/bold]")
-    console.print("  1. User-level (~/.gemini/.env)")
-    console.print("  2. Project-level (./.gemini/.env)")
-    choice = Prompt.ask("Select", choices=["1", "2"], default="1")
+    get_client("gemini")().generate()
 
-    paths = get_gemini_cli_paths()
-    level = "user" if choice == "1" else "project"
-    env_path = paths[level]
 
-    # Step 2: Backup if exists
-    _backup_if_exists(env_path)
+# --- back-compat re-exports -------------------------------------------------
+# Keep the private helpers that tests/external callers import from this module
+# resolvable after the split into ``client_configs``. ``Prompt``/``Confirm``/
+# ``Path`` are re-imported above so ``config.Prompt.ask`` etc. still name the
+# shared class objects the client modules use (class-attribute monkeypatch
+# seams keep working unchanged).
+from router_maestro.cli.client_configs.base import (  # noqa: E402
+    _bare_upstream_model_id,
+    _display_models,
+    _fetch_and_display_models,
+    _fetch_models,
+    _model_key,
+    _select_model,
+    _select_model_dict,
+)
+from router_maestro.cli.client_configs.claude_code import (  # noqa: E402
+    _OPUS_1M_NATIVE_KEY,
+    _OPUS_1M_SOURCE_MODEL,
+    _OPUS_47_1M_NATIVE_KEY,
+    _OPUS_48_1M_NATIVE_KEY,
+    _SONNET_46_1M_NATIVE_KEY,
+    _maybe_inject_opus_1m,
+    _prompt_auto_compact_window,
+    _prompt_endpoint_mode,
+)
+from router_maestro.cli.client_configs.gemini import _parse_env_file  # noqa: E402
 
-    # Step 3: Select model
-    models = _fetch_and_display_models()
-
-    console.print("\n[bold]Step 2: Select model[/bold]")
-    selected_model_dict = _select_model_dict(models, "Enter number (or 0 for auto-routing)")
-    selected_model = _model_key(selected_model_dict) if selected_model_dict else "router-maestro"
-
-    # Step 4: Generate config
-    auth_key = get_current_context_api_key() or "router-maestro"
-    client = get_admin_client()
-    base_url = (
-        client.endpoint.rstrip("/") if hasattr(client, "endpoint") else "http://localhost:8080"
-    )
-    gemini_url = f"{base_url}/api/gemini"
-
-    # Load existing .env to preserve other variables
-    existing_env = _parse_env_file(env_path)
-
-    # Router-Maestro's Gemini path converter accepts the provider-qualified public
-    # ID, preserving an unambiguous selection when providers share an upstream ID.
-    model_name = selected_model
-
-    # Set Gemini CLI variables
-    existing_env["GOOGLE_GEMINI_BASE_URL"] = gemini_url
-    existing_env["GEMINI_API_KEY"] = auth_key
-    existing_env["GEMINI_MODEL"] = model_name
-    existing_env["GEMINI_TELEMETRY_ENABLED"] = "false"
-
-    _write_env_file(env_path, existing_env)
-
-    console.print(
-        Panel(
-            f"[green]Created {env_path}[/green]\n\n"
-            f"Model: {model_name}\n"
-            f"Backend URL: {gemini_url}\n"
-            f"Telemetry: disabled\n\n"
-            "[dim]Start router-maestro server before using Gemini CLI:[/dim]\n"
-            "  router-maestro server start\n\n"
-            "[dim]Then run Gemini CLI normally:[/dim]\n"
-            "  gemini",
-            title="Success",
-            border_style="green",
-        )
-    )
+__all__ = [
+    "_OPUS_1M_NATIVE_KEY",
+    "_OPUS_1M_SOURCE_MODEL",
+    "_OPUS_47_1M_NATIVE_KEY",
+    "_OPUS_48_1M_NATIVE_KEY",
+    "_SONNET_46_1M_NATIVE_KEY",
+    "Confirm",
+    "Path",
+    "Prompt",
+    "_bare_upstream_model_id",
+    "_display_models",
+    "_fetch_and_display_models",
+    "_fetch_models",
+    "_maybe_inject_opus_1m",
+    "_model_key",
+    "_parse_env_file",
+    "_prompt_auto_compact_window",
+    "_prompt_endpoint_mode",
+    "_select_model",
+    "_select_model_dict",
+    "app",
+    "claude_code_config",
+    "codex_config",
+    "config_callback",
+    "console",
+    "gemini_cli_config",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,8 @@ import tomlkit
 from rich.console import Console
 
 from router_maestro.cli import config as cli_config
+from router_maestro.cli.client_configs import base as cc_base
+from router_maestro.cli.client_configs import claude_code as cc_claude
 from router_maestro.cli.config import (
     _OPUS_1M_NATIVE_KEY,
     _OPUS_1M_SOURCE_MODEL,
@@ -446,7 +448,7 @@ class TestSelectModel:
 
     def test_display_uses_qualified_server_id_once(self, monkeypatch):
         output = Console(record=True, width=120)
-        monkeypatch.setattr(cli_config, "console", output)
+        monkeypatch.setattr(cc_base, "console", output)
 
         _display_models(
             [
@@ -763,8 +765,8 @@ def _setup_codex_env(
         {"provider": "github-copilot", "id": "gpt-5.5", "name": "GPT-5.5"},
         {"provider": "github-copilot", "id": "claude-opus-4.6", "name": "Claude Opus 4.6"},
     ]
-    monkeypatch.setattr(cli_config, "_fetch_and_display_models", lambda: list(fake_models))
-    monkeypatch.setattr(cli_config, "get_admin_client", lambda: _StubAdminClient())
+    monkeypatch.setattr(cc_base, "_fetch_and_display_models", lambda: list(fake_models))
+    monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
 
     answers = iter([level_choice, model_choice])
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
@@ -819,7 +821,7 @@ class TestCodexConfig:
     def test_qualified_server_model_writes_single_provider_prefix(self, tmp_path, monkeypatch):
         home, _ = _setup_codex_env(monkeypatch, tmp_path, level_choice="1")
         monkeypatch.setattr(
-            cli_config,
+            cc_base,
             "_fetch_and_display_models",
             lambda: _qualified_server_models(),
         )
@@ -914,10 +916,10 @@ def test_claude_config_qualified_models_write_single_prefix_and_offer_beta(
     home.mkdir()
     monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
     monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: tmp_path))
-    monkeypatch.setattr(cli_config, "_fetch_models", _qualified_server_models)
-    monkeypatch.setattr(cli_config, "get_admin_client", lambda: _StubAdminClient())
-    monkeypatch.setattr(cli_config, "get_current_context_api_key", lambda: "test-key")
-    monkeypatch.setattr(cli_config, "_prompt_auto_compact_window", lambda _model: None)
+    monkeypatch.setattr(cc_base, "_fetch_models", _qualified_server_models)
+    monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
+    monkeypatch.setattr(cc_base, "get_current_context_api_key", lambda: "test-key")
+    monkeypatch.setattr(cc_claude, "_prompt_auto_compact_window", lambda _model: None)
     answers = iter(["1", "2", "1", "2"])
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
     monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
@@ -936,7 +938,7 @@ def test_claude_config_writes_provider_qualified_native_1m_key(tmp_path, monkeyp
     monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
     monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: tmp_path))
     monkeypatch.setattr(
-        cli_config,
+        cc_base,
         "_fetch_models",
         lambda: [
             {
@@ -947,10 +949,10 @@ def test_claude_config_writes_provider_qualified_native_1m_key(tmp_path, monkeyp
             }
         ],
     )
-    monkeypatch.setattr(cli_config, "get_admin_client", lambda: _StubAdminClient())
-    monkeypatch.setattr(cli_config, "get_current_context_api_key", lambda: "test-key")
-    monkeypatch.setattr(cli_config, "_prompt_auto_compact_window", lambda _model: None)
-    monkeypatch.setattr(cli_config, "_prompt_endpoint_mode", lambda _model: False)
+    monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
+    monkeypatch.setattr(cc_base, "get_current_context_api_key", lambda: "test-key")
+    monkeypatch.setattr(cc_claude, "_prompt_auto_compact_window", lambda _model: None)
+    monkeypatch.setattr(cc_claude, "_prompt_endpoint_mode", lambda _model: False)
     answers = iter(["1", "1", "2"])
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
     monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
@@ -967,12 +969,12 @@ def test_gemini_config_qualified_model_preserves_public_id(tmp_path, monkeypatch
     monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
     monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: tmp_path))
     monkeypatch.setattr(
-        cli_config,
+        cc_base,
         "_fetch_and_display_models",
         lambda: [_qualified_server_models()[2]],
     )
-    monkeypatch.setattr(cli_config, "get_admin_client", lambda: _StubAdminClient())
-    monkeypatch.setattr(cli_config, "get_current_context_api_key", lambda: "test-key")
+    monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
+    monkeypatch.setattr(cc_base, "get_current_context_api_key", lambda: "test-key")
     answers = iter(["1", "1"])
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
     monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)


### PR DESCRIPTION
## Summary

Behavior-preserving refactor of `router-maestro config`. The 701-line
`cli/config.py` — three near-identical inline `@app.command` functions plus a
hardcoded `if/elif` dispatch — is split into a `client_configs` package where
each external client owns its **entire** generation flow via a `ClientConfig`
ABC + template-method `generate()`.

This is **Part A of two**. Part B (a follow-up PR) adds the optional
official-model-id feature on top of the stubs introduced here.

## What changed

- **`client_configs/base.py`** — `ClientConfig` ABC, template `generate()`, and
  all shared seams (model fetch/display/select, backup prompt, level picker,
  base-url/auth resolvers). Also introduces `IdStyle`/`GenerateContext` and
  `resolve_id_style`/`resolve_model_string` as Part A stubs that always resolve
  `QUALIFIED` (current behavior).
- **`client_configs/claude_code.py`** — `ClaudeCodeConfig`: 1M-context
  injection, 2-model (main + fast) select, auto-compact-window and
  beta-endpoint prompts, JSON `settings.json` write.
- **`client_configs/codex.py`** — `CodexConfig`: TOML provider table, user vs
  project scope, project-scope self-heal.
- **`client_configs/gemini.py`** — `GeminiConfig`: order-preserving `.env`.
- **`client_configs/registry.py`** — ordered registry driving the interactive
  tool picker and dispatch. Adding a client is now one line + one module.
- **`cli/config.py`** — reduced to Typer bindings, a registry-driven callback
  menu, and a back-compat re-export block that keeps `tests/test_config.py`'s
  imports and class-attribute monkeypatch seams working unchanged.

## Testing

- `uv run pytest tests/` — **3562 passed** (56 config tests unchanged; only the
  ~7 module-attribute monkeypatch targets relocated to their new home modules).
- `uv run ruff check src/ tests/` + `ruff format --check` — clean.
- End-to-end smoke: codex user-level TOML, gemini `.env` preservation, and
  `router-maestro config --help` subcommand registration all verified.
- Independent code review (Codex CLI is currently down) traced all
  behavior-preservation landmines (prompt order, injection timing, project
  self-heal, base-url/auth resolvers, re-export completeness) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)