### PR TITLE
fix: preserve model catalog on transient provider auth failure

### DIFF
--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -670,12 +670,10 @@ class Router:
         if self._models_cache_ttl.is_valid:
             return
 
-        if self._models_cache:
-            logger.debug("Cache expired, refreshing")
-            self._models_cache.clear()
-            self._fuzzy_cache.clear()
-
         logger.debug("Initializing models cache")
+        previous_cache = self._models_cache
+        new_cache: dict[str, tuple[str, ModelInfo]] = {}
+        any_provider_failed = False
         for provider_name, provider in self.providers.items():
             if provider.is_authenticated():
                 try:
@@ -705,31 +703,52 @@ class Router:
                         # aliases when their strings collide. This can happen when
                         # an upstream ID itself contains '/', for example
                         # ``meta-llama/llama-3``.
-                        existing = self._models_cache.get(ref.qualified_id)
+                        existing = new_cache.get(ref.qualified_id)
                         if existing is None or not self._is_qualified_cache_entry(
                             ref.qualified_id,
                             existing,
                         ):
-                            self._models_cache[ref.qualified_id] = entry
+                            new_cache[ref.qualified_id] = entry
 
                         # Keep a bare alias only when it does not shadow a
                         # canonical provider/model identity. Duplicate aliases
                         # retain the first catalog entry; RoutePlan later chooses
                         # the provider by configured priority and capability.
-                        alias_entry = self._models_cache.get(ref.upstream_id)
+                        alias_entry = new_cache.get(ref.upstream_id)
                         if alias_entry is None:
-                            self._models_cache[ref.upstream_id] = entry
+                            new_cache[ref.upstream_id] = entry
                     logger.debug("Cached %d models from %s", len(models), provider_name)
                 except ProviderError as e:
+                    any_provider_failed = True
                     logger.warning(
                         "model_catalog_failed provider=%s kind=%s retryable=%s",
                         provider_name,
                         e.kind.value,
                         str(e.retryable).lower(),
                     )
+                    # A transient failure (e.g. a token-refresh race that briefly
+                    # reports the provider as unauthenticated, or an upstream 502
+                    # while minting a token) must not drop a provider's models from
+                    # the catalog, so retain its previously cached entries and let
+                    # in-flight requests keep resolving. Trade-off: a *persistent*
+                    # provider failure keeps serving the last-known catalog until a
+                    # refresh finally succeeds; that is surfaced by the repeated
+                    # model_catalog_failed warning above (the TTL is not refreshed
+                    # on failure, so each request retries) rather than by silently
+                    # emptying the cache.
+                    for key, cached_entry in previous_cache.items():
+                        if cached_entry[0] == provider_name and key not in new_cache:
+                            new_cache[key] = cached_entry
                     continue
 
-        self._models_cache_ttl.set(True)
+        self._models_cache = new_cache
+        self._fuzzy_cache.clear()
+        # Only mark the cache fresh when every authenticated provider refreshed
+        # successfully. If any provider failed, leave the TTL expired so the next
+        # request retries promptly instead of serving a degraded catalog for a
+        # full TTL window.
+        if not any_provider_failed:
+            self._models_cache_ttl.set(True)
         logger.info("Models cache initialized with %d entries", len(self._models_cache))
 
         self._apply_model_overrides()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -147,3 +147,51 @@ class TestRouterCacheInvalidation:
 
         assert router._priorities_cache.get() is None
         assert not router._priorities_cache.is_valid
+
+
+class TestRouterCatalogRefreshResilience:
+    """Cache refresh must not drop a provider on a transient auth failure."""
+
+    def _make_router(self, provider: BaseProvider) -> Router:
+        router = Router.__new__(Router)
+        router.providers = {provider.name: provider}
+        _init_router_caches(router)
+        router._managed_generation = True
+        return router
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_preserves_stale_entries(self):
+        """A refresh where ensure_token fails keeps previously cached models."""
+
+        class FlakyProvider(MockProvider):
+            def __init__(self):
+                super().__init__(
+                    name="github-copilot",
+                    models=[ModelInfo(id="gpt-5.6-sol", name="GPT", provider="github-copilot")],
+                )
+                self.fail_next_token = False
+
+            async def ensure_token(self) -> None:
+                if self.fail_next_token:
+                    raise ProviderError(
+                        "Not authenticated with GitHub Copilot",
+                        status_code=401,
+                    )
+
+        provider = FlakyProvider()
+        router = self._make_router(provider)
+
+        # First refresh succeeds and populates the catalog.
+        await router._ensure_models_cache()
+        assert "gpt-5.6-sol" in router._models_cache
+        assert router._models_cache_ttl.is_valid
+
+        # Force the next refresh and make the token check fail transiently.
+        router._models_cache_ttl.clear()
+        provider.fail_next_token = True
+        await router._ensure_models_cache()
+
+        # Stale entries survive so bare-name resolution keeps working, and the
+        # TTL stays expired so the next request retries instead of waiting.
+        assert "gpt-5.6-sol" in router._models_cache
+        assert not router._models_cache_ttl.is_valid


### PR DESCRIPTION
## Problem

A single transient failure while refreshing a provider's catalog wipes the **entire** model cache to zero. Until the next TTL window, every request that resolves a model — including bare model names via fuzzy match — fails with `404 Not Found: Model alias '<name>' not found in any provider`.

The trigger is intermittent and outside our control (a token-refresh race, or an upstream 502 from GitHub while minting a Copilot token), but the *amplification* is ours: one momentary refresh failure becomes minutes of hard 404s.

## Evidence

Observed independently on two machines with the same signature — a healthy catalog, one failed refresh, then the cache drops to `0 entries` and stays there:

**Machine A** (token-refresh race):
```
09:16:04  DEBUG  Refreshing Copilot token
09:16:04  DEBUG  Copilot token refreshed, expires at 1784713563   ← refresh reports success
09:16:04  DEBUG  Fetching Copilot models from API
          ERROR  Not authenticated with GitHub Copilot            ← get_credential() returns None a moment later
          WARNING model_catalog_failed provider=github-copilot kind=authentication retryable=false
          INFO   Models cache initialized with 0 entries          ← catalog wiped
```
Then every request 404s until the next refresh happens to succeed. The pattern repeats on the ~5-minute TTL cycle (e.g. 09:16, 09:22, 09:28 all `0 entries`; 09:46 recovers).

**Machine B** (upstream 502):
```
09:59:17  token refresh hits GitHub 502
          → catalog reset to 0 entries
          → all subsequent requests 404
```
Catalog had been healthy for 24h (42/44 entries, rebuilding on each TTL refresh) right up until this one failure.

In both cases the model was resolvable seconds earlier — this is not a missing provider prefix or a genuinely absent model.

## Root cause

`Router._ensure_models_cache()` cleared the cache up front, then repopulated it provider by provider:

```python
if self._models_cache:
    self._models_cache.clear()       # wipe first
    self._fuzzy_cache.clear()
for provider_name, provider in self.providers.items():
    if provider.is_authenticated():
        try:
            await provider.ensure_token()
            models = await provider.list_models()
            ...
        except ProviderError:
            continue                  # failed provider contributes nothing
self._models_cache_ttl.set(True)     # TTL refreshed even on failure
```

If `ensure_token()` / `list_models()` raised for a provider, that provider was skipped after the cache had already been cleared, leaving `0 entries`. Worse, the TTL was still marked fresh, so the degraded (empty) catalog was served for a full TTL window before the next retry.

## Fix

Build the refreshed catalog into a local dict and swap it in atomically at the end. On a per-provider failure, retain that provider's previously cached entries, and leave the TTL expired so the next request retries promptly.

- **No wipe-then-fail gap.** `self._models_cache = new_cache` is an atomic reference swap; requests never observe a half-built or empty cache mid-refresh.
- **Transient failure preserves the catalog.** A failed provider keeps its last-known entries, so in-flight requests keep resolving instead of 404ing.
- **Prompt retry.** The TTL is only marked fresh when every authenticated provider refreshed successfully; on failure it stays expired so the next request retries (rather than serving a degraded catalog for a full TTL).

### Why this doesn't cause a refresh storm

Leaving the TTL expired means the router asks the provider to refresh on each request, but the actual network calls are already throttled a layer down:

- The Copilot catalog has its own 300s TTL (`models_ttl_cache`) — within that window `list_models()` returns cached data without even calling `ensure_token()`.
- Concurrent refreshes are de-duplicated by a single-flight lock (`_refresh_task`), so at most one refresh runs at a time and callers share it.

So the only added cost, in the worst case where the catalog's stale copy is also gone, is that requests synchronously await one shared refresh instead of 404ing for minutes — i.e. faster self-healing, not repeated token minting.

### Trade-off (documented in-code)

A *persistent* provider failure keeps serving the last-known catalog until a refresh finally succeeds. This is surfaced by the repeated `model_catalog_failed` warning (the TTL is not refreshed on failure, so each request retries) rather than by silently emptying the cache. For the transient failures this PR targets, the next successful refresh fully overwrites the retained entries.

## Tests

Added `TestRouterCatalogRefreshResilience::test_transient_failure_preserves_stale_entries`: a first refresh populates the catalog, a second refresh with a transiently-failing `ensure_token()` must keep the prior entries and leave the TTL expired. Fails on the old wipe-then-fail logic, passes with this change. Full `tests/test_router.py` green; changed files lint clean.