### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.7.2 (2026-07-16)
+
+### Features
+
+- **Optional official model id in generated client configs.** `router-maestro
+  config` (claude-code / codex / gemini) can now write a model's official vendor
+  id — `gpt-4.1`, `claude-opus-4-6`, `gemini-2.5-pro` — instead of the internal
+  `provider/model` form, so the client/TUI recognizes it natively. Opt in with
+  the new `--id-style official` flag or the interactive prompt; the default
+  stays `qualified` (`provider/model`), which remains unambiguous when several
+  providers serve the same upstream id. The option is offered only for models of
+  the client's native vendor (Codex↔OpenAI, Claude Code↔Anthropic, Gemini↔Google),
+  and the conversion is derived from each vendor's naming convention rather than
+  a hardcoded per-model table (Anthropic uses dashes, OpenAI/Google keep dots).
+
+### Changes
+
+- **Per-client config-generation abstraction.** The `router-maestro config`
+  command internals are refactored so each supported client owns its entire
+  generation flow behind a `ClientConfig` abstraction. Adding a new client is now
+  a single focused module plus one registry entry. Behavior-preserving: the
+  generated config files are byte-identical to v0.7.1.
+
 ## v0.7.1 (2026-07-15)
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.7.1"
+version = "0.7.2"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Release v0.7.2.

Bundles the two merged config-generation PRs into one release:

- **#143** — per-client `ClientConfig` abstraction (behavior-preserving refactor
  of `router-maestro config` internals).
- **#144** — opt-in official model id in generated client configs
  (`--id-style official|qualified` + interactive prompt).

### Release checklist
- [x] `pyproject.toml` → 0.7.2
- [x] `src/router_maestro/__init__.py` → 0.7.2
- [x] `uv lock` updated (router-maestro 0.7.1 → 0.7.2)
- [x] CHANGELOG entry
- [x] Full suite: 3604 passed; ruff clean

Merging + pushing the `v0.7.2` tag triggers the GHA Release workflow
(PyPI + Docker + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)