### PR TITLE
chore: release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
-## Unreleased
+## v0.7.7 (2026-07-23)
+
+### Features
+
+- **Bidirectional Gemini reasoning passthrough.** Parse
+  `generationConfig.thinkingConfig` (`thinkingBudget`: `>0` enabled / `0`
+  disabled / `-1` adaptive; `includeThoughts`) into the internal `ChatRequest`
+  so reasoning flows through `resolve_reasoning` and routing treats the request
+  as reasoning-capable. On the response side, emit Gemini thought parts
+  (`{text, thought: true}`) for both non-stream and stream when
+  `includeThoughts` is set. Non-reasoning Gemini models still strip cleanly.
 
 ### Fixes
 
@@ -12,6 +22,13 @@ All notable changes to Router-Maestro are documented here.
   persisted Copilot access token while it remains valid, allow a still-unexpired token to
   survive exhausted proactive-refresh retries, and propagate cold-start catalog failures
   instead of misclassifying the requested model as missing.
+- **Consistent `reasoning.effort` validation on the Responses beta native path.**
+  The beta native `/responses` path lacked the standard path's strict effort
+  `Literal` gate, so an invalid effort was silently clamp-and-forwarded (`200`
+  where the standard path `400`s) and, in the cold-catalog + known-reasoning
+  window, forwarded verbatim upstream. Validate `reasoning.effort` via
+  `ResponsesReasoningConfig` before native dispatch so both entry points return
+  an identical native `400` with `parameter=reasoning_effort`.
 
 ## v0.7.6 (2026-07-23)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.7.6"
+version = "0.7.7"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.7.6"
+version = "0.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Version bump **0.7.6 → 0.7.7**, rolling up everything merged since the last release.

## Included

- **#159** — Copilot refresh-outage resilience: reuse a still-valid persisted token after restart, keep an unexpired token usable when proactive-refresh retries exhaust, and propagate cold-start catalog failures as retryable 502s instead of persistent 404s.
- **#160** — Reasoning-path consistency across GHC entry paths: bidirectional Gemini reasoning passthrough (`thinkingConfig` ⇄ thought parts), and strict `reasoning.effort` validation on the Responses beta native path (matches the standard path's native 400).

## Release mechanics

- `pyproject.toml`, `src/router_maestro/__init__.py`, `uv.lock` bumped to `0.7.7`.
- `CHANGELOG.md`: `## Unreleased` finalized as `## v0.7.7` and #160 added (it was missing from the changelog).
- Affected test suites green locally: `test_auth_session_retry`, `test_router`, `test_gemini_routes`, `test_openai_responses_beta` — 132 passed.

Tag `v0.7.7` will be pushed after merge to trigger the PyPI + Docker + GitHub Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)