### PR TITLE
fix: resilient Copilot token refresh + catalog thinking capability

### DIFF
--- a/integration_tests/test_live_anthropic_beta.py
+++ b/integration_tests/test_live_anthropic_beta.py
@@ -264,10 +264,11 @@ def test_beta_tool_choice_any(client: httpx.Client, tool_model: str):
 # ---------------------------------------------------------------------------
 
 
-def test_beta_thinking_non_streaming(client: httpx.Client, chat_model: str):
+def test_beta_thinking_non_streaming(client: httpx.Client, anthropic_thinking_models: list[str]):
     """Beta endpoint supports extended thinking natively."""
+    model = anthropic_thinking_models[0]
     payload = {
-        "model": chat_model,
+        "model": model,
         "messages": [{"role": "user", "content": "What is 7*8?"}],
         "max_tokens": 8000,
         "thinking": {"type": "enabled", "budget_tokens": 4000},
@@ -284,10 +285,11 @@ def test_beta_thinking_non_streaming(client: httpx.Client, chat_model: str):
     assert_anthropic_usage(data["usage"])
 
 
-def test_beta_thinking_streaming(client: httpx.Client, chat_model: str):
+def test_beta_thinking_streaming(client: httpx.Client, anthropic_thinking_models: list[str]):
     """Beta streaming surfaces thinking_delta and signature_delta events."""
+    model = anthropic_thinking_models[0]
     payload = {
-        "model": chat_model,
+        "model": model,
         "messages": [{"role": "user", "content": "What is 3+5?"}],
         "max_tokens": 8000,
         "stream": True,

--- a/src/router_maestro/auth/github_oauth.py
+++ b/src/router_maestro/auth/github_oauth.py
@@ -50,13 +50,6 @@ class GitHubOAuthError(Exception):
     pass
 
 
-def _is_retryable_token_error(error: httpx.HTTPError) -> bool:
-    """Whether a Copilot token refresh error is likely transient."""
-    if isinstance(error, httpx.HTTPStatusError):
-        return error.response.status_code == 429 or error.response.status_code >= 500
-    return True
-
-
 async def request_device_code(client: httpx.AsyncClient) -> DeviceCodeResponse:
     """Request a device code from GitHub.
 
@@ -168,23 +161,11 @@ async def get_copilot_token(
         "X-Vscode-User-Agent-Library-Version": "electron-fetch",
     }
 
-    response: httpx.Response | None = None
-    max_attempts = 3
-    for attempt in range(max_attempts):
-        try:
-            response = await client.get(
-                COPILOT_TOKEN_URL,
-                headers=headers,
-            )
-            response.raise_for_status()
-            break
-        except httpx.HTTPError as e:
-            if attempt == max_attempts - 1 or not _is_retryable_token_error(e):
-                raise
-            await _async_sleep(0.2 * (attempt + 1))
-
-    if response is None:
-        raise GitHubOAuthError("Failed to exchange GitHub token for Copilot token")
+    response = await client.get(
+        COPILOT_TOKEN_URL,
+        headers=headers,
+    )
+    response.raise_for_status()
 
     data = response.json()
     endpoints = data.get("endpoints")

--- a/src/router_maestro/providers/copilot_support/auth_session.py
+++ b/src/router_maestro/providers/copilot_support/auth_session.py
@@ -46,6 +46,13 @@ class CopilotAuthSession:
         mint: Callable[[httpx.AsyncClient, str], Awaitable[Any]] = get_copilot_token,
     ) -> None:
         """Ensure a usable Copilot token, serializing concurrent refreshes."""
+        # Fast-path: a valid in-memory token needs no disk read. This must run
+        # before get_credential() so a transient auth.json read failure cannot
+        # turn a perfectly good cached token into a spurious auth error.
+        current_time = int(time.time())
+        if not force and self.cached_token and self.token_expires > current_time + 60:
+            return
+
         cred = self.auth_manager.get_credential(self.provider_name)
         if not cred or not isinstance(cred, OAuthCredential):
             logger.error("Not authenticated with GitHub Copilot")
@@ -58,10 +65,6 @@ class CopilotAuthSession:
 
         if cred.api_endpoint:
             self.api_base = cred.api_endpoint
-
-        current_time = int(time.time())
-        if not force and self.cached_token and self.token_expires > current_time + 60:
-            return
 
         token_before_lock = self.cached_token
         async with self.token_refresh_lock:

--- a/src/router_maestro/providers/copilot_support/auth_session.py
+++ b/src/router_maestro/providers/copilot_support/auth_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 import time
 from collections.abc import Awaitable, Callable
 from typing import Any, NoReturn
@@ -10,7 +11,11 @@ from typing import Any, NoReturn
 import httpx
 
 from router_maestro.auth import AuthManager, AuthType, CredentialRepository
-from router_maestro.auth.github_oauth import GitHubOAuthError, get_copilot_token
+from router_maestro.auth.github_oauth import (
+    GitHubOAuthError,
+    _async_sleep,
+    get_copilot_token,
+)
 from router_maestro.auth.storage import OAuthCredential
 from router_maestro.providers.base import ProviderError, ProviderFailureKind
 from router_maestro.utils import get_logger
@@ -19,6 +24,19 @@ logger = get_logger("providers.copilot.auth")
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 AUTH_RETRY_STATUSES = frozenset({401, 403})
+
+# Token-mint retry policy. Retry only genuinely transient failures — NOT
+# AUTHENTICATION: this codebase raises 401/403 with retryable=True to drive
+# the router's cross-provider fallback, which is unrelated to re-minting.
+_RETRYABLE_MINT_KINDS = frozenset(
+    {
+        ProviderFailureKind.RATE_LIMIT,
+        ProviderFailureKind.UPSTREAM_STATUS,
+        ProviderFailureKind.TRANSPORT,
+    }
+)
+_MINT_MAX_RETRIES = 3
+_MINT_BACKOFF_BASE = 0.3
 
 
 class CopilotAuthSession:
@@ -37,6 +55,94 @@ class CopilotAuthSession:
     def is_authenticated(self) -> bool:
         cred = self.auth_manager.get_credential(self.provider_name)
         return cred is not None and cred.type == AuthType.OAUTH
+
+    async def _mint_token(
+        self,
+        cred: OAuthCredential,
+        mint: Callable[[httpx.AsyncClient, str], Awaitable[Any]],
+    ) -> Any:
+        """Mint a Copilot token, mapping HTTP errors to ProviderError.
+
+        Raises the mapped ProviderError on failure; the retry policy lives in
+        the caller (_mint_with_retry).
+        """
+        logger.debug("Refreshing Copilot token")
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0)
+            ) as client:
+                return await mint(client, cred.refresh)
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code in AUTH_RETRY_STATUSES:
+                logger.error(
+                    "GitHub Copilot authentication failed (%s)",
+                    error.response.status_code,
+                )
+                raise ProviderError(
+                    "GitHub Copilot authentication expired. If Copilot is your only "
+                    "provider, re-authenticate: `router-maestro auth login github-copilot`.",
+                    status_code=401,
+                    retryable=True,
+                    kind=ProviderFailureKind.AUTHENTICATION,
+                    upstream_status_code=error.response.status_code,
+                    provider=self.provider_name,
+                    cause=error,
+                ) from error
+            logger.error(
+                "Failed to refresh Copilot token: status=%d",
+                error.response.status_code,
+            )
+            kind = (
+                ProviderFailureKind.RATE_LIMIT
+                if error.response.status_code in (429, 529)
+                else ProviderFailureKind.UPSTREAM_STATUS
+            )
+            raise ProviderError(
+                "Failed to refresh Copilot token",
+                status_code=error.response.status_code,
+                retryable=(error.response.status_code == 429 or error.response.status_code >= 500),
+                kind=kind,
+                upstream_status_code=error.response.status_code,
+                provider=self.provider_name,
+                cause=error,
+            ) from error
+        except (httpx.HTTPError, GitHubOAuthError) as error:
+            logger.error("Failed to refresh Copilot token (%s)", type(error).__name__)
+            raise ProviderError(
+                "Failed to refresh Copilot token",
+                status_code=502,
+                retryable=True,
+                kind=ProviderFailureKind.TRANSPORT,
+                provider=self.provider_name,
+                cause=error,
+            ) from error
+
+    async def _mint_with_retry(
+        self,
+        cred: OAuthCredential,
+        mint: Callable[[httpx.AsyncClient, str], Awaitable[Any]],
+    ) -> Any:
+        """Mint a token, retrying transient failures with bounded backoff.
+
+        Only RATE_LIMIT / UPSTREAM_STATUS / TRANSPORT failures are retried;
+        AUTHENTICATION (a genuinely expired credential) surfaces immediately.
+        """
+        attempt = 0
+        while True:
+            try:
+                return await self._mint_token(cred, mint)
+            except ProviderError as error:
+                if error.kind not in _RETRYABLE_MINT_KINDS or attempt >= _MINT_MAX_RETRIES:
+                    raise
+                delay = _MINT_BACKOFF_BASE * (2**attempt) + random.uniform(0, 0.1)
+                logger.warning(
+                    "copilot_token_mint_retry attempt=%d kind=%s delay=%.2f",
+                    attempt + 1,
+                    error.kind.value,
+                    delay,
+                )
+                await _async_sleep(delay)
+                attempt += 1
 
     async def ensure_token(
         self,
@@ -84,58 +190,7 @@ class CopilotAuthSession:
                     provider=self.provider_name,
                 )
 
-            logger.debug("Refreshing Copilot token")
-            try:
-                async with httpx.AsyncClient(
-                    timeout=httpx.Timeout(connect=10.0, read=30.0, write=10.0, pool=10.0)
-                ) as client:
-                    copilot_token = await mint(client, cred.refresh)
-            except httpx.HTTPStatusError as error:
-                if error.response.status_code in AUTH_RETRY_STATUSES:
-                    logger.error(
-                        "GitHub Copilot authentication failed (%s)",
-                        error.response.status_code,
-                    )
-                    raise ProviderError(
-                        "GitHub Copilot authentication expired. If Copilot is your only "
-                        "provider, re-authenticate: `router-maestro auth login github-copilot`.",
-                        status_code=401,
-                        retryable=True,
-                        kind=ProviderFailureKind.AUTHENTICATION,
-                        upstream_status_code=error.response.status_code,
-                        provider=self.provider_name,
-                        cause=error,
-                    ) from error
-                logger.error(
-                    "Failed to refresh Copilot token: status=%d",
-                    error.response.status_code,
-                )
-                kind = (
-                    ProviderFailureKind.RATE_LIMIT
-                    if error.response.status_code in (429, 529)
-                    else ProviderFailureKind.UPSTREAM_STATUS
-                )
-                raise ProviderError(
-                    "Failed to refresh Copilot token",
-                    status_code=error.response.status_code,
-                    retryable=(
-                        error.response.status_code == 429 or error.response.status_code >= 500
-                    ),
-                    kind=kind,
-                    upstream_status_code=error.response.status_code,
-                    provider=self.provider_name,
-                    cause=error,
-                ) from error
-            except (httpx.HTTPError, GitHubOAuthError) as error:
-                logger.error("Failed to refresh Copilot token (%s)", type(error).__name__)
-                raise ProviderError(
-                    "Failed to refresh Copilot token",
-                    status_code=502,
-                    retryable=True,
-                    kind=ProviderFailureKind.TRANSPORT,
-                    provider=self.provider_name,
-                    cause=error,
-                ) from error
+            copilot_token = await self._mint_with_retry(cred, mint)
 
             self.cached_token = copilot_token.token
             self.token_expires = copilot_token.expires_at

--- a/src/router_maestro/providers/copilot_support/catalog.py
+++ b/src/router_maestro/providers/copilot_support/catalog.py
@@ -244,7 +244,7 @@ class CopilotCatalog:
                     max_context_window_tokens=normalize_catalog_limit(
                         limits, "max_context_window_tokens"
                     ),
-                    supports_thinking=thinking_support is True,
+                    supports_thinking=(thinking_support is True or bool(reasoning_values)),
                     supports_vision=vision_support is True,
                     reasoning_effort_values=reasoning_values,
                     supported_endpoints=supported_endpoints,

--- a/tests/test_auth_advanced.py
+++ b/tests/test_auth_advanced.py
@@ -95,28 +95,18 @@ class TestGitHubOAuth:
         assert token.api_endpoint == "https://api.enterprise.githubcopilot.com"
 
     @pytest.mark.asyncio
-    async def test_get_copilot_token_retries_transient_errors(self):
-        """Transient refresh failures should be retried before surfacing to callers."""
-        ok = httpx.Response(
-            200,
-            json={
-                "token": "copilot-token",
-                "expires_at": 1234567890,
-                "refresh_in": 1000,
-            },
-            request=httpx.Request("GET", "https://api.github.com/copilot_internal/v2/token"),
-        )
+    async def test_get_copilot_token_makes_single_attempt(self):
+        """Token exchange no longer retries internally; the caller owns retry."""
         client = AsyncMock()
-        client.get.side_effect = [
-            httpx.ConnectError("temporary"),
-            ok,
-        ]
+        client.get.side_effect = httpx.ConnectError("temporary")
 
-        with patch("router_maestro.auth.github_oauth._async_sleep", new=AsyncMock()):
-            token = await get_copilot_token(client, "github-token")
+        with (
+            patch("router_maestro.auth.github_oauth._async_sleep", new=AsyncMock()),
+            pytest.raises(httpx.ConnectError),
+        ):
+            await get_copilot_token(client, "github-token")
 
-        assert token.token == "copilot-token"
-        assert client.get.call_count == 2
+        assert client.get.call_count == 1
 
     @pytest.mark.asyncio
     async def test_get_copilot_token_does_not_retry_auth_errors(self):

--- a/tests/test_auth_session_retry.py
+++ b/tests/test_auth_session_retry.py
@@ -1,0 +1,53 @@
+"""Resilience contracts for CopilotAuthSession.ensure_token."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from router_maestro.auth.storage import OAuthCredential
+from router_maestro.providers.base import ProviderError, ProviderFailureKind
+from router_maestro.providers.copilot_support.auth_session import CopilotAuthSession
+
+
+def _oauth(access: str = "copilot-token") -> OAuthCredential:
+    return OAuthCredential(
+        refresh="github-refresh",
+        access=access,
+        expires=2**31,
+        api_endpoint="https://api.githubcopilot.com",
+    )
+
+
+def _session_with_stub_manager() -> tuple[CopilotAuthSession, MagicMock]:
+    """A session whose auth_manager.get_credential is a controllable mock."""
+    session = CopilotAuthSession.__new__(CopilotAuthSession)
+    session.provider_name = "github-copilot"
+    session.cached_token = None
+    session.token_expires = 0
+    session.api_base = "https://api.githubcopilot.com"
+    import asyncio
+
+    session.token_refresh_lock = asyncio.Lock()
+    manager = MagicMock()
+    session.auth_manager = manager
+    return session, manager
+
+
+@pytest.mark.asyncio
+async def test_valid_cached_token_skips_disk_read():
+    """A valid in-memory token must return without reading auth.json."""
+    session, manager = _session_with_stub_manager()
+    session.cached_token = "live-token"
+    session.token_expires = int(time.time()) + 3600
+    # If the fast-path is correct, get_credential is never consulted; make it
+    # explode so any disk read fails the test.
+    manager.get_credential.side_effect = AssertionError("disk read must not happen")
+
+    await session.ensure_token()
+
+    manager.get_credential.assert_not_called()
+    assert session.cached_token == "live-token"

--- a/tests/test_auth_session_retry.py
+++ b/tests/test_auth_session_retry.py
@@ -51,3 +51,102 @@ async def test_valid_cached_token_skips_disk_read():
 
     manager.get_credential.assert_not_called()
     assert session.cached_token == "live-token"
+
+
+class _FlakyMint:
+    """A mint callable that raises `errors[i]` on call i, else returns a token."""
+
+    def __init__(self, errors: list[ProviderError | None]):
+        self._errors = errors
+        self.calls = 0
+
+    async def __call__(self, _client, _refresh):
+        idx = self.calls
+        self.calls += 1
+        err = self._errors[idx] if idx < len(self._errors) else None
+        if err is not None:
+            raise err
+        return SimpleNamespace(
+            token="minted-token",
+            expires_at=2**31,
+            api_endpoint="https://api.githubcopilot.com",
+        )
+
+
+def _transient(kind=ProviderFailureKind.UPSTREAM_STATUS) -> ProviderError:
+    return ProviderError(
+        "Failed to refresh Copilot token",
+        status_code=502,
+        retryable=True,
+        kind=kind,
+        provider="github-copilot",
+    )
+
+
+def _auth_error() -> ProviderError:
+    return ProviderError(
+        "GitHub Copilot authentication expired.",
+        status_code=401,
+        retryable=True,  # router-fallback flag; must NOT trigger local retry
+        kind=ProviderFailureKind.AUTHENTICATION,
+        provider="github-copilot",
+    )
+
+
+async def _noop_persist(_cred) -> None:
+    return None
+
+
+@pytest.fixture
+def _fast_backoff(monkeypatch):
+    """Make retry backoff instant so tests add no wall-clock delay."""
+    from unittest.mock import AsyncMock
+
+    from router_maestro.providers.copilot_support import auth_session as mod
+
+    monkeypatch.setattr(mod, "_async_sleep", AsyncMock())
+
+
+def _session_needs_refresh() -> tuple[CopilotAuthSession, MagicMock]:
+    session, manager = _session_with_stub_manager()
+    manager.get_credential.return_value = _oauth()
+    manager.get_credential.side_effect = None
+    return session, manager
+
+
+@pytest.mark.asyncio
+async def test_retry_rides_out_transient_mint_failures(_fast_backoff):
+    """Two transient failures then success => ensure_token succeeds, mint x3."""
+    session, _ = _session_needs_refresh()
+    mint = _FlakyMint([_transient(), _transient(ProviderFailureKind.TRANSPORT), None])
+
+    await session.ensure_token(persist=_noop_persist, mint=mint)
+
+    assert mint.calls == 3
+    assert session.cached_token == "minted-token"
+
+
+@pytest.mark.asyncio
+async def test_authentication_failure_is_not_retried(_fast_backoff):
+    """A 401/403 mint error surfaces immediately, mint called exactly once."""
+    session, _ = _session_needs_refresh()
+    mint = _FlakyMint([_auth_error()])
+
+    with pytest.raises(ProviderError) as exc:
+        await session.ensure_token(persist=_noop_persist, mint=mint)
+
+    assert exc.value.kind == ProviderFailureKind.AUTHENTICATION
+    assert mint.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_reraises_transient_error(_fast_backoff):
+    """Always-transient mint => raises after 1 + 3 retries = 4 attempts."""
+    session, _ = _session_needs_refresh()
+    mint = _FlakyMint([_transient(), _transient(), _transient(), _transient(), _transient()])
+
+    with pytest.raises(ProviderError) as exc:
+        await session.ensure_token(persist=_noop_persist, mint=mint)
+
+    assert exc.value.retryable is True
+    assert mint.calls == 4

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -515,6 +515,53 @@ async def test_copilot_catalog_preserves_explicit_capabilities_and_unknown_keys(
 
 
 @pytest.mark.asyncio
+async def test_copilot_catalog_reasoning_effort_implies_supports_thinking():
+    """A model advertising reasoning_effort tiers supports thinking even when the
+    Copilot catalog omits/denies ``supports.thinking``.
+
+    GitHub Copilot's catalog reports ``supports.thinking`` as false (or omits it)
+    for reasoning-capable Claude/GPT/Gemini models that nonetheless expose
+    ``reasoning_effort`` tiers. ``supports_thinking`` must follow the same
+    ``thinking OR reasoning_effort`` rule the REASONING feature already uses, so
+    the native passthrough does not strip a valid thinking request.
+    """
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "claude-sonnet-4.6",
+                        "name": "Claude Sonnet 4.6",
+                        "capabilities": {
+                            "type": "chat",
+                            "supports": {
+                                "thinking": False,
+                                "reasoning_effort": ["low", "medium", "high", "max"],
+                            },
+                        },
+                    },
+                ]
+            },
+            request=httpx.Request("GET", "https://api.githubcopilot.com/models"),
+        )
+
+    provider = CopilotProvider()
+    provider._cached_token = "token"
+    provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
+    with patch(
+        "httpx.AsyncClient",
+        return_value=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    ):
+        (model,) = await provider.list_models(force_refresh=True)
+
+    assert model.reasoning_effort_values == ["low", "medium", "high", "max"]
+    assert model.supports_thinking is True
+    assert model.feature_capabilities[Feature.REASONING] is True
+
+
+@pytest.mark.asyncio
 async def test_copilot_catalog_results_are_deep_defensive_copies():
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Summary

Two independent fixes. The first is the branch's purpose (Copilot token-refresh resilience); the second is a pre-existing catalog bug this branch's full integration run surfaced, fixed here at the source.

## 1. Copilot token refresh resilience

A single transient failure while refreshing a Copilot token could fail requests that were otherwise fine. Two defects in `CopilotAuthSession.ensure_token`:

- **Read-after-write race.** `ensure_token` read `auth.json` (`get_credential()`) *before* checking the valid in-memory token, so a momentary disk-read hiccup turned a perfectly good cached token into a spurious `Not authenticated` error.
- **502 pass-through.** A GitHub 5xx/network blip while minting the token propagated as a hard failure — `ensure_token` did not retry.

### Changes
- **Hoist the cached-token fast-path above the disk read** (`08aa4f8`, `0e2b8f1`). A valid in-memory token now returns immediately, never touching `auth.json`.
- **Bounded, kind-based retry around the mint** (`a5a0827`). Retries only genuinely transient failures (`RATE_LIMIT` / `UPSTREAM_STATUS` / `TRANSPORT`) — 3 retries, `0.3·2ⁿ` backoff + jitter (~2s cap). `AUTHENTICATION` (401/403) is **never** retried, even though this codebase raises it with `retryable=True` (that flag drives router fallback, not re-minting). The mint + error-mapping is extracted into `_mint_token`; `_mint_with_retry` owns the policy.
- **Single-attempt `get_copilot_token`** (`08aa4f8`). Removed the lower-layer inner retry so retry lives in exactly one place (no 3×3 multiplication).

Retry now lives in one layer; the `force=True` (401/403 self-heal) path shares it.

## 2. Catalog `supports_thinking` derivation

GitHub Copilot's catalog reports `supports.thinking=false` (or omits it) for **18** reasoning-capable models (`claude-sonnet-4.6`, `claude-opus-4.6/4.7/4.8`, `claude-sonnet-5`, `gpt-5.x`, `gemini-3.x`) that nonetheless advertise `reasoning_effort` tiers. The native Anthropic beta passthrough trusted that flag and **stripped a valid `thinking` request**, so these models returned reasoning as plain text with no thinking block.

- **Source fix** (`c7a0dba`): `supports_thinking` now follows the same `thinking OR reasoning_effort` rule the `REASONING` feature already uses two lines below in the same function.
- **Test fix** (`f31d074`): two beta thinking tests asserted a thinking block but drew their model from the generic `chat_model` fixture (which can resolve to `claude-haiku-4.5`, genuinely non-reasoning on Copilot). Repointed to the `anthropic_thinking_models` fixture.

## Testing

- **Unit:** 3491 passed, 0 failures (the 18-model `supports_thinking` flip caused zero unit fallout). New tests: `test_auth_session_retry.py` (fast-path skips disk read; retry rides out transient then succeeds; `AUTHENTICATION` not retried; exhaustion re-raises after 4 attempts), single-attempt `get_copilot_token`, and catalog `reasoning_effort` → `supports_thinking`.
- **Integration (full live suite):** 79 passed, 3 skipped, 0 failed. The 4 tests that failed before the thinking fix (`test_beta_thinking_non_streaming`, `test_beta_thinking_streaming`, `test_beta_thinking_budget_matrix`, `test_anthropic_claude_thinking_budget_matrix`) all pass now.
- ruff lint + format clean across `src/`, `tests/`, `integration_tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)