### PR TITLE
chore: release v0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.7.6 (2026-07-23)
+
+### Fixes
+
+- **Resilient Copilot token refresh.** `ensure_token` now checks the valid
+  in-memory token before reading `auth.json`, so a transient credential-read
+  hiccup no longer turns a good cached token into a spurious `Not authenticated`
+  error. The token mint gained a bounded, kind-based retry (3 retries, `0.3·2ⁿ`
+  backoff + jitter) for genuinely transient failures (`RATE_LIMIT` /
+  `UPSTREAM_STATUS` / `TRANSPORT`); `AUTHENTICATION` (401/403) is never retried.
+  Retry now lives in a single layer — the inner retry in `get_copilot_token`
+  was removed to avoid multiplicative attempts.
+- **Catalog thinking capability for reasoning models.** GitHub Copilot's catalog
+  reports `supports.thinking=false` for reasoning-capable models (e.g.
+  `claude-sonnet-4.6`, `claude-opus-4.6/4.7/4.8`, `claude-sonnet-5`, `gpt-5.x`,
+  `gemini-3.x`) that nonetheless expose `reasoning_effort` tiers. The native
+  Anthropic beta passthrough trusted that flag and stripped a valid `thinking`
+  request, so these models returned reasoning as plain text with no thinking
+  block. `supports_thinking` now follows the same `thinking OR reasoning_effort`
+  rule the `REASONING` feature already uses.
+
 ## v0.7.5 (2026-07-21)
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.7.5"
+version = "0.7.6"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Patch release. Bumps `pyproject.toml`, `__init__.py`, `uv.lock` to `0.7.6` and adds the CHANGELOG entry for the fixes merged in #157:

- Resilient Copilot token refresh (cached-token fast-path + bounded kind-based mint retry; single-layer retry).
- Catalog `supports_thinking` now derived from `reasoning_effort` tiers, so reasoning-capable models (sonnet-4.6, opus-4.x, gpt-5.x, gemini-3.x) keep their native `thinking` on the beta passthrough.

Merging this, then tagging `v0.7.6` triggers the GHA release (PyPI + Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)