### PR TITLE
fix: don't crash vision detection on non-string JSON Schema tool type

### DIFF
--- a/src/router_maestro/routing/capabilities.py
+++ b/src/router_maestro/routing/capabilities.py
@@ -196,7 +196,10 @@ def _contains_image(value: object) -> bool:
         return any(_contains_image(item) for item in value)
     if isinstance(value, dict):
         block_type = value.get("type")
-        if block_type in {"image", "image_url", "input_image"}:
+        # A tool's JSON Schema can carry a non-string ``type`` (e.g.
+        # ``"type": ["string", "null"]``). Only string block types can name an
+        # image block; testing membership with an unhashable list would raise.
+        if isinstance(block_type, str) and block_type in {"image", "image_url", "input_image"}:
             return True
         return any(_contains_image(item) for item in value.values())
     content = getattr(value, "content", None)

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -1373,6 +1373,34 @@ def test_request_feature_detection_covers_chat_and_responses_shapes():
     )
 
 
+def test_request_feature_detection_tolerates_non_string_schema_type():
+    # A prior turn echoes tool JSON Schemas whose ``type`` is a list, e.g.
+    # ``{"type": ["string", "null"]}``. Vision detection walks the whole input
+    # and must not choke testing an unhashable list against the image-block set.
+    responses_request = ResponsesRequest(
+        model="m",
+        input=[
+            {
+                "type": "function_call",
+                "parameters": {
+                    "properties": {
+                        "org": {"type": ["string", "null"]},
+                        "count": {"type": ["array", "null"]},
+                    }
+                },
+            }
+        ],
+        tools=[{"type": "function", "name": "tool"}],
+    )
+
+    assert RequestFeatures.for_responses(responses_request) == RequestFeatures(
+        tools=True,
+        vision=False,
+        reasoning=False,
+        parallel_tools=False,
+    )
+
+
 def test_plan_route_is_not_used_for_token_counting_operation():
     assert {operation.value for operation in Operation} == {
         "chat",


### PR DESCRIPTION
## Summary

`_contains_image` (routing/capabilities.py) walks the entire Responses `input` looking for image blocks. When a prior turn echoes tool JSON Schemas whose `type` is a list — the standard nullable shape `{"type": ["string", "null"]}` emitted by many MCP tool definitions (ado, icm, …) — the membership test `block_type in {"image", "image_url", "input_image"}` tries to hash the list and raises `TypeError: unhashable type: 'list'`. This surfaces as a **500**, which ChatGPT/Codex render to the user as *"We're currently experiencing high demand."*

Fix: guard the membership test with `isinstance(block_type, str)`. Only string block types can name an image block; non-string types keep recursing into `values()`.

## Reproduction

A real gpt-5.5 Responses request with ~350 input items, one of which echoed a namespace tool registry whose parameter schemas used `"type": ["string", "null"]`. Every turn 500'd on `_contains_image`. Verified end-to-end after the fix: same client request → **200 completed**.

Note: this is pre-existing (capabilities.py unchanged here), but it became reachable more often once namespace tool registries stopped being rejected at the tools filter (#148) — such requests now progress far enough to hit vision detection.

## Test plan

- [x] Unit: `_contains_image` on a dict with `{"type": ["string","null"]}` returns False instead of raising; real image blocks still detected
- [x] Regression test added: `for_responses` tolerates list-valued schema `type`
- [x] `test_provider_capabilities.py` + `test_openai_responses_beta.py`: 118 passed
- [x] End-to-end via local image + ChatGPT (gpt-5.5): `POST /api/openai/v1/responses` → **200 completed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)