### PR TITLE
fix: preserve namespace inner tools; drop unsupported Responses tools

### DIFF
--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -443,13 +443,10 @@ class CopilotOutboundContract(OutboundContract):
                     )
             elif tool_type not in self._RESPONSES_UNSUPPORTED_TOOL_TYPES:
                 validated.append(tool)
-            else:
-                raise RequestOptionError(
-                    f"GitHub Copilot does not support Responses tool type '{tool_type}'",
-                    provider="github-copilot",
-                    model=model,
-                    parameter="tools",
-                )
+            # else: silently drop tools Copilot Responses cannot express
+            # (web_search, web_search_preview, code_interpreter). Clients like
+            # Codex inject these unconditionally; 400-ing the whole request over
+            # a tool the backend can't run is worse than dropping it.
         return validated or None
 
     def allows_temperature(self, operation: Operation) -> bool:

--- a/src/router_maestro/server/schemas/responses.py
+++ b/src/router_maestro/server/schemas/responses.py
@@ -75,13 +75,24 @@ class ResponsesFunctionParameters(BaseModel):
 
 
 class ResponsesFunctionTool(BaseModel):
-    """A function tool definition."""
+    """A function tool definition.
+
+    ``extra="allow"`` and the explicit ``tools`` field are critical for
+    ``type="namespace"`` wrappers: Codex groups MCP servers as
+    ``{type: "namespace", name, description, tools: [...]}``. Without them the
+    union coerces the wrapper into this model and silently drops the inner
+    ``tools`` registry, so ``filter_tools`` then sees an empty namespace and
+    rejects the request with "namespace tools ... non-empty".
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     type: str = "function"
-    name: str
+    name: str | None = None
     description: str | None = None
     parameters: dict[str, Any] | None = None
     strict: bool | None = None
+    tools: list[dict[str, Any]] | None = None
 
 
 class ResponsesToolChoiceFunction(BaseModel):

--- a/tests/test_copilot_tool_filter.py
+++ b/tests/test_copilot_tool_filter.py
@@ -74,33 +74,30 @@ class TestFilterUnsupportedTools:
         "tool_type",
         ["web_search", "web_search_preview", "code_interpreter"],
     )
-    def test_rejects_unsupported_tool_types(self, tool_type):
-        with pytest.raises(RequestOptionError) as caught:
-            self.provider._build_responses_payload(
-                ResponsesRequest(
-                    model="gpt-5.4",
-                    input="hi",
-                    tools=[{"type": tool_type}],
-                )
+    def test_drops_unsupported_tool_types(self, tool_type):
+        # Copilot Responses cannot express these; they are silently dropped
+        # rather than 400-ing the whole request (Codex injects web_search
+        # unconditionally). With no other tools the payload carries none.
+        payload = self.provider._build_responses_payload(
+            ResponsesRequest(
+                model="gpt-5.4",
+                input="hi",
+                tools=[{"type": tool_type}],
             )
+        )
+        assert "tools" not in payload
 
-        assert caught.value.kind is ProviderFailureKind.CLIENT_REQUEST
-        assert caught.value.parameter == "tools"
-        assert caught.value.model == "gpt-5.4"
-
-    def test_mixed_supported_and_unsupported_tools_rejects_entire_request(self):
+    def test_mixed_supported_and_unsupported_tools_drops_only_unsupported(self):
         tools = [
             {"type": "function", "name": "lookup", "parameters": {}},
             {"type": "web_search"},
         ]
 
-        with pytest.raises(RequestOptionError) as caught:
-            self.provider._build_responses_payload(
-                ResponsesRequest(model="gpt-5.4", input="hi", tools=tools)
-            )
+        payload = self.provider._build_responses_payload(
+            ResponsesRequest(model="gpt-5.4", input="hi", tools=tools)
+        )
 
-        assert caught.value.parameter == "tools"
-        assert caught.value.model == "gpt-5.4"
+        assert payload["tools"] == [{"type": "function", "name": "lookup", "parameters": {}}]
 
     def test_keeps_unknown_non_function_types(self):
         # denylist semantics: anything not in UNSUPPORTED_TOOL_TYPES passes through

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -130,26 +130,32 @@ def test_copilot_resolve_reasoning_responses_unsupported_model_rejects():
 # --- Round 2: tool filtering + temperature verdict ---
 
 
-def test_copilot_filter_tools_keeps_function_rejects_web_search():
-    import pytest
-
-    from router_maestro.providers import RequestOptionError
-
+def test_copilot_filter_tools_keeps_function_drops_web_search():
     c = _copilot_contract()
     # A function tool and an unknown/other type are kept; a known-unsupported
-    # type raises (behavior preserved from filter_unsupported_tools).
+    # type (web_search) is silently dropped rather than rejected, so clients
+    # like Codex that inject it unconditionally still get their other tools.
     kept = c.filter_tools(
         [{"type": "function", "name": "echo"}, {"type": "custom_future"}],
         operation=Operation.RESPONSES,
         model="github-copilot/gpt-5.5",
     )
     assert kept == [{"type": "function", "name": "echo"}, {"type": "custom_future"}]
-    with pytest.raises(RequestOptionError):
-        c.filter_tools(
-            [{"type": "web_search"}],
-            operation=Operation.RESPONSES,
-            model="github-copilot/gpt-5.5",
-        )
+
+    mixed = c.filter_tools(
+        [{"type": "function", "name": "echo"}, {"type": "web_search"}],
+        operation=Operation.RESPONSES,
+        model="github-copilot/gpt-5.5",
+    )
+    assert mixed == [{"type": "function", "name": "echo"}]
+
+    # web_search alone leaves nothing → None
+    only_unsupported = c.filter_tools(
+        [{"type": "web_search"}],
+        operation=Operation.RESPONSES,
+        model="github-copilot/gpt-5.5",
+    )
+    assert only_unsupported is None
 
 
 def test_copilot_filter_tools_rejects_empty_namespace():

--- a/tests/test_protocol_error_envelopes.py
+++ b/tests/test_protocol_error_envelopes.py
@@ -1780,7 +1780,7 @@ def test_responses_unsupported_tools_use_native_400(client: TestClient) -> None:
             json={
                 "model": "m",
                 "input": "hi",
-                "tools": [{"type": "web_search"}],
+                "tools": [{"type": "namespace", "name": "mcp__empty__", "tools": []}],
             },
         )
 

--- a/tests/test_provider_option_fidelity.py
+++ b/tests/test_provider_option_fidelity.py
@@ -592,7 +592,7 @@ def test_copilot_tool_prevalidation_replaces_incompatible_fallback_without_spend
     request = ResponsesRequest(
         model="router-maestro",
         input="hi",
-        tools=[{"type": "web_search"}],
+        tools=[{"type": "namespace", "name": "mcp__empty__", "tools": []}],
     )
 
     validated = Router.prevalidate_plan(


### PR DESCRIPTION
## Summary

Two fixes for the OpenAI Responses path (Codex / ChatGPT via `wire_api=responses`):

1. **Namespace inner tools were stripped at the request boundary.** `ResponsesFunctionTool` lacked `extra="allow"` and a `tools` field, so the Pydantic union coerced `type="namespace"` wrappers (Codex's MCP registry shape) into it and dropped the inner `tools` array. `filter_tools` then saw an empty namespace and rejected the whole request with `GitHub Copilot requires namespace tools to contain a non-empty tools list` — even though the real payload carried populated registries (`mcp__ado`=33, `mcp__icm`=36, …). Fix: add `extra="allow"`, an explicit `tools` field, and relax `name` to optional.

2. **Unsupported Responses tool types now dropped instead of 400.** `filter_tools` used to raise on `web_search` / `web_search_preview` / `code_interpreter`. Codex injects `web_search` unconditionally (even with it disabled in config), so every turn 400'd. These are now silently dropped — Copilot can't run them anyway, and failing the whole request is worse.

## Root cause detail

Verified against a real failing request via audit traces: 9 namespace wrappers all carried non-empty inner tools in the inbound body, but after schema parsing every `inner_tools` was `None`. The `web_search` tool that superficially looked like the culprit was actually just downstream of the namespace loop — `filter_tools` never reached it because it raised on the first namespace.

## Test plan

- [x] Reparse the real failing trace through the patched schema → all 9 namespaces retain inner tools (`STILL-BAD: []`)
- [x] `filter_tools` drops `web_search`, keeps namespaces (20 in → 19 out)
- [x] Updated `test_copilot_filter_tools_*` to assert drop-not-raise
- [x] Contract + schema regression: 168 passed
- [x] End-to-end via local image + Codex CLI: `POST /api/openai/v1/responses` → **200 completed**, upstream payload has web_search dropped and all namespaces intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)