### PR TITLE
feat: optional official model id in generated client configs

### DIFF
--- a/src/router_maestro/cli/client_configs/base.py
+++ b/src/router_maestro/cli/client_configs/base.py
@@ -208,6 +208,18 @@ class ClientConfig(ABC):
     ) -> None:
         """Print the post-generation success panel."""
 
+    @abstractmethod
+    def is_native_family(self, bare_id: str) -> bool:
+        """Whether ``bare_id`` belongs to this client's native vendor.
+
+        The official-id option is only offered for native models (Codex↔OpenAI,
+        Claude Code↔Anthropic, Gemini CLI↔Google).
+        """
+
+    @abstractmethod
+    def to_official_id(self, bare_id: str) -> str:
+        """Convert a native ``bare_id`` to this vendor's official spelling."""
+
     # ---- overridable hooks (single-model, no injection, no extras) ------
 
     def load_models(self) -> list[dict]:
@@ -223,21 +235,63 @@ class ClientConfig(ABC):
         """Prompt for any client-specific options (default: none)."""
         return {}
 
-    # ---- id-style resolution (base-owned; Part B extends) ---------------
+    # ---- id-style resolution (base-owned) ------------------------------
+
+    def _is_convertible(self, model: dict | None) -> bool:
+        """Whether ``model`` could be written as an official id.
+
+        The auto-routing sentinel and entries carrying an explicit
+        ``wire_key``/``custom_key`` (e.g. Claude's injected 1M variants) are
+        never converted, so they never gate the prompt on.
+        """
+        if model is None or "wire_key" in model or "custom_key" in model:
+            return False
+        return self.is_native_family(_bare_upstream_model_id(model))
 
     def resolve_id_style(self, id_style: IdStyle | None, selected: list[dict | None]) -> IdStyle:
-        """Resolve the effective id style. Part A: always ``QUALIFIED``."""
-        return id_style or IdStyle.QUALIFIED
+        """Resolve the effective id style, prompting only when it matters.
+
+        An explicit ``id_style`` (from ``--id-style``) wins with no prompt.
+        Otherwise the interactive choice is offered only when at least one
+        selected model is convertible; if nothing is convertible the option is
+        meaningless, so we skip the prompt and stay ``QUALIFIED``.
+        """
+        if id_style is not None:
+            return id_style
+        if any(self._is_convertible(model) for model in selected):
+            choice = Prompt.ask(
+                "Model ID style — 'official' uses the vendor's native id the client "
+                "recognizes and may optimize for; 'qualified' is provider/model",
+                choices=[IdStyle.OFFICIAL.value, IdStyle.QUALIFIED.value],
+                default=IdStyle.QUALIFIED.value,
+            )
+            return IdStyle(choice)
+        return IdStyle.QUALIFIED
 
     def resolve_model_string(self, model: dict | None, id_style: IdStyle) -> str:
         """Resolve one selected model dict to the string written into config.
 
-        Part A always produces the provider-qualified wire key (or the
-        auto-routing sentinel). Part B adds official-id conversion here.
+        ``None`` -> the auto-routing sentinel. An explicit ``wire_key``/
+        ``custom_key`` (Claude 1M variants) is returned unchanged regardless of
+        style. Under ``OFFICIAL``, native models are converted to the vendor's
+        spelling; non-native models stay provider-qualified (with a warning),
+        since dropping the prefix would be meaningless for another vendor.
         """
         if model is None:
             return "router-maestro"
-        return _model_key(model)
+        if "wire_key" in model or "custom_key" in model:
+            return _model_key(model)
+        qualified = _model_key(model)
+        if id_style is IdStyle.QUALIFIED:
+            return qualified
+        bare = _bare_upstream_model_id(model)
+        if not self.is_native_family(bare):
+            console.print(
+                f"[yellow]{qualified} is not a native {self.display_name} model; "
+                f"keeping the provider-qualified id.[/yellow]"
+            )
+            return qualified
+        return self.to_official_id(bare)
 
     # ---- shared resolvers ----------------------------------------------
 

--- a/src/router_maestro/cli/client_configs/claude_code.py
+++ b/src/router_maestro/cli/client_configs/claude_code.py
@@ -22,6 +22,11 @@ from router_maestro.cli.client_configs.base import (
     _upstream_context_window,
     console,
 )
+from router_maestro.cli.client_configs.model_id import (
+    ModelFamily,
+    detect_family,
+    to_anthropic_official,
+)
 from router_maestro.routing.model_ref import qualify_model_id
 
 # Claude Code native model IDs for 1M context variants.
@@ -234,6 +239,12 @@ class ClaudeCodeConfig(ClientConfig):
             "User-level (~/.claude/settings.json)",
             "Project-level (./.claude/settings.json)",
         )
+
+    def is_native_family(self, bare_id: str) -> bool:
+        return detect_family(bare_id) is ModelFamily.ANTHROPIC
+
+    def to_official_id(self, bare_id: str) -> str:
+        return to_anthropic_official(bare_id)
 
     def load_models(self) -> list[dict]:
         # Import from base's module namespace so tests that patch

--- a/src/router_maestro/cli/client_configs/codex.py
+++ b/src/router_maestro/cli/client_configs/codex.py
@@ -13,6 +13,11 @@ from router_maestro.cli.client_configs.base import (
     GenerateContext,
     console,
 )
+from router_maestro.cli.client_configs.model_id import (
+    ModelFamily,
+    detect_family,
+    to_openai_official,
+)
 
 
 def get_codex_paths() -> dict[str, Path]:
@@ -60,6 +65,12 @@ class CodexConfig(ClientConfig):
             "User-level (~/.codex/config.toml)",
             "Project-level (./.codex/config.toml)",
         )
+
+    def is_native_family(self, bare_id: str) -> bool:
+        return detect_family(bare_id) is ModelFamily.OPENAI
+
+    def to_official_id(self, bare_id: str) -> str:
+        return to_openai_official(bare_id)
 
     def write(self, *, level: str, path: Path, models: list[str], ctx: GenerateContext) -> None:
         selected_model = models[0]

--- a/src/router_maestro/cli/client_configs/gemini.py
+++ b/src/router_maestro/cli/client_configs/gemini.py
@@ -11,6 +11,11 @@ from router_maestro.cli.client_configs.base import (
     GenerateContext,
     console,
 )
+from router_maestro.cli.client_configs.model_id import (
+    ModelFamily,
+    detect_family,
+    to_gemini_official,
+)
 
 
 def get_gemini_cli_paths() -> dict[str, Path]:
@@ -61,6 +66,12 @@ class GeminiConfig(ClientConfig):
             "User-level (~/.gemini/.env)",
             "Project-level (./.gemini/.env)",
         )
+
+    def is_native_family(self, bare_id: str) -> bool:
+        return detect_family(bare_id) is ModelFamily.GOOGLE
+
+    def to_official_id(self, bare_id: str) -> str:
+        return to_gemini_official(bare_id)
 
     def write(self, *, level: str, path: Path, models: list[str], ctx: GenerateContext) -> None:
         model_name = models[0]

--- a/src/router_maestro/cli/client_configs/model_id.py
+++ b/src/router_maestro/cli/client_configs/model_id.py
@@ -1,0 +1,65 @@
+"""Structural model-family detection and per-vendor official-id spelling.
+
+The optional "official model id" feature writes a vendor's native id (e.g.
+``gpt-4.1``, ``claude-opus-4-6``) instead of the internal ``provider/upstream``
+form. The conversion is derived from naming conventions — NOT a per-model lookup
+table — so new models work without code changes. Each client binds the family it
+considers native and the spelling function for that vendor.
+
+Vendors disagree on spelling: Anthropic uses dashes in version numbers
+(``claude-opus-4.6`` -> ``claude-opus-4-6``), while OpenAI and Google keep dots
+(``gpt-4.1`` stays, ``gemini-2.5-pro`` stays). That divergence is exactly why
+the conversion is bound per client rather than shared.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+from router_maestro.utils.model_match import normalize_model_identity
+
+
+class ModelFamily(StrEnum):
+    """Vendor family a model id belongs to, by naming convention."""
+
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    GOOGLE = "google"
+    UNKNOWN = "unknown"
+
+
+# OpenAI reasoning "o-series": o1/o3/o4 followed by a boundary (end, '-', or a
+# digit like o1 vs a hypothetical o10). Excludes words like "olmo"/"orca".
+_O_SERIES = re.compile(r"^o[1-9]\d*(?:-|$)")
+
+
+def detect_family(bare_id: str) -> ModelFamily:
+    """Classify a bare (un-prefixed) model id into its vendor family."""
+    s = bare_id.lower()
+    if s.startswith("claude"):
+        return ModelFamily.ANTHROPIC
+    if s.startswith("gpt") or s.startswith("codex") or _O_SERIES.match(s):
+        return ModelFamily.OPENAI
+    if s.startswith("gemini"):
+        return ModelFamily.GOOGLE
+    return ModelFamily.UNKNOWN
+
+
+def to_anthropic_official(bare_id: str) -> str:
+    """Anthropic official spelling: lowercase, dots become dashes.
+
+    ``normalize_model_identity`` also preserves date suffixes, which are part of
+    Anthropic's official dated ids (``claude-sonnet-4-20250514``).
+    """
+    return normalize_model_identity(bare_id)
+
+
+def to_openai_official(bare_id: str) -> str:
+    """OpenAI official spelling: the bare id as-is (dots kept)."""
+    return bare_id
+
+
+def to_gemini_official(bare_id: str) -> str:
+    """Google/Gemini official spelling: the bare id as-is (dots kept)."""
+    return bare_id

--- a/src/router_maestro/cli/config.py
+++ b/src/router_maestro/cli/config.py
@@ -6,14 +6,26 @@ picker, and a small back-compat re-export block.
 """
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich.prompt import Confirm, Prompt
 
-from router_maestro.cli.client_configs import get_client, list_clients
+from router_maestro.cli.client_configs import IdStyle, get_client, list_clients
 from router_maestro.cli.client_configs.base import console
 
 app = typer.Typer(invoke_without_command=True)
+
+_ID_STYLE_OPT = typer.Option(
+    "--id-style",
+    help=(
+        "Model id spelling: 'official' writes the vendor's native id (e.g. gpt-4.1, "
+        "claude-opus-4-6) that the client recognizes and may optimize for — only "
+        "applied to models of this client's native vendor, and it drops the "
+        "provider/ prefix (ambiguous if several providers share the id). "
+        "'qualified' (default) writes provider/model. Omit for an interactive prompt."
+    ),
+)
 
 
 @app.callback(invoke_without_command=True)
@@ -40,21 +52,21 @@ def config_callback(ctx: typer.Context) -> None:
 
 
 @app.command(name="claude-code")
-def claude_code_config() -> None:
+def claude_code_config(id_style: Annotated[IdStyle | None, _ID_STYLE_OPT] = None) -> None:
     """Generate Claude Code CLI settings.json for router-maestro."""
-    get_client("claude-code")().generate()
+    get_client("claude-code")().generate(id_style=id_style)
 
 
 @app.command(name="codex")
-def codex_config() -> None:
+def codex_config(id_style: Annotated[IdStyle | None, _ID_STYLE_OPT] = None) -> None:
     """Generate OpenAI Codex CLI config.toml for router-maestro."""
-    get_client("codex")().generate()
+    get_client("codex")().generate(id_style=id_style)
 
 
 @app.command(name="gemini")
-def gemini_cli_config() -> None:
+def gemini_cli_config(id_style: Annotated[IdStyle | None, _ID_STYLE_OPT] = None) -> None:
     """Generate Gemini CLI .env for router-maestro."""
-    get_client("gemini")().generate()
+    get_client("gemini")().generate(id_style=id_style)
 
 
 # --- back-compat re-exports -------------------------------------------------

--- a/tests/test_client_config_model_id.py
+++ b/tests/test_client_config_model_id.py
@@ -1,0 +1,80 @@
+"""Tests for the structural official-model-id primitives.
+
+The conversion from an internal ``provider/upstream-id`` to a vendor's official
+id is derived from naming conventions, NOT a per-model lookup table. These tests
+pin the family-detection rules and the per-vendor spelling conventions:
+Anthropic uses dashes (``claude-opus-4.6`` -> ``claude-opus-4-6``) while OpenAI
+and Google keep dots (``gpt-4.1`` stays, ``gemini-2.5-pro`` stays).
+"""
+
+import pytest
+
+from router_maestro.cli.client_configs.model_id import (
+    ModelFamily,
+    detect_family,
+    to_anthropic_official,
+    to_gemini_official,
+    to_openai_official,
+)
+
+
+class TestDetectFamily:
+    @pytest.mark.parametrize(
+        "bare_id,expected",
+        [
+            ("claude-opus-4.6", ModelFamily.ANTHROPIC),
+            ("claude-sonnet-4-20250514", ModelFamily.ANTHROPIC),
+            ("Claude-Haiku-4.5", ModelFamily.ANTHROPIC),
+            ("gpt-4.1", ModelFamily.OPENAI),
+            ("gpt-5.5", ModelFamily.OPENAI),
+            ("GPT-4o", ModelFamily.OPENAI),
+            ("o1", ModelFamily.OPENAI),
+            ("o3-mini", ModelFamily.OPENAI),
+            ("o4-preview", ModelFamily.OPENAI),
+            ("codex-mini-latest", ModelFamily.OPENAI),
+            ("gemini-2.5-pro", ModelFamily.GOOGLE),
+            ("Gemini-2.0-flash", ModelFamily.GOOGLE),
+            ("llama-3.1-70b", ModelFamily.UNKNOWN),
+            ("mistral-large", ModelFamily.UNKNOWN),
+            ("", ModelFamily.UNKNOWN),
+        ],
+    )
+    def test_detects_family_by_naming_convention(self, bare_id, expected):
+        assert detect_family(bare_id) is expected
+
+    def test_o_series_does_not_match_other_o_words(self):
+        # "olmo" / "orca" start with 'o' but are not the OpenAI o-series.
+        assert detect_family("olmo-7b") is ModelFamily.UNKNOWN
+        assert detect_family("orca-2") is ModelFamily.UNKNOWN
+
+
+class TestAnthropicOfficial:
+    def test_dot_becomes_dash(self):
+        assert to_anthropic_official("claude-opus-4.6") == "claude-opus-4-6"
+        assert to_anthropic_official("claude-sonnet-4.6") == "claude-sonnet-4-6"
+
+    def test_idempotent_on_already_dashed(self):
+        assert to_anthropic_official("claude-opus-4-6") == "claude-opus-4-6"
+
+    def test_preserves_dated_official_id(self):
+        # A dated Anthropic id is already official spelling.
+        assert to_anthropic_official("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
+
+    def test_lowercases(self):
+        assert to_anthropic_official("Claude-Opus-4.6") == "claude-opus-4-6"
+
+
+class TestOpenAIOfficial:
+    def test_keeps_dots(self):
+        assert to_openai_official("gpt-4.1") == "gpt-4.1"
+        assert to_openai_official("gpt-5.5") == "gpt-5.5"
+
+    def test_identity(self):
+        assert to_openai_official("o3-mini") == "o3-mini"
+        assert to_openai_official("gpt-4o") == "gpt-4o"
+
+
+class TestGeminiOfficial:
+    def test_keeps_dots_and_structure(self):
+        assert to_gemini_official("gemini-2.5-pro") == "gemini-2.5-pro"
+        assert to_gemini_official("gemini-2.0-flash") == "gemini-2.0-flash"

--- a/tests/test_client_config_official_id.py
+++ b/tests/test_client_config_official_id.py
@@ -1,0 +1,112 @@
+"""Tests for official-vs-qualified id resolution on ClientConfig.
+
+Covers ``resolve_model_string`` (per selected model) and ``resolve_id_style``
+(whether to prompt), including every edge the feature must honor: the
+auto-routing sentinel and explicit wire/custom keys are never converted;
+non-native families stay qualified even under OFFICIAL (with a warning); the
+interactive prompt is gated on there being something convertible.
+"""
+
+from rich.console import Console
+
+from router_maestro.cli.client_configs import base as cc_base
+from router_maestro.cli.client_configs.base import IdStyle
+from router_maestro.cli.client_configs.claude_code import ClaudeCodeConfig
+from router_maestro.cli.client_configs.codex import CodexConfig
+from router_maestro.cli.client_configs.gemini import GeminiConfig
+
+_GPT = {"provider": "github-copilot", "id": "gpt-5.5", "name": "GPT-5.5"}
+_CLAUDE = {"provider": "github-copilot", "id": "claude-opus-4.6", "name": "Claude Opus 4.6"}
+_GEMINI = {"provider": "github-copilot", "id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro"}
+_WIRE_1M = {
+    "provider": "github-copilot",
+    "id": "claude-opus-4.6",
+    "name": "Opus 4.6 1M",
+    "display_key": "claude-opus-4-6[1m]",
+    "wire_key": "github-copilot/claude-opus-4-6[1m]",
+}
+_CUSTOM = {
+    "provider": "github-copilot",
+    "id": "claude-opus-4.6-1m",
+    "name": "custom",
+    "custom_key": "claude-opus-4-6[1m]",
+}
+
+
+class TestResolveModelString:
+    def test_sentinel_never_converted(self):
+        assert CodexConfig().resolve_model_string(None, IdStyle.OFFICIAL) == "router-maestro"
+        assert CodexConfig().resolve_model_string(None, IdStyle.QUALIFIED) == "router-maestro"
+
+    def test_qualified_returns_provider_prefixed(self):
+        assert (
+            CodexConfig().resolve_model_string(_GPT, IdStyle.QUALIFIED) == "github-copilot/gpt-5.5"
+        )
+
+    def test_official_native_openai_keeps_dots_unprefixed(self):
+        assert CodexConfig().resolve_model_string(_GPT, IdStyle.OFFICIAL) == "gpt-5.5"
+
+    def test_official_native_anthropic_dashes(self):
+        assert (
+            ClaudeCodeConfig().resolve_model_string(_CLAUDE, IdStyle.OFFICIAL) == "claude-opus-4-6"
+        )
+
+    def test_official_native_gemini_keeps_dots(self):
+        assert GeminiConfig().resolve_model_string(_GEMINI, IdStyle.OFFICIAL) == "gemini-2.5-pro"
+
+    def test_official_non_native_stays_qualified_and_warns(self, monkeypatch):
+        rec = Console(record=True, width=120)
+        monkeypatch.setattr(cc_base, "console", rec)
+        # Codex is OpenAI-native; a Claude model must NOT be converted.
+        result = CodexConfig().resolve_model_string(_CLAUDE, IdStyle.OFFICIAL)
+        assert result == "github-copilot/claude-opus-4.6"
+        assert "not a native" in rec.export_text()
+
+    def test_official_wire_key_entry_untouched(self):
+        # Claude 1M injected entry: explicit wire_key must survive OFFICIAL mode.
+        assert (
+            ClaudeCodeConfig().resolve_model_string(_WIRE_1M, IdStyle.OFFICIAL)
+            == "github-copilot/claude-opus-4-6[1m]"
+        )
+
+    def test_official_custom_key_entry_untouched(self):
+        assert (
+            ClaudeCodeConfig().resolve_model_string(_CUSTOM, IdStyle.OFFICIAL)
+            == "claude-opus-4-6[1m]"
+        )
+
+
+class TestResolveIdStyle:
+    def test_cli_option_wins_no_prompt(self, monkeypatch):
+        def boom(*a, **kw):
+            raise AssertionError("prompt must not be shown when id_style is explicit")
+
+        monkeypatch.setattr(cc_base.Prompt, "ask", boom)
+        assert CodexConfig().resolve_id_style(IdStyle.OFFICIAL, [_GPT]) is IdStyle.OFFICIAL
+        assert CodexConfig().resolve_id_style(IdStyle.QUALIFIED, [_GPT]) is IdStyle.QUALIFIED
+
+    def test_prompts_when_convertible_and_none(self, monkeypatch):
+        monkeypatch.setattr(cc_base.Prompt, "ask", lambda *a, **kw: "official")
+        assert CodexConfig().resolve_id_style(None, [_GPT]) is IdStyle.OFFICIAL
+
+    def test_prompt_default_qualified(self, monkeypatch):
+        # Simulate the user pressing enter → Prompt.ask returns the default it was given.
+        monkeypatch.setattr(cc_base.Prompt, "ask", lambda *a, **kw: kw.get("default"))
+        assert CodexConfig().resolve_id_style(None, [_GPT]) is IdStyle.QUALIFIED
+
+    def test_no_prompt_when_nothing_convertible(self, monkeypatch):
+        def boom(*a, **kw):
+            raise AssertionError("prompt must not be shown when nothing is convertible")
+
+        monkeypatch.setattr(cc_base.Prompt, "ask", boom)
+        # Codex + a Claude model (non-native) → no option offered.
+        assert CodexConfig().resolve_id_style(None, [_CLAUDE]) is IdStyle.QUALIFIED
+        # Only the auto-routing sentinel selected → nothing to convert.
+        assert CodexConfig().resolve_id_style(None, [None]) is IdStyle.QUALIFIED
+        # Wire-key entry is not convertible.
+        assert ClaudeCodeConfig().resolve_id_style(None, [_WIRE_1M]) is IdStyle.QUALIFIED
+
+    def test_prompts_when_any_selected_is_convertible(self, monkeypatch):
+        # Claude Code picking a native main + non-native fast still offers the option.
+        monkeypatch.setattr(cc_base.Prompt, "ask", lambda *a, **kw: "official")
+        assert ClaudeCodeConfig().resolve_id_style(None, [_CLAUDE, _GPT]) is IdStyle.OFFICIAL

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from router_maestro.cli import config as cli_config
 from router_maestro.cli.client_configs import base as cc_base
 from router_maestro.cli.client_configs import claude_code as cc_claude
+from router_maestro.cli.client_configs.base import IdStyle
 from router_maestro.cli.config import (
     _OPUS_1M_NATIVE_KEY,
     _OPUS_1M_SOURCE_MODEL,
@@ -802,7 +803,7 @@ class TestCodexConfig:
         """User-level scope writes ``model``, ``model_provider``, and the provider table."""
         home, _ = _setup_codex_env(monkeypatch, tmp_path, level_choice="1")
 
-        cli_config.codex_config()
+        cli_config.codex_config(id_style=IdStyle.QUALIFIED)
 
         user_path = home / ".codex" / "config.toml"
         assert user_path.exists()
@@ -826,7 +827,7 @@ class TestCodexConfig:
             lambda: _qualified_server_models(),
         )
 
-        cli_config.codex_config()
+        cli_config.codex_config(id_style=IdStyle.QUALIFIED)
 
         with open(home / ".codex" / "config.toml", "rb") as f:
             data = tomllib.load(f)
@@ -836,7 +837,7 @@ class TestCodexConfig:
         """Project-level scope must NOT write ``model_provider``/``model_providers``."""
         _, cwd = _setup_codex_env(monkeypatch, tmp_path, level_choice="2")
 
-        cli_config.codex_config()
+        cli_config.codex_config(id_style=IdStyle.QUALIFIED)
 
         project_path = cwd / ".codex" / "config.toml"
         assert project_path.exists()
@@ -868,7 +869,7 @@ class TestCodexConfig:
         with open(project_path, "w", encoding="utf-8") as f:
             f.write(tomlkit.dumps(stale))
 
-        cli_config.codex_config()
+        cli_config.codex_config(id_style=IdStyle.QUALIFIED)
 
         with open(project_path, "rb") as f:
             data = tomllib.load(f)
@@ -898,7 +899,7 @@ class TestCodexConfig:
         with open(project_path, "w", encoding="utf-8") as f:
             f.write(tomlkit.dumps(seed))
 
-        cli_config.codex_config()
+        cli_config.codex_config(id_style=IdStyle.QUALIFIED)
 
         with open(project_path, "rb") as f:
             data = tomllib.load(f)
@@ -924,7 +925,7 @@ def test_claude_config_qualified_models_write_single_prefix_and_offer_beta(
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
     monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
 
-    cli_config.claude_code_config()
+    cli_config.claude_code_config(id_style=IdStyle.QUALIFIED)
 
     data = json.loads((home / ".claude" / "settings.json").read_text(encoding="utf-8"))
     assert data["env"]["ANTHROPIC_MODEL"] == "github-copilot/claude-opus-4.6"
@@ -957,7 +958,7 @@ def test_claude_config_writes_provider_qualified_native_1m_key(tmp_path, monkeyp
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
     monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
 
-    cli_config.claude_code_config()
+    cli_config.claude_code_config(id_style=IdStyle.QUALIFIED)
 
     data = json.loads((home / ".claude" / "settings.json").read_text(encoding="utf-8"))
     assert data["env"]["ANTHROPIC_MODEL"] == f"github-copilot/{_OPUS_1M_NATIVE_KEY}"
@@ -979,7 +980,138 @@ def test_gemini_config_qualified_model_preserves_public_id(tmp_path, monkeypatch
     monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
     monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
 
-    cli_config.gemini_cli_config()
+    cli_config.gemini_cli_config(id_style=IdStyle.QUALIFIED)
 
     env = cli_config._parse_env_file(home / ".gemini" / ".env")
     assert env["GEMINI_MODEL"] == "github-copilot/gemini-2.5-pro"
+
+
+class TestOfficialIdStyleEndToEnd:
+    """End-to-end ``--id-style official`` behavior through the command functions.
+
+    The existing integration tests above pin ``IdStyle.QUALIFIED`` and assert the
+    provider-qualified output. These cover the OFFICIAL path: native models are
+    converted to the vendor's spelling, non-native models stay qualified, and
+    injected 1M keys survive untouched.
+    """
+
+    def test_codex_official_writes_unprefixed_gpt(self, tmp_path, monkeypatch):
+        home, _ = _setup_codex_env(monkeypatch, tmp_path, level_choice="1", model_choice="1")
+
+        cli_config.codex_config(id_style=IdStyle.OFFICIAL)
+
+        with open(home / ".codex" / "config.toml", "rb") as f:
+            data = tomllib.load(f)
+        # gpt-5.5 is OpenAI-native → official id drops the provider prefix, keeps dots.
+        assert data["model"] == "gpt-5.5"
+
+    def test_codex_official_non_native_claude_stays_qualified(self, tmp_path, monkeypatch):
+        # Select the Claude model (index 2) while configuring Codex (OpenAI-native).
+        home, _ = _setup_codex_env(monkeypatch, tmp_path, level_choice="1", model_choice="2")
+
+        cli_config.codex_config(id_style=IdStyle.OFFICIAL)
+
+        with open(home / ".codex" / "config.toml", "rb") as f:
+            data = tomllib.load(f)
+        # Claude is not OpenAI-native → must NOT be converted; provider prefix kept.
+        assert data["model"] == "github-copilot/claude-opus-4.6"
+
+    def test_gemini_official_writes_unprefixed_gemini(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(
+            cc_base,
+            "_fetch_and_display_models",
+            lambda: [_qualified_server_models()[2]],
+        )
+        monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
+        monkeypatch.setattr(cc_base, "get_current_context_api_key", lambda: "test-key")
+        answers = iter(["1", "1"])
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
+        monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
+
+        cli_config.gemini_cli_config(id_style=IdStyle.OFFICIAL)
+
+        env = cli_config._parse_env_file(home / ".gemini" / ".env")
+        # gemini-2.5-pro is Google-native → official id drops prefix, keeps dots.
+        assert env["GEMINI_MODEL"] == "gemini-2.5-pro"
+
+    def test_claude_official_converts_dots_to_dashes(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(
+            cc_base,
+            "_fetch_models",
+            lambda: [
+                {"provider": "github-copilot", "id": "claude-opus-4.6", "name": "Claude Opus 4.6"},
+                {"provider": "github-copilot", "id": "gpt-5.5", "name": "GPT-5.5"},
+            ],
+        )
+        monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
+        monkeypatch.setattr(cc_base, "get_current_context_api_key", lambda: "test-key")
+        monkeypatch.setattr(cc_claude, "_prompt_auto_compact_window", lambda _model: None)
+        monkeypatch.setattr(cc_claude, "_prompt_endpoint_mode", lambda _model: False)
+        # main=1 (claude), fast=2 (gpt); no id-style prompt (explicit OFFICIAL).
+        answers = iter(["1", "1", "2"])
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
+        monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
+
+        cli_config.claude_code_config(id_style=IdStyle.OFFICIAL)
+
+        data = json.loads((home / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        # Claude main → Anthropic official (dashes); GPT fast is non-native → stays qualified.
+        assert data["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-6"
+        assert data["env"]["ANTHROPIC_SMALL_FAST_MODEL"] == "github-copilot/gpt-5.5"
+
+    def test_claude_official_preserves_injected_1m_wire_key(self, tmp_path, monkeypatch):
+        """The injected 1M entry carries an explicit wire_key that must survive
+        OFFICIAL mode untouched (converting it would mangle the ``[1m]`` suffix)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(cli_config.Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setattr(cli_config.Path, "cwd", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(
+            cc_base,
+            "_fetch_models",
+            lambda: [
+                {
+                    "provider": "github-copilot",
+                    "id": "claude-opus-4.6",
+                    "name": "Claude Opus 4.6",
+                    "max_context_window_tokens": 1_000_000,
+                }
+            ],
+        )
+        monkeypatch.setattr(cc_base, "get_admin_client", lambda: _StubAdminClient())
+        monkeypatch.setattr(cc_base, "get_current_context_api_key", lambda: "test-key")
+        monkeypatch.setattr(cc_claude, "_prompt_auto_compact_window", lambda _model: None)
+        monkeypatch.setattr(cc_claude, "_prompt_endpoint_mode", lambda _model: False)
+        # level=1 (user), main=1 (injected 1M variant), fast=2 (base claude-opus-4.6).
+        answers = iter(["1", "1", "2"])
+        monkeypatch.setattr(cli_config.Prompt, "ask", lambda *a, **kw: next(answers))
+        monkeypatch.setattr(cli_config.Confirm, "ask", lambda *a, **kw: False)
+
+        cli_config.claude_code_config(id_style=IdStyle.OFFICIAL)
+
+        data = json.loads((home / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        # Injected main keeps its explicit provider-qualified wire_key…
+        assert data["env"]["ANTHROPIC_MODEL"] == f"github-copilot/{_OPUS_1M_NATIVE_KEY}"
+        # …while the plain native fast model is converted to official dashes.
+        assert data["env"]["ANTHROPIC_SMALL_FAST_MODEL"] == "claude-opus-4-6"
+
+    def test_codex_no_id_style_prompt_when_non_native_selected(self, tmp_path, monkeypatch):
+        """Configuring Codex and picking a Claude model must NOT offer the option
+        (nothing convertible), so the answer iterator only needs level + model."""
+        home, _ = _setup_codex_env(monkeypatch, tmp_path, level_choice="1", model_choice="2")
+
+        # id_style=None → interactive resolution; with only a non-native model the
+        # prompt must be skipped. If it fired, the 2-item iterator would StopIteration.
+        cli_config.codex_config(id_style=None)
+
+        with open(home / ".codex" / "config.toml", "rb") as f:
+            data = tomllib.load(f)
+        assert data["model"] == "github-copilot/claude-opus-4.6"


### PR DESCRIPTION
## Summary

Adds an opt-in **official model id** choice to `router-maestro config`. Instead
of the internal `github-copilot/gpt-4.1`, users can now write the vendor's
official id `gpt-4.1` — which the client/TUI recognizes natively and may
optimize for. The provider-qualified form remains the default (unambiguous when
several providers serve the same upstream id).

This is **Part B**, built on the `ClientConfig` abstraction from #143.

## How it works

- **`--id-style official|qualified`** CLI option **and** an interactive prompt.
  Default = `qualified` (current behavior); `official` is opt-in.
- The interactive prompt appears **only when a selected model is convertible** —
  i.e. belongs to the client's native vendor (Codex↔OpenAI, Claude Code↔Anthropic,
  Gemini↔Google) and isn't an injected 1M `wire_key` entry or the auto-routing
  sentinel. Configuring Codex with a Claude model shows no prompt.
- **Conversion is structural, not a per-model table** (`model_id.py`):
  `detect_family` classifies by naming convention, then each client applies its
  vendor's spelling rule — Anthropic uses dashes (`claude-opus-4.6` →
  `claude-opus-4-6`, via the existing `normalize_model_identity`); OpenAI and
  Google keep dots (`gpt-4.1`, `gemini-2.5-pro` unchanged). Each client owns its
  own family + spelling binding.
- **Edges honored**: non-native models under `official` stay provider-qualified
  (with a warning); the `router-maestro` sentinel and Claude's injected 1M
  `wire_key`/`custom_key` entries are never converted.

## Trade-off (documented in `--help`)

Official ids drop the `provider/` prefix, so if two providers serve the same
upstream id the official form can fuzzy-match ambiguously at routing time. This
is why `qualified` stays the default and `official` is opt-in.

## Testing

- New: `tests/test_client_config_model_id.py` (family detection + per-vendor
  spelling), `tests/test_client_config_official_id.py` (resolve_id_style /
  resolve_model_string edges), and `TestOfficialIdStyleEndToEnd` in
  `tests/test_config.py` (full `--id-style official` through each command).
- Existing qualified-output integration tests pinned to `id_style=QUALIFIED` so
  the new prompt doesn't change their assertions.
- Full suite: **3604 passed**; `ruff check` + `format` clean.
- Verified end-to-end via `CliRunner`: interactive prompt appears for native
  models, `official` → unprefixed, blank/enter → qualified default; `--id-style
  official` non-interactive suppresses the prompt.
- Independent review (Codex CLI down): traced o-series regex, bare-id stripping,
  resolution ordering, prompt-gating alignment, and default-path byte-identity —
  no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)