### PR TITLE
feat: alias Codex codex-auto-review to gpt-5.4-mini on Copilot

### DIFF
--- a/integration_tests/test_live_review_fixes.py
+++ b/integration_tests/test_live_review_fixes.py
@@ -16,19 +16,26 @@ from __future__ import annotations
 import httpx
 
 from integration_tests.conftest import (
+    _post_compat_probe_with_marked_400_retry,
     anthropic_thinking_replay_payload,
     anthropic_tool_choice_any_payload,
     assert_anthropic_has_tool_use,
     assert_anthropic_usage,
     assert_gemini_usage,
     assert_http_success,
+    assert_responses_usage,
     assert_text_response,
+    bare_model,
     event_payloads,
     gemini_model_path,
     gemini_payload,
     openai_chat_tool_required_payload,
+    openai_responses_payload,
     parse_sse_events,
 )
+
+CODEX_AUTO_REVIEW_ALIAS = "codex-auto-review"
+CODEX_AUTO_REVIEW_TARGET = "gpt-5.4-mini"
 
 
 def test_anthropic_tool_choice_any_forces_tool(client: httpx.Client, tool_model: str):
@@ -131,3 +138,32 @@ def test_wrong_api_key_is_rejected(
         },
     )
     assert response.status_code == 401, response.text
+
+
+def test_codex_auto_review_alias_routes_to_real_model(client: httpx.Client):
+    """Codex's ``codex-auto-review`` guardian model must route to a real GHC model.
+
+    OpenAI Codex's Auto-review (guardian) mode issues a Responses request with
+    ``model="codex-auto-review"``, a synthetic id that exists only on the
+    ChatGPT/Codex subscription backend — not in GHC's catalog. Before the alias
+    fix this 404'd at routing and Codex's approval failed. The Copilot provider
+    now aliases it to ``gpt-5.4-mini``; this asserts the live request succeeds
+    (200, not 404) and that the response echoes the *resolved* target model, not
+    the synthetic alias — i.e. the alias actually normalized to a real model
+    rather than some unrelated fallback answering.
+    """
+    response = _post_compat_probe_with_marked_400_retry(
+        client,
+        "/api/openai/v1/responses",
+        json_payload=openai_responses_payload(CODEX_AUTO_REVIEW_ALIAS),
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["object"] == "response"
+    assert data["status"] == "completed", data
+    # The public model id must reflect the resolved target, never the alias.
+    returned_model = bare_model(data["model"])
+    assert returned_model != CODEX_AUTO_REVIEW_ALIAS, data
+    assert returned_model == CODEX_AUTO_REVIEW_TARGET, data
+    assert_responses_usage(data["usage"])

--- a/src/router_maestro/providers/base.py
+++ b/src/router_maestro/providers/base.py
@@ -1,7 +1,7 @@
 """Base provider interface."""
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field, fields, replace
 from enum import StrEnum
 from logging import Logger
@@ -713,6 +713,17 @@ class BaseProvider(ABC):
             True if authenticated
         """
         pass
+
+    def model_aliases(self) -> Mapping[str, str]:
+        """Internal upstream aliases this provider recognizes.
+
+        Maps an incoming client model id -> a real upstream model id owned by
+        this provider. Used to satisfy synthetic model names (e.g. Codex's
+        ``codex-auto-review`` guardian model) that have no catalog entry. The
+        router normalizes a matching id to ``provider/<target>`` before route
+        resolution; aliases are never added to the model catalog.
+        """
+        return {}
 
     async def ensure_token(self) -> None:
         """Ensure the provider has a valid token.

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -58,6 +58,13 @@ COPILOT_CHAT_PATH = "/chat/completions"
 COPILOT_RESPONSES_PATH = "/responses"
 COPILOT_COUNT_TOKENS_PATH = "/v1/messages/count_tokens"
 
+# Internal model aliases bound to the Copilot provider. Maps a synthetic client
+# model id (with no GHC catalog entry) to a real upstream Copilot model. Codex's
+# Auto-review (guardian) mode issues Responses requests with model
+# ``codex-auto-review``, which only exists on the ChatGPT/Codex subscription
+# backend; route it to GHC's low-latency ``gpt-5.4-mini`` subagent model.
+COPILOT_MODEL_ALIASES: dict[str, str] = {"codex-auto-review": "gpt-5.4-mini"}
+
 _COPILOT_UNSUPPORTED_OPERATION_CODE = "unsupported_api_for_model"
 _MAX_COPILOT_ERROR_BODY_BYTES = 64 * 1024
 _EXACT_COPILOT_BARE_BAD_REQUEST = b"Bad Request\n"
@@ -731,6 +738,10 @@ class CopilotProvider(BaseProvider):
     def is_authenticated(self) -> bool:
         """Check if authenticated with GitHub Copilot."""
         return self._auth_session.is_authenticated()
+
+    def model_aliases(self) -> Mapping[str, str]:
+        """Synthetic model ids routed to real GHC models (see COPILOT_MODEL_ALIASES)."""
+        return COPILOT_MODEL_ALIASES
 
     async def ensure_token(self, force: bool = False) -> None:
         """Ensure we have a valid Copilot token, refreshing if needed.

--- a/src/router_maestro/routing/router.py
+++ b/src/router_maestro/routing/router.py
@@ -511,6 +511,9 @@ class Router:
         self._priorities_cache: TTLCache[PrioritiesConfig] = TTLCache(CACHE_TTL_SECONDS)
         # Fuzzy match result cache: raw_query -> resolved_cache_key (or None)
         self._fuzzy_cache: dict[str, str | None] = {}
+        # Provider-declared internal alias map: casefolded alias -> qualified id.
+        # Built lazily from provider.model_aliases(); static, no auth/catalog dep.
+        self._model_aliases: dict[str, str] | None = None
         # Providers config cache
         self._providers_ttl: TTLCache[bool] = TTLCache(CACHE_TTL_SECONDS)
         snapshot_config = getattr(config_snapshot, "config", config_snapshot)
@@ -601,6 +604,7 @@ class Router:
             self._models_cache.clear()
             self._fuzzy_cache.clear()
             self._models_cache_ttl.clear()
+            self._model_aliases = None
 
     def needs_provider_config_reload(self) -> bool:
         """Return whether this immutable managed generation needs replacement."""
@@ -825,6 +829,41 @@ class Router:
             return deepcopy(entry[1])
         return None
 
+    def _ensure_alias_map(self) -> dict[str, str]:
+        """Build (once) the provider-declared internal alias map.
+
+        Maps a casefolded synthetic alias to a fully-qualified ``provider/model``
+        id. Derived purely from ``provider.model_aliases()`` declarations, so it
+        needs neither authentication nor a fresh catalog. Invalidated (set to
+        ``None``) whenever providers reload.
+        """
+        cached = getattr(self, "_model_aliases", None)
+        if cached is not None:
+            return cached
+        aliases: dict[str, str] = {}
+        for provider_name, provider in getattr(self, "providers", {}).items():
+            for alias, target in provider.model_aliases().items():
+                try:
+                    qualified = ModelRef(provider_name, target).qualified_id
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "model_alias_skipped provider=%s alias=%s reason=invalid_target",
+                        provider_name,
+                        alias,
+                    )
+                    continue
+                aliases.setdefault(alias.casefold(), qualified)
+        self._model_aliases = aliases
+        return aliases
+
+    def _normalize_model_alias(self, model_id: str) -> str:
+        """Resolve a provider-declared internal alias to its qualified target id.
+
+        Idempotent: a real (unaliased) id maps to itself, so this is safe to call
+        at every routing entry point regardless of prior normalization.
+        """
+        return self._ensure_alias_map().get(model_id.casefold(), model_id)
+
     async def _resolve_provider(self, model_id: str) -> tuple[str, str, BaseProvider]:
         """Resolve model_id to provider.
 
@@ -837,6 +876,9 @@ class Router:
         Raises:
             ProviderError: If model not found or no models available
         """
+        # Normalize provider-declared internal aliases (e.g. codex-auto-review)
+        # to their real qualified target before any resolution runs.
+        model_id = self._normalize_model_alias(model_id)
         # Check for auto-routing
         if model_id == AUTO_ROUTE_MODEL:
             result = await self._get_auto_route_model()
@@ -1103,6 +1145,9 @@ class Router:
                 cause=error,
             ) from error
         await self._ensure_models_cache()
+        # Normalize provider-declared internal aliases (e.g. codex-auto-review)
+        # to their real qualified target so resolution flows the explicit path.
+        model_id = self._normalize_model_alias(model_id)
         features = features or RequestFeatures()
         explicit = self._is_explicit_model_id(model_id)
         if explicit:

--- a/tests/test_copilot_codex_auto_review_alias.py
+++ b/tests/test_copilot_codex_auto_review_alias.py
@@ -1,0 +1,170 @@
+"""Internal alias: Codex's ``codex-auto-review`` guardian model → GHC.
+
+OpenAI Codex's Auto-review mode issues Responses requests with model
+``codex-auto-review``, a synthetic id that only exists on the ChatGPT/Codex
+subscription backend — it is absent from GitHub Copilot's catalog and from the
+public OpenAI API, so it otherwise 404s at routing. The Copilot provider
+declares an internal alias (``COPILOT_MODEL_ALIASES``) that the router
+normalizes to a real GHC model before route resolution. These tests pin that
+contract at both the provider declaration and the two routing chokepoints
+(``plan_route`` and ``_resolve_provider``), and prove the alias never leaks into
+the public catalog.
+"""
+
+import pytest
+
+from router_maestro.config import PrioritiesConfig
+from router_maestro.providers import (
+    ChatRequest,
+    ChatResponse,
+    ModelInfo,
+    ProviderError,
+)
+from router_maestro.providers.base import BaseProvider
+from router_maestro.providers.copilot import COPILOT_MODEL_ALIASES, CopilotProvider
+from router_maestro.routing.capabilities import Operation, ProviderCapabilities
+from router_maestro.routing.model_ref import ModelRef
+from router_maestro.routing.router import CACHE_TTL_SECONDS, Router
+from router_maestro.utils.cache import TTLCache
+
+ALIAS = "codex-auto-review"
+TARGET = "gpt-5.4-mini"
+
+
+class AliasCopilotMock(BaseProvider):
+    """Stand-in for the Copilot provider that declares the guardian alias.
+
+    Mirrors the real ``CopilotProvider.model_aliases()`` contract without any
+    network/auth dependency, and exposes ``gpt-5.4-mini`` with ``/responses``
+    support so a normalized alias has a real catalog target to resolve against.
+    """
+
+    name = "github-copilot"
+
+    def __init__(self, *, authenticated: bool = True) -> None:
+        self._authenticated = authenticated
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(operations=frozenset(Operation))
+
+    def is_authenticated(self) -> bool:
+        return self._authenticated
+
+    async def ensure_token(self) -> None:
+        pass
+
+    async def chat_completion(self, request: ChatRequest) -> ChatResponse:
+        return ChatResponse(content="x", model=request.model, finish_reason="stop")
+
+    async def chat_completion_stream(self, request: ChatRequest):
+        yield ChatResponse(content="x", model=request.model, finish_reason="stop")
+
+    async def list_models(self) -> list[ModelInfo]:
+        return [
+            ModelInfo(
+                id=TARGET,
+                name="GPT-5.4 mini",
+                provider="github-copilot",
+                operation_capabilities={"responses": True, "chat": True},
+            )
+        ]
+
+    def model_aliases(self):
+        return {ALIAS: TARGET}
+
+
+def _make_router(provider: BaseProvider) -> Router:
+    """Build a Router (via ``__new__``) wired to a single provider, no I/O."""
+    router = Router.__new__(Router)
+    router.providers = {provider.name: provider}
+    router._models_cache = {}
+    router._models_cache_ttl = TTLCache(CACHE_TTL_SECONDS)
+    router._priorities_cache = TTLCache(CACHE_TTL_SECONDS)
+    router._fuzzy_cache = {}
+    router._providers_ttl = TTLCache(CACHE_TTL_SECONDS)
+    router._model_aliases = None
+    router._priorities_cache.set(PrioritiesConfig(priorities=[]))
+    router._providers_ttl.set(True)
+    return router
+
+
+def test_copilot_provider_declares_guardian_alias() -> None:
+    # The declaration lives with the provider that owns the target model.
+    assert CopilotProvider().model_aliases()[ALIAS] == TARGET
+    assert COPILOT_MODEL_ALIASES[ALIAS] == TARGET
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_normalizes_alias_to_target() -> None:
+    router = _make_router(AliasCopilotMock())
+    provider_name, upstream_id, provider = await router._resolve_provider(ALIAS)
+    assert provider_name == "github-copilot"
+    assert upstream_id == TARGET
+    assert provider is router.providers["github-copilot"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_provider_alias_is_case_insensitive() -> None:
+    router = _make_router(AliasCopilotMock())
+    provider_name, upstream_id, _ = await router._resolve_provider("Codex-Auto-Review")
+    assert (provider_name, upstream_id) == ("github-copilot", TARGET)
+
+
+@pytest.mark.asyncio
+async def test_plan_route_resolves_alias_for_responses() -> None:
+    router = _make_router(AliasCopilotMock())
+    plan = await router.plan_route(ALIAS, Operation.RESPONSES)
+    # Normalization flows the request through the explicit qualified-id path.
+    assert plan.explicit is True
+    assert plan.primary.model == ModelRef("github-copilot", TARGET)
+
+
+@pytest.mark.asyncio
+async def test_plan_route_alias_is_case_insensitive() -> None:
+    router = _make_router(AliasCopilotMock())
+    plan = await router.plan_route("CODEX-AUTO-REVIEW", Operation.RESPONSES)
+    assert plan.primary.model == ModelRef("github-copilot", TARGET)
+
+
+@pytest.mark.asyncio
+async def test_alias_absent_from_public_catalog() -> None:
+    # The alias is purely internal — it must never surface in the model list.
+    router = _make_router(AliasCopilotMock())
+    listed = await router.list_models()
+    ids = {model.id for model in listed}
+    assert TARGET in ids
+    assert ALIAS not in ids
+    assert not any(ALIAS in (model.id or "") for model in listed)
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_alias_still_404s_no_silent_pass() -> None:
+    # Normalization must not fabricate success: with Copilot unauthenticated the
+    # target is absent from cache, so the normalized id 404s naturally.
+    router = _make_router(AliasCopilotMock(authenticated=False))
+    with pytest.raises(ProviderError) as excinfo:
+        await router._resolve_provider(ALIAS)
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_beta_responses_resolver_rewrites_model_to_target(monkeypatch) -> None:
+    """Real-layer: the beta Responses route resolves the alias to the target.
+
+    Drives ``_resolve_responses_model`` — the exact resolver the beta passthrough
+    route feeds into ``body["model"] = resolution.actual_model`` — with a real
+    Router. A request whose ``model`` is ``codex-auto-review`` must yield
+    ``actual_model == "gpt-5.4-mini"``, i.e. the id sent upstream to GHC. This is
+    the layer Codex's guardian request actually hits, not a helper below it.
+    """
+    from router_maestro.routing.capabilities import RequestFeatures
+    from router_maestro.server.routes import openai_responses_beta as beta
+
+    router = _make_router(AliasCopilotMock())
+    monkeypatch.setattr(beta, "get_router", lambda: router)
+
+    resolution = await beta._resolve_responses_model(ALIAS, Operation.RESPONSES, RequestFeatures())
+
+    assert resolution.provider_name == "github-copilot"
+    assert resolution.actual_model == TARGET


### PR DESCRIPTION
## Problem

OpenAI Codex's **Auto-review** (guardian) mode issues a Responses API request with `model: "codex-auto-review"` to grade whether a boundary-crossing action should run. That model id **only exists on the ChatGPT/Codex subscription backend** — it is not in GitHub Copilot's (GHC) catalog and not in the public OpenAI API. When Codex is pointed at Router-Maestro, the guardian request hits routing, no provider owns `codex-auto-review`, and we return **HTTP 404 `model_not_found`**. Codex then fails the approval and the underlying command never runs (matches upstream `openai/codex#19420`).

## Fix

Add a **provider-bound internal alias**:

- `BaseProvider.model_aliases()` — new hook, default `{}`.
- `CopilotProvider` overrides it: `codex-auto-review → gpt-5.4-mini` (GHC's low-latency `/responses` subagent model, full reasoning range, tool calling).
- The router builds a casefolded `alias → qualified-id` map once from provider declarations and normalizes the incoming id to the **explicit** `github-copilot/gpt-5.4-mini` **before** resolution, at the top of **both** `plan_route` and `_resolve_provider` (the two 404 chokepoints). The normalized id then flows through the existing explicit-id path and sends `gpt-5.4-mini` upstream.

### Properties

- The alias is **never** inserted into `_models_cache`, so it stays out of `list_models()` / the admin catalog — purely internal.
- Normalization is **idempotent** (a real id maps to itself), so covering both entry points is safe.
- Provider reload invalidates the alias map.
- **Unauthenticated Copilot still 404s naturally** — no fake success.
- Covers every surface uniformly (chat, responses, beta passthrough, anthropic beta) because they all resolve through these two chokepoints.

## Why not a cache-injection alias

`plan_route`'s bare-alias branch sets `upstream_id = model_id` (the cache key itself) and matches candidates by `candidate.model.upstream_id == upstream_id`. A bare injected alias would make it try to send `codex-auto-review` upstream and match zero candidates → `NoCompatibleRouteError`. Normalizing to the explicit qualified id sidesteps this entirely.

## Tests

**Unit (8, `tests/test_copilot_codex_auto_review_alias.py`):** provider declaration, resolution at both `plan_route` and `_resolve_provider`, case-insensitivity, absence from `list_models()`, unauthenticated-still-404, and a real-layer test driving the beta route's `_resolve_responses_model` (the exact resolver that writes `body["model"] = resolution.actual_model`).

**Live integration (`integration_tests/test_live_review_fixes.py`):** a real `/responses` request with `model: "codex-auto-review"` — asserts 200 (not 404), `status == "completed"`, and that the response model resolves to `gpt-5.4-mini` (not the alias, proving real normalization). Verified against GHC: trace shows `upstream.json` `model=gpt-5.4-mini`, `outbound.json` `status=200`. Reuses the existing Copilot bare-400 retry helper.

## Verification

- `ruff check src/ tests/` — clean (ruff 0.14.14, matching CI)
- `ruff format --check src/ tests/` — clean
- Unit suite: **3484 passed**
- Live integration (new case + 5 siblings): passed against real GHC

Reviewed by the code-reviewer agent: no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)