### PR TITLE
chore: release v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.7.4 (2026-07-21)
+
+### Fixes
+
+- **Responses tool compatibility.** Preserve the inner `tools` arrays in Codex
+  namespace/MCP wrappers through schema parsing, so populated registries no longer
+  look empty and fail validation. Copilot-unsupported Responses tools
+  (`web_search`, `web_search_preview`, `code_interpreter`) are now silently
+  dropped instead of rejecting the entire request, allowing clients that inject
+  them by default to continue.
+- **Native Anthropic beta stream keepalives.** Prime planned Copilot streams
+  inside the SSE keepalive wrapper and emit an eager ping plus recurring pings
+  during long first-frame waits. Claude Code no longer hits its 300-second idle
+  timeout on large-context `[1m]` requests; failures after the stream commits
+  surface as sanitized SSE error events.
+- **Scoped thinking-budget downgrades.** Allow the caller-scoped primary candidate
+  to proceed when per-candidate budget adaptation disables thinking because
+  `max_tokens` leaves no budget headroom. This prevents a spurious HTTP 400 on
+  reasoning-capable models while retaining reasoning-drift guards for fallbacks
+  and unscoped requests.
+
 ## v0.7.3 (2026-07-17)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.7.3"
+version = "0.7.4"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- bump Router-Maestro from 0.7.3 to 0.7.4 across package metadata and lockfile
- document Responses tool compatibility, Anthropic beta stream keepalives, and scoped thinking-budget downgrade fixes
- prepare the master commit for the v0.7.4 release tag

## Verification

- `uv lock --check`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/ -q` (3458 passed)
- `uv build`
- verified wheel/sdist metadata and package `__version__` are 0.7.4