### PR TITLE
refactor: apply OutboundContract protections on beta passthrough routes

### DIFF
--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -44,7 +44,9 @@ from router_maestro.providers.copilot_support.transport import CopilotTransport
 from router_maestro.providers.outbound_contract import OutboundContract, ReasoningResolution
 from router_maestro.routing.capabilities import Operation, ProviderCapabilities
 from router_maestro.utils import get_logger
+from router_maestro.utils.context_window import resolve_thinking_budget
 from router_maestro.utils.reasoning import (
+    VALID_EFFORTS,
     budget_to_effort,
     downgrade_for_upstream,
     pick_closest_effort,
@@ -452,6 +454,189 @@ class CopilotOutboundContract(OutboundContract):
     def allows_temperature(self, operation: Operation) -> bool:
         """Copilot Responses rejects explicit temperature; Chat forwards it."""
         return operation not in (Operation.RESPONSES, Operation.RESPONSES_STREAM)
+
+    # ------------------------------------------------------------------
+    # Native Anthropic passthrough normalization (folded in from the beta
+    # Anthropic route). These own the outbound wire knowledge; the route keeps
+    # thin seams that delegate here. Kept as staticmethods because they carry no
+    # instance state and are Copilot-native-Anthropic specific.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def sanitize_output_config(body: dict) -> str | None:
+        """Keep only a valid effort supported by Copilot's native endpoint."""
+        output_config = body.get("output_config")
+        if not isinstance(output_config, dict):
+            body.pop("output_config", None)
+            return None
+
+        effort = output_config.get("effort")
+        if effort not in VALID_EFFORTS:
+            body.pop("output_config", None)
+            return None
+
+        body["output_config"] = {"effort": effort}
+        return effort
+
+    @staticmethod
+    def resolve_native_effort(
+        effort: str,
+        allowed: tuple[str, ...] | list[str] | None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> str:
+        """Resolve a native effort exactly or downward, preserving unknown catalogs.
+
+        The native passthrough resolves ``output_config.effort`` with its own
+        catalog-or-passthrough rule (distinct error surface and no family fallback),
+        so it is intentionally NOT routed through ``resolve_reasoning`` (the
+        chat/responses orchestration). Both share the ``pick_closest_effort``
+        primitive as the single source of the downgrade math.
+        """
+        if allowed is None:
+            return effort
+        mapped_effort = pick_closest_effort(effort, list(allowed))
+        if mapped_effort is None:
+            raise RequestOptionError(
+                "output_config.effort has no supported tier at or below the requested tier",
+                parameter="output_config.effort",
+                provider=provider,
+                model=model,
+            )
+        return mapped_effort
+
+    @staticmethod
+    def reject_unpreservable_native_options(body: dict) -> None:
+        """Reject native Anthropic options the transport cannot preserve together."""
+        if "temperature" in body and "top_p" in body:
+            raise RequestOptionError(
+                "top_p cannot be combined with temperature on the native Anthropic transport",
+                parameter="top_p",
+            )
+
+    @staticmethod
+    def apply_native_anthropic_thinking(
+        body: dict,
+        actual_model: str,
+        reasoning_effort_values: tuple[str, ...] | list[str] | None = None,
+    ) -> dict:
+        """Apply effort precedence or the server budget fallback to a raw body.
+
+        Explicit ``output_config.effort`` removes an adaptive thinking budget.
+        Manual enabled thinking retains a normalized budget, using the server
+        fallback when the client omits it. Without effort, budget resolution is
+        unchanged.
+        """
+        effort = CopilotOutboundContract.sanitize_output_config(body)
+        client_thinking = body.get("thinking")
+
+        model_router = None
+        model_info = None
+
+        if effort is not None:
+            effort = CopilotOutboundContract.resolve_native_effort(
+                effort,
+                reasoning_effort_values,
+                provider="github-copilot",
+                model=actual_model,
+            )
+            body["output_config"] = {"effort": effort}
+
+        if isinstance(client_thinking, dict) and client_thinking.get("type") == "adaptive":
+            thinking = dict(client_thinking)
+            thinking.pop("budget_tokens", None)
+            body["thinking"] = thinking
+            return body
+
+        if effort is not None:
+            if not (
+                isinstance(client_thinking, dict)
+                and client_thinking.get("type") in ("enabled", "disabled")
+            ):
+                return body
+
+        from router_maestro.runtime import get_current_request_context
+
+        context = get_current_request_context()
+        if context is not None:
+            priorities = context.config
+        else:
+            from router_maestro.config import load_priorities_config
+
+            priorities = load_priorities_config()
+        thinking_config = priorities.thinking
+
+        client_budget = None
+        client_type = None
+        if isinstance(client_thinking, dict):
+            client_budget = client_thinking.get("budget_tokens")
+            client_type = client_thinking.get("type")
+
+        if model_router is None:
+            from router_maestro.routing import get_router
+
+            model_router = get_router()
+        if model_info is None and hasattr(model_router, "_models_cache"):
+            cache_entry = model_router._models_cache.get(actual_model)
+            if cache_entry:
+                _, model_info = cache_entry
+
+        supports_thinking = model_info.supports_thinking if model_info else True
+        max_output = (model_info.max_output_tokens or 16384) if model_info else 16384
+        request_max_output = body.get("max_tokens")
+        if isinstance(request_max_output, int):
+            max_output = min(max_output, request_max_output)
+
+        budget, thinking_type = resolve_thinking_budget(
+            client_budget=client_budget,
+            client_thinking_type=client_type,
+            model_id=actual_model,
+            max_output_tokens=max_output,
+            thinking_config=thinking_config,
+            supports_thinking=supports_thinking,
+        )
+
+        if thinking_type == "adaptive":
+            adaptive = dict(client_thinking) if isinstance(client_thinking, dict) else {}
+            adaptive["type"] = "adaptive"
+            adaptive.pop("budget_tokens", None)
+            body["thinking"] = adaptive
+            if budget != client_budget or thinking_type != client_type:
+                logger.debug(
+                    "Thinking budget adjusted: %s/%s -> %s/%s for model=%s",
+                    client_type,
+                    client_budget,
+                    thinking_type,
+                    budget,
+                    actual_model,
+                )
+        elif thinking_type == "enabled" and budget is not None:
+            enabled = dict(client_thinking) if isinstance(client_thinking, dict) else {}
+            enabled["type"] = "enabled"
+            enabled["budget_tokens"] = budget
+            body["thinking"] = enabled
+            if budget != client_budget or thinking_type != client_type:
+                logger.debug(
+                    "Thinking budget adjusted: %s/%s -> %s/%s for model=%s",
+                    client_type,
+                    client_budget,
+                    thinking_type,
+                    budget,
+                    actual_model,
+                )
+        else:
+            body.pop("thinking", None)
+            if client_type is not None:
+                logger.debug(
+                    "Thinking removed: client had %s/%s, resolved to %s for model=%s",
+                    client_type,
+                    client_budget,
+                    thinking_type,
+                    actual_model,
+                )
+
+        return body
 
 
 class CopilotProvider(BaseProvider):

--- a/src/router_maestro/providers/outbound_contract.py
+++ b/src/router_maestro/providers/outbound_contract.py
@@ -1,10 +1,19 @@
 """Provider-bound knowledge of what an upstream will accept on the wire.
 
-Round 1 governs only the raw-passthrough forward path (currently the beta
-native Anthropic route): which top-level fields survive the strip before the
-body is sent upstream. Round 2 will grow this contract with per-option value
-reconciliation (downgrade/drop/reject) and tool filtering, migrating the rules
-currently scattered across each provider's ``_build_payload``.
+The contract is the single home for *outbound* protection: Router-Maestro is
+lenient with what a client sends, but normalizes or rejects anything the
+upstream backend cannot accept before forwarding. ``reconcile_passthrough_body``
+is the entry point the OpenAI Responses beta passthrough route calls; it
+composes the per-concern hooks (``forwardable_fields`` field strip,
+``filter_tools``, ``allows_temperature`` verdict, ``resolve_reasoning``
+downgrade) that each provider overrides.
+
+The beta native Anthropic route has a differently shaped body (Anthropic-format
+tools, ``thinking`` budgets, ``output_config.effort``) and does not go through
+this orchestrator; it applies the Copilot-specific hooks directly
+(``CopilotOutboundContract.apply_native_anthropic_thinking`` and siblings) plus
+its own top-level field strip. Those hooks live on the contract so it stays the
+single source of the Copilot wire rules.
 """
 
 from abc import ABC
@@ -66,6 +75,69 @@ class OutboundContract(ABC):
     def allows_temperature(self, operation: Operation) -> bool:
         """Whether the upstream accepts explicit ``temperature``. Default: yes."""
         return True
+
+    def reconcile_passthrough_body(
+        self,
+        body: dict,
+        *,
+        operation: Operation,
+        model: str,
+        catalog_effort_values: list[str] | None,
+    ) -> None:
+        """Reconcile a raw passthrough body in place against the wire contract.
+
+        Composes the per-concern hooks for the generic (Responses-shaped) body:
+        top-level field strip, tool filtering, temperature verdict, and reasoning
+        downgrade. Mutates ``body`` in place; raises ``RequestOptionError`` for
+        options the upstream cannot represent (temperature on a rejecting
+        operation, malformed tools, or unsupported reasoning). Routes whose
+        passthrough body is shaped differently (e.g. the native Anthropic wire)
+        call the provider's hooks directly instead of this orchestrator.
+        """
+        # 1. Top-level field strip (permissive default forwards everything).
+        forwardable = self.forwardable_fields(operation)
+        if forwardable is not None:
+            for key in set(body) - forwardable:
+                del body[key]
+
+        # 2. Tools — filter_tools may drop unsupported types or raise on malformed.
+        if "tools" in body:
+            filtered = self.filter_tools(body.get("tools"), operation=operation, model=model)
+            if filtered:
+                body["tools"] = filtered
+            else:
+                body.pop("tools", None)
+
+        # 3. Temperature verdict.
+        if body.get("temperature") is not None and not self.allows_temperature(operation):
+            from router_maestro.providers.base import RequestOptionError  # lazy: base<-contract
+
+            raise RequestOptionError(
+                "upstream does not support request option 'temperature' on this operation",
+                model=model,
+                parameter="temperature",
+            )
+
+        # 4. Reasoning effort — only when the client sent an explicit effort.
+        reasoning = body.get("reasoning")
+        if isinstance(reasoning, dict) and isinstance(reasoning.get("effort"), str):
+            resolution = self.resolve_reasoning(
+                model=model,
+                reasoning_effort=reasoning["effort"],
+                thinking_budget=None,
+                catalog_effort_values=catalog_effort_values,
+                operation=operation,
+            )
+            if resolution.effort is not None:
+                # Rewrite only the effort; preserve sibling keys (summary) and the
+                # client's own ``include`` so encrypted reasoning still round-trips.
+                body["reasoning"] = {**reasoning, "effort": resolution.effort}
+            else:
+                # Unreachable when the client sent a string effort (the guard
+                # above): resolve_reasoning either returns a concrete tier or
+                # raises. Kept only so a future None-yielding resolver cannot
+                # forward an effort the upstream rejected.
+                body.pop("reasoning", None)
 
 
 class PermissiveOutboundContract(OutboundContract):

--- a/src/router_maestro/server/routes/anthropic_beta.py
+++ b/src/router_maestro/server/routes/anthropic_beta.py
@@ -30,7 +30,7 @@ from router_maestro.providers import (
     exception_outcome,
     unexpected_eof_outcome,
 )
-from router_maestro.providers.copilot import CopilotProvider
+from router_maestro.providers.copilot import CopilotOutboundContract, CopilotProvider
 from router_maestro.routing import get_router
 from router_maestro.routing.capabilities import CapabilitySupport, Operation, RequestFeatures
 from router_maestro.routing.model_ref import qualify_model_id
@@ -50,8 +50,7 @@ from router_maestro.server.routes.anthropic import (
 from router_maestro.server.streaming import parse_sse_frame, sse_streaming_response
 from router_maestro.utils import get_logger
 from router_maestro.utils.async_iterators import close_async_iterator
-from router_maestro.utils.context_window import resolve_thinking_budget
-from router_maestro.utils.reasoning import VALID_EFFORTS, pick_closest_effort
+from router_maestro.utils.reasoning import VALID_EFFORTS
 
 logger = get_logger("server.routes.anthropic_beta")
 
@@ -131,19 +130,13 @@ def _is_native_eligible(provider_name: str, actual_model: str) -> bool:
 
 
 def _sanitize_output_config(body: dict) -> str | None:
-    """Keep only a valid effort supported by Copilot's native endpoint."""
-    output_config = body.get("output_config")
-    if not isinstance(output_config, dict):
-        body.pop("output_config", None)
-        return None
+    """Keep only a valid effort supported by Copilot's native endpoint.
 
-    effort = output_config.get("effort")
-    if effort not in VALID_EFFORTS:
-        body.pop("output_config", None)
-        return None
-
-    body["output_config"] = {"effort": effort}
-    return effort
+    Thin seam over ``CopilotOutboundContract.sanitize_output_config`` (the single
+    source of the native-Anthropic wire rules); kept here as a stable name for
+    the route's fast-fail validation and its test hooks.
+    """
+    return CopilotOutboundContract.sanitize_output_config(body)
 
 
 def _validate_beta_request_options(body: dict) -> None:
@@ -187,12 +180,7 @@ def _validate_beta_request_options(body: dict) -> None:
 def _validate_native_request_options(body: dict) -> None:
     """Reject explicit options that the native Copilot transport cannot preserve."""
     _validate_beta_request_options(body)
-
-    if "temperature" in body and "top_p" in body:
-        raise RequestOptionError(
-            "top_p cannot be combined with temperature on the native Anthropic transport",
-            parameter="top_p",
-        )
+    CopilotOutboundContract.reject_unpreservable_native_options(body)
 
 
 def _resolve_native_effort(
@@ -204,24 +192,13 @@ def _resolve_native_effort(
 ) -> str:
     """Resolve a native effort exactly or downward, preserving unknown catalogs.
 
-    The native passthrough resolves ``output_config.effort`` with its own
-    catalog-or-passthrough rule (distinct error surface and no family fallback),
-    so it is intentionally NOT routed through
-    ``CopilotOutboundContract.resolve_reasoning`` (the chat/responses orchestration).
-    Both share the ``pick_closest_effort`` primitive as the single source of the
-    downgrade math.
+    Thin seam over ``CopilotOutboundContract.resolve_native_effort``. The native
+    passthrough deliberately keeps its own catalog-or-passthrough rule (distinct
+    error surface, no family fallback), separate from ``resolve_reasoning``.
     """
-    if allowed is None:
-        return effort
-    mapped_effort = pick_closest_effort(effort, list(allowed))
-    if mapped_effort is None:
-        raise RequestOptionError(
-            "output_config.effort has no supported tier at or below the requested tier",
-            parameter="output_config.effort",
-            provider=provider,
-            model=model,
-        )
-    return mapped_effort
+    return CopilotOutboundContract.resolve_native_effort(
+        effort, allowed, provider=provider, model=model
+    )
 
 
 def _validate_native_candidate_options(body: dict, candidate: RouteCandidate) -> None:
@@ -463,117 +440,13 @@ def _apply_thinking_budget_native(
 ) -> dict:
     """Apply effort precedence or the server budget fallback to a raw body.
 
-    Explicit ``output_config.effort`` removes an adaptive thinking budget.
-    Manual enabled thinking retains a normalized budget, using the server fallback
-    when the client omits it. Without effort, budget resolution is unchanged.
+    Thin seam over ``CopilotOutboundContract.apply_native_anthropic_thinking``
+    (the single source of the native-Anthropic thinking/effort rules); kept here
+    as a stable name and mock point for the route's transport tests.
     """
-    effort = _sanitize_output_config(body)
-    client_thinking = body.get("thinking")
-
-    model_router = None
-    model_info = None
-
-    if effort is not None:
-        effort = _resolve_native_effort(
-            effort,
-            reasoning_effort_values,
-            provider="github-copilot",
-            model=actual_model,
-        )
-        body["output_config"] = {"effort": effort}
-
-    if isinstance(client_thinking, dict) and client_thinking.get("type") == "adaptive":
-        thinking = dict(client_thinking)
-        thinking.pop("budget_tokens", None)
-        body["thinking"] = thinking
-        return body
-
-    if effort is not None:
-        if not (
-            isinstance(client_thinking, dict)
-            and client_thinking.get("type") in ("enabled", "disabled")
-        ):
-            return body
-
-    from router_maestro.runtime import get_current_request_context
-
-    context = get_current_request_context()
-    if context is not None:
-        priorities = context.config
-    else:
-        from router_maestro.config import load_priorities_config
-
-        priorities = load_priorities_config()
-    thinking_config = priorities.thinking
-
-    client_budget = None
-    client_type = None
-    if isinstance(client_thinking, dict):
-        client_budget = client_thinking.get("budget_tokens")
-        client_type = client_thinking.get("type")
-
-    if model_router is None:
-        model_router = get_router()
-    if model_info is None and hasattr(model_router, "_models_cache"):
-        cache_entry = model_router._models_cache.get(actual_model)
-        if cache_entry:
-            _, model_info = cache_entry
-
-    supports_thinking = model_info.supports_thinking if model_info else True
-    max_output = (model_info.max_output_tokens or 16384) if model_info else 16384
-    request_max_output = body.get("max_tokens")
-    if isinstance(request_max_output, int):
-        max_output = min(max_output, request_max_output)
-
-    budget, thinking_type = resolve_thinking_budget(
-        client_budget=client_budget,
-        client_thinking_type=client_type,
-        model_id=actual_model,
-        max_output_tokens=max_output,
-        thinking_config=thinking_config,
-        supports_thinking=supports_thinking,
+    return CopilotOutboundContract.apply_native_anthropic_thinking(
+        body, actual_model, reasoning_effort_values
     )
-
-    if thinking_type == "adaptive":
-        adaptive = dict(client_thinking) if isinstance(client_thinking, dict) else {}
-        adaptive["type"] = "adaptive"
-        adaptive.pop("budget_tokens", None)
-        body["thinking"] = adaptive
-        if budget != client_budget or thinking_type != client_type:
-            logger.debug(
-                "Thinking budget adjusted: %s/%s -> %s/%s for model=%s",
-                client_type,
-                client_budget,
-                thinking_type,
-                budget,
-                actual_model,
-            )
-    elif thinking_type == "enabled" and budget is not None:
-        enabled = dict(client_thinking) if isinstance(client_thinking, dict) else {}
-        enabled["type"] = "enabled"
-        enabled["budget_tokens"] = budget
-        body["thinking"] = enabled
-        if budget != client_budget or thinking_type != client_type:
-            logger.debug(
-                "Thinking budget adjusted: %s/%s -> %s/%s for model=%s",
-                client_type,
-                client_budget,
-                thinking_type,
-                budget,
-                actual_model,
-            )
-    else:
-        body.pop("thinking", None)
-        if client_type is not None:
-            logger.debug(
-                "Thinking removed: client had %s/%s, resolved to %s for model=%s",
-                client_type,
-                client_budget,
-                thinking_type,
-                actual_model,
-            )
-
-    return body
 
 
 async def _resolve_model(model: str) -> _ResolvedModel:

--- a/src/router_maestro/server/routes/openai_responses_beta.py
+++ b/src/router_maestro/server/routes/openai_responses_beta.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from router_maestro.providers import (
     ProviderError,
     ProviderFailureKind,
+    RequestOptionError,
     ResponseStatus,
     TerminalOutcome,
     TransportTermination,
@@ -37,6 +38,7 @@ from router_maestro.routing.capabilities import CapabilitySupport, Operation, Re
 from router_maestro.routing.route_plan import NoCompatibleRouteError, RouteCandidate, RoutePlan
 from router_maestro.routing.router import Router
 from router_maestro.server.protocols.errors import (
+    client_error_response,
     postcommit_error_data,
     protocol_error_response,
 )
@@ -126,16 +128,10 @@ async def _resolve_responses_model(
     )
 
 
-def _strip_forbidden_fields(body: dict, copilot_provider: CopilotProvider, operation: Operation):
-    """Remove top-level fields GHC's /responses rejects before forwarding."""
-    forwardable = copilot_provider.outbound_contract.forwardable_fields(operation)
-    if forwardable is None:
-        return
-    unknown = set(body.keys()) - forwardable
-    if unknown:
-        logger.debug("Stripping unknown fields before passthrough: %s", sorted(unknown))
-        for key in unknown:
-            del body[key]
+def _candidate_effort_values(candidate: RouteCandidate) -> list[str] | None:
+    """The per-candidate reasoning-effort catalog list for reasoning downgrade."""
+    values = candidate.capabilities.reasoning_effort_values
+    return list(values) if values is not None else None
 
 
 def _strip_response(data: dict) -> dict:
@@ -215,6 +211,12 @@ async def _send_native_nonstream(candidate: RouteCandidate, body: dict):
             model=candidate.model.upstream_id,
         )
     payload = dict(body)
+    provider.outbound_contract.reconcile_passthrough_body(
+        payload,
+        operation=Operation.RESPONSES,
+        model=candidate.model.upstream_id,
+        catalog_effort_values=_candidate_effort_values(candidate),
+    )
     payload["model"] = candidate.model.upstream_id
     payload["stream"] = False
     await provider.ensure_token()
@@ -264,6 +266,12 @@ async def _stream_native_candidate(
             model=candidate.model.upstream_id,
         )
     payload = dict(body)
+    provider.outbound_contract.reconcile_passthrough_body(
+        payload,
+        operation=Operation.RESPONSES_STREAM,
+        model=candidate.model.upstream_id,
+        catalog_effort_values=_candidate_effort_values(candidate),
+    )
     payload["model"] = candidate.model.upstream_id
     payload["stream"] = True
     await provider.ensure_token()
@@ -544,7 +552,9 @@ async def beta_responses(raw_request: FastAPIRequest):
         )
         return await _fallback_to_standard(body)
 
-    _strip_forbidden_fields(body, copilot_provider, operation)
+    # Field strip + tool/temperature/reasoning reconciliation happen per-candidate
+    # inside the send helpers (each on its own payload copy), so fallback candidates
+    # with different catalogs resolve independently.
     body["model"] = resolution.actual_model
     plan = resolution.plan
 
@@ -577,6 +587,8 @@ async def beta_responses(raw_request: FastAPIRequest):
                 log_prefix="Beta Responses",
             )
         except ProviderError as error:
+            if isinstance(error, RequestOptionError):
+                return client_error_response(error, "openai")
             logger.error(
                 "beta_responses_stream_open_failed kind=%s retryable=%s",
                 error.kind.value,
@@ -593,6 +605,8 @@ async def beta_responses(raw_request: FastAPIRequest):
             lambda candidate: _send_native_nonstream(candidate, body),
         )
     except ProviderError as error:
+        if isinstance(error, RequestOptionError):
+            return client_error_response(error, "openai")
         logger.error(
             "beta_responses_request_failed kind=%s retryable=%s",
             error.kind.value,

--- a/tests/test_anthropic_beta.py
+++ b/tests/test_anthropic_beta.py
@@ -694,7 +694,7 @@ class TestStripHistoryThinkingBlocks:
 
 
 class TestApplyThinkingBudgetNative:
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_effort_removes_conflicting_budget(self, mock_resolve_tb):
         body = {
             "thinking": {"type": "adaptive", "budget_tokens": 16000},
@@ -707,9 +707,9 @@ class TestApplyThinkingBudgetNative:
         assert result["output_config"] == {"effort": "xhigh"}
         mock_resolve_tb.assert_not_called()
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_effort_preserves_required_enabled_budget(
         self, mock_resolve_tb, mock_config, mock_router
     ):
@@ -729,9 +729,9 @@ class TestApplyThinkingBudgetNative:
         assert result["output_config"] == {"effort": "xhigh"}
         mock_resolve_tb.assert_called_once()
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_effort_maps_to_catalog_supported_tier(self, mock_resolve_tb, mock_config, mock_router):
         mock_config.return_value = MagicMock(
             thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
@@ -763,9 +763,9 @@ class TestApplyThinkingBudgetNative:
         # Decision C: xhigh must substitute down to high, never up to max.
         assert result["output_config"] == {"effort": "high"}
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_enabled_budget_normalization_preserves_display(
         self, mock_resolve_tb, mock_config, mock_router
     ):
@@ -793,9 +793,9 @@ class TestApplyThinkingBudgetNative:
             "display": "summarized",
         }
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_effort_fills_missing_enabled_budget(self, mock_resolve_tb, mock_config, mock_router):
         mock_config.return_value = MagicMock(
             thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
@@ -815,9 +815,9 @@ class TestApplyThinkingBudgetNative:
         assert result["output_config"] == {"effort": "xhigh"}
         mock_resolve_tb.assert_called_once()
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_effort_normalizes_enabled_budget(self, mock_resolve_tb, mock_config, mock_router):
         mock_config.return_value = MagicMock(
             thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
@@ -839,9 +839,9 @@ class TestApplyThinkingBudgetNative:
         mock_resolve_tb.assert_called_once()
         assert mock_resolve_tb.call_args.kwargs["max_output_tokens"] == 4096
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_effort_removes_disabled_thinking(self, mock_resolve_tb, mock_config, mock_router):
         mock_config.return_value = MagicMock(
             thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
@@ -861,7 +861,7 @@ class TestApplyThinkingBudgetNative:
         assert result["output_config"] == {"effort": "xhigh"}
         mock_resolve_tb.assert_called_once()
 
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_adaptive_without_effort_omits_budget(self, mock_resolve_tb):
         result = _apply_thinking_budget_native(
             {"thinking": {"type": "adaptive", "budget_tokens": 16000}},
@@ -871,9 +871,9 @@ class TestApplyThinkingBudgetNative:
         assert result["thinking"] == {"type": "adaptive"}
         mock_resolve_tb.assert_not_called()
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_enabled_without_budget_headroom_is_removed(
         self, mock_resolve_tb, mock_config, mock_router
     ):
@@ -895,9 +895,9 @@ class TestApplyThinkingBudgetNative:
         assert "thinking" not in result
         mock_resolve_tb.assert_called_once()
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_no_change_when_client_sets_budget(self, mock_resolve_tb, mock_config, mock_router):
         mock_config.return_value = MagicMock(
             thinking=MagicMock(default_budget=16000, auto_enable=False, model_budgets={})
@@ -909,9 +909,9 @@ class TestApplyThinkingBudgetNative:
         result = _apply_thinking_budget_native(body, "claude-sonnet-4.5")
         assert result["thinking"]["budget_tokens"] == 5000
 
-    @patch("router_maestro.server.routes.anthropic_beta.get_router")
+    @patch("router_maestro.routing.get_router")
     @patch("router_maestro.config.load_priorities_config")
-    @patch("router_maestro.server.routes.anthropic_beta.resolve_thinking_budget")
+    @patch("router_maestro.providers.copilot.resolve_thinking_budget")
     def test_removes_thinking_when_server_disables(self, mock_resolve_tb, mock_config, mock_router):
         """Server config forces thinking off when client requested it."""
         mock_config.return_value = MagicMock(

--- a/tests/test_openai_responses_beta.py
+++ b/tests/test_openai_responses_beta.py
@@ -20,12 +20,12 @@ from router_maestro.routing.capabilities import (
 from router_maestro.routing.model_ref import ModelRef
 from router_maestro.routing.route_plan import RouteCandidate, RoutePlan
 from router_maestro.server.routes.openai_responses_beta import (
+    _candidate_effort_values,
     _frame_terminal_outcome,
     _guard_chunk,
     _iter_sse_frames,
     _operation_for,
     _ResponsesResolution,
-    _strip_forbidden_fields,
     router,
 )
 
@@ -90,21 +90,86 @@ def test_operation_for_stream_flag() -> None:
     assert _operation_for(False) is Operation.RESPONSES
 
 
-def test_strip_forbidden_fields_removes_unlisted_keys() -> None:
+def test_candidate_effort_values_reads_capabilities() -> None:
     provider = MagicMock(spec=CopilotProvider)
-    provider.outbound_contract = CopilotOutboundContract()
+    provider.name = "github-copilot"
+    plan = _responses_plan_with_efforts(provider, efforts=("low", "high"))
+    assert _candidate_effort_values(plan.primary) == ["low", "high"]
+    # None catalog (cold) yields None, not an empty list.
+    bare = _responses_plan_with_efforts(provider, efforts=None)
+    assert _candidate_effort_values(bare.primary) is None
+
+
+def test_reconcile_passthrough_body_strips_and_reconciles() -> None:
+    contract = CopilotOutboundContract()
     body = {
         "model": "gpt-5.2",
         "input": "hi",
-        "store": True,  # rejected by GHC
-        "mcp_servers": [],  # not in the allowlist
+        "store": True,  # rejected by GHC -> stripped
+        "mcp_servers": [],  # not in the allowlist -> stripped
         "reasoning": {"effort": "high"},
     }
-    _strip_forbidden_fields(body, provider, Operation.RESPONSES)
+    contract.reconcile_passthrough_body(
+        body,
+        operation=Operation.RESPONSES,
+        model="gpt-5.2",
+        catalog_effort_values=["low", "medium", "high"],
+    )
     assert "store" not in body
     assert "mcp_servers" not in body
     assert body["model"] == "gpt-5.2"
     assert body["reasoning"] == {"effort": "high"}
+
+
+def test_reconcile_passthrough_body_drops_unsupported_tool() -> None:
+    contract = CopilotOutboundContract()
+    body = {
+        "model": "gpt-5.5",
+        "input": "hi",
+        "tools": [{"type": "function", "name": "echo"}, {"type": "web_search"}],
+    }
+    contract.reconcile_passthrough_body(
+        body,
+        operation=Operation.RESPONSES,
+        model="gpt-5.5",
+        catalog_effort_values=None,
+    )
+    assert body["tools"] == [{"type": "function", "name": "echo"}]
+
+
+def test_reconcile_passthrough_body_rejects_temperature() -> None:
+    from router_maestro.providers import RequestOptionError
+
+    contract = CopilotOutboundContract()
+    body = {"model": "gpt-5.5", "input": "hi", "temperature": 0.5}
+    with pytest.raises(RequestOptionError) as excinfo:
+        contract.reconcile_passthrough_body(
+            body,
+            operation=Operation.RESPONSES,
+            model="gpt-5.5",
+            catalog_effort_values=None,
+        )
+    assert excinfo.value.parameter == "temperature"
+
+
+def test_reconcile_passthrough_body_downgrades_reasoning_effort() -> None:
+    contract = CopilotOutboundContract()
+    body = {
+        "model": "gpt-5.5",
+        "input": "hi",
+        "reasoning": {"effort": "xhigh", "summary": "auto"},
+        "include": ["reasoning.encrypted_content"],
+    }
+    contract.reconcile_passthrough_body(
+        body,
+        operation=Operation.RESPONSES,
+        model="gpt-5.5",
+        catalog_effort_values=["low", "medium", "high"],
+    )
+    # Effort downgraded to the nearest supported tier; sibling keys + client
+    # include preserved (no summary/include injection on passthrough).
+    assert body["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert body["include"] == ["reasoning.encrypted_content"]
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +419,113 @@ def test_nonstream_passthrough_forwards_raw_and_rewrites_model(client) -> None:
     assert "store" not in sent_payload
     assert sent_payload["previous_response_id"] == "resp_prev"
     assert sent_payload["input"] == "hi"
+
+
+def _responses_plan_with_efforts(provider, *, model="gpt-5.5", efforts=None) -> RoutePlan:
+    ref = ModelRef("github-copilot", model)
+    operation = Operation.RESPONSES
+    features = RequestFeatures()
+    capabilities = ModelCapabilities(
+        model=ref,
+        operations={operation: CapabilitySupport.SUPPORTED},
+        reasoning_effort_values=tuple(efforts) if efforts is not None else None,
+    )
+    return RoutePlan(
+        operation=operation,
+        features=features,
+        primary=RouteCandidate(
+            model=ref,
+            provider=provider,
+            capabilities=capabilities,
+            evaluated_operation=operation,
+            evaluated_features=features,
+            support=CapabilitySupport.SUPPORTED,
+        ),
+        fallbacks=(),
+        explicit=True,
+    )
+
+
+def _native_resolution(provider, plan, *, model="gpt-5.5") -> _ResponsesResolution:
+    return _ResponsesResolution(
+        provider_name="github-copilot",
+        actual_model=model,
+        copilot_provider=provider,
+        support=CapabilitySupport.SUPPORTED,
+        plan=plan,
+    )
+
+
+def test_nonstream_passthrough_drops_unsupported_tool(client) -> None:
+    provider = _native_provider()
+    plan = _responses_plan_with_efforts(provider)
+    resolution = _native_resolution(provider, plan)
+    with patch(
+        "router_maestro.server.routes.openai_responses_beta._resolve_responses_model",
+        new_callable=AsyncMock,
+        return_value=resolution,
+    ):
+        downstream = client.post(
+            "/api/openai/beta/v1/responses",
+            json={
+                "model": "github-copilot/gpt-5.5",
+                "input": "hi",
+                "tools": [
+                    {"type": "function", "name": "echo"},
+                    {"type": "web_search"},
+                ],
+            },
+        )
+    assert downstream.status_code == 200
+    sent_payload = provider._send_with_auth_retry.await_args.kwargs["json"]
+    assert sent_payload["tools"] == [{"type": "function", "name": "echo"}]
+
+
+def test_nonstream_passthrough_rejects_temperature(client) -> None:
+    provider = _native_provider()
+    plan = _responses_plan_with_efforts(provider)
+    resolution = _native_resolution(provider, plan)
+    with patch(
+        "router_maestro.server.routes.openai_responses_beta._resolve_responses_model",
+        new_callable=AsyncMock,
+        return_value=resolution,
+    ):
+        downstream = client.post(
+            "/api/openai/beta/v1/responses",
+            json={
+                "model": "github-copilot/gpt-5.5",
+                "input": "hi",
+                "temperature": 0.5,
+            },
+        )
+    assert downstream.status_code == 400
+    assert downstream.json()["error"]["type"] == "invalid_request_error"
+    # Upstream was never called — rejected locally before transport.
+    provider._send_with_auth_retry.assert_not_awaited()
+
+
+def test_nonstream_passthrough_downgrades_reasoning_effort(client) -> None:
+    provider = _native_provider()
+    plan = _responses_plan_with_efforts(provider, efforts=("low", "medium", "high"))
+    resolution = _native_resolution(provider, plan)
+    with patch(
+        "router_maestro.server.routes.openai_responses_beta._resolve_responses_model",
+        new_callable=AsyncMock,
+        return_value=resolution,
+    ):
+        downstream = client.post(
+            "/api/openai/beta/v1/responses",
+            json={
+                "model": "github-copilot/gpt-5.5",
+                "input": "hi",
+                "reasoning": {"effort": "xhigh", "summary": "auto"},
+            },
+        )
+    assert downstream.status_code == 200
+    sent_payload = provider._send_with_auth_retry.await_args.kwargs["json"]
+    assert sent_payload["reasoning"]["effort"] == "high"
+    # Sibling reasoning keys preserved (no injection on passthrough).
+    assert sent_payload["reasoning"]["summary"] == "auto"
 
 
 def test_nonstream_falls_back_to_standard_for_unsupported(client) -> None:

--- a/tests/test_outbound_contract.py
+++ b/tests/test_outbound_contract.py
@@ -185,3 +185,106 @@ def test_permissive_defaults_for_tools_and_temperature():
     tools = [{"type": "anything"}]
     assert c.filter_tools(tools, operation=Operation.CHAT, model="m") == tools
     assert c.allows_temperature(Operation.RESPONSES) is True
+
+
+# --- reconcile_passthrough_body orchestrator (Responses shape) ---
+
+
+def test_reconcile_responses_strips_filters_and_downgrades():
+    c = _copilot_contract()
+    body = {
+        "model": "github-copilot/gpt-5.5",
+        "input": "hi",
+        "store": True,  # stripped (not in allowlist)
+        "tools": [{"type": "function", "name": "echo"}, {"type": "web_search"}],
+        "reasoning": {"effort": "xhigh", "summary": "auto"},
+        "include": ["reasoning.encrypted_content"],
+    }
+    c.reconcile_passthrough_body(
+        body,
+        operation=Operation.RESPONSES,
+        model="github-copilot/gpt-5.5",
+        catalog_effort_values=["low", "medium", "high"],
+    )
+    assert "store" not in body
+    assert body["tools"] == [{"type": "function", "name": "echo"}]
+    assert body["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert body["include"] == ["reasoning.encrypted_content"]  # preserved, not injected
+
+
+def test_reconcile_responses_rejects_temperature():
+    import pytest
+
+    from router_maestro.providers import RequestOptionError
+
+    c = _copilot_contract()
+    with pytest.raises(RequestOptionError) as excinfo:
+        c.reconcile_passthrough_body(
+            {"model": "m", "input": "hi", "temperature": 0.5},
+            operation=Operation.RESPONSES,
+            model="github-copilot/gpt-5.5",
+            catalog_effort_values=None,
+        )
+    assert excinfo.value.parameter == "temperature"
+
+
+def test_reconcile_permissive_is_noop():
+    from router_maestro.providers.outbound_contract import PermissiveOutboundContract
+
+    c = PermissiveOutboundContract()
+    body = {"model": "m", "input": "hi", "temperature": 0.5, "reasoning": {"effort": "high"}}
+    before = dict(body)
+    c.reconcile_passthrough_body(
+        body, operation=Operation.RESPONSES, model="m", catalog_effort_values=None
+    )
+    assert body == before
+
+
+# --- native Anthropic normalizers (folded in from the beta route) ---
+
+
+def test_sanitize_output_config_keeps_only_valid_effort():
+    from router_maestro.providers.copilot import CopilotOutboundContract
+
+    body = {"output_config": {"effort": "xhigh", "format": "json"}}
+    assert CopilotOutboundContract.sanitize_output_config(body) == "xhigh"
+    assert body["output_config"] == {"effort": "xhigh"}
+
+    dropped = {"output_config": {"effort": "invalid"}}
+    assert CopilotOutboundContract.sanitize_output_config(dropped) is None
+    assert "output_config" not in dropped
+
+
+def test_resolve_native_effort_downgrades_or_rejects():
+    import pytest
+
+    from router_maestro.providers import RequestOptionError
+    from router_maestro.providers.copilot import CopilotOutboundContract
+
+    # Unknown catalog (None) is preserved verbatim.
+    assert CopilotOutboundContract.resolve_native_effort("xhigh", None) == "xhigh"
+    # Downgrades to the nearest tier at or below.
+    assert (
+        CopilotOutboundContract.resolve_native_effort("xhigh", ("low", "medium", "high")) == "high"
+    )
+    # No tier at or below the request -> reject (no family fallback).
+    with pytest.raises(RequestOptionError) as excinfo:
+        CopilotOutboundContract.resolve_native_effort("low", ("high",))
+    assert excinfo.value.parameter == "output_config.effort"
+
+
+def test_reject_unpreservable_native_options_flags_temp_plus_top_p():
+    import pytest
+
+    from router_maestro.providers import RequestOptionError
+    from router_maestro.providers.copilot import CopilotOutboundContract
+
+    # Either alone is fine.
+    CopilotOutboundContract.reject_unpreservable_native_options({"temperature": 0.5})
+    CopilotOutboundContract.reject_unpreservable_native_options({"top_p": 0.9})
+    # Both together cannot be preserved on the native transport.
+    with pytest.raises(RequestOptionError) as excinfo:
+        CopilotOutboundContract.reject_unpreservable_native_options(
+            {"temperature": 0.5, "top_p": 0.9}
+        )
+    assert excinfo.value.parameter == "top_p"


### PR DESCRIPTION
## Context

The beta raw-passthrough routes previously ran only a top-level field strip (`forwardable_fields`) and never applied tool filtering, temperature rejection, or reasoning-effort downgrade. Because `tools`, `temperature`, and `reasoning` are all in the forward allowlist, they reached GitHub Copilot untouched — producing opaque upstream 400s instead of clean local handling. `OutboundContract`'s own docstring named this as "Round 2": migrating the per-option reconciliation and tool filtering scattered across each provider's payload builders into the contract.

## What changed

- **`reconcile_passthrough_body` orchestrator** on `OutboundContract` — composes the existing per-concern hooks (`forwardable_fields`, `filter_tools`, `allows_temperature`, `resolve_reasoning`) for the generic Responses-shaped body.
- **Beta OpenAI Responses route** now reconciles per-candidate: tools filtered, `temperature` rejected with a clean 400 (matching the typed `/v1/responses` path), reasoning effort silently downgraded. Sibling reasoning keys and the client's own `include` are preserved (no injection), keeping the encrypted-reasoning round-trip intact.
- **Beta Anthropic route** — native normalizers (`output_config` sanitize, native-effort resolution, `top_p`+`temperature` reject, thinking-budget resolution) folded into `CopilotOutboundContract` so the contract is the single source of the Copilot wire rules. The route keeps thin same-named delegating seams, preserving all existing behavior and test hooks.

Net: `anthropic_beta.py` shrank ~150 lines as logic moved into the contract.

## Behavior

On the beta Responses path, behavior now matches the typed path: `temperature` → 400, over-tier reasoning → silent downgrade. Tools already handled by the existing `filter_tools` (silently drops `web_search`/`code_interpreter`, raises only on a malformed empty-namespace tool).

## Verification

- **3471 tests pass**, ruff clean.
- New unit + route-level tests cover tool drop, temperature→400 (upstream not hit), and reasoning downgrade at the real route layer.
- **Live e2e against GitHub Copilot:** temperature→400 without hitting upstream; `reasoning.effort=xhigh`→downgraded + succeeded; `web_search` tool→dropped + succeeded; native Anthropic thinking→`['thinking','text']` returned.

## Code review

Ran a 6-pass multi-agent review (CLAUDE.md, bug scan, git history ×2, prior-PR invariants, code-comment adherence). One doc-vs-code mismatch found and fixed (a docstring described an override/`super()` design that wasn't built); one clarifying comment added on an unreachable defensive branch. No confirmed functional bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)