### PR TITLE
fix: accept zero-argument tool calls in Anthropic stream reducer

### DIFF
--- a/src/router_maestro/server/protocols/anthropic_reducer.py
+++ b/src/router_maestro/server/protocols/anthropic_reducer.py
@@ -115,9 +115,9 @@ def _parse_tool_call(tool_call: dict[str, Any]) -> ToolCall:
         raise AnthropicStreamProtocolError("tool call missing name")
     arguments = function.get("arguments", "{}")
     if isinstance(arguments, str):
-        arguments_json = arguments
+        arguments_json = arguments if arguments.strip() else "{}"
         try:
-            parsed = json.loads(arguments) if arguments else {}
+            parsed = json.loads(arguments_json)
         except (json.JSONDecodeError, TypeError) as exc:
             raise AnthropicStreamProtocolError(
                 "tool call arguments must be a valid JSON object"
@@ -135,6 +135,12 @@ def _parse_tool_call(tool_call: dict[str, Any]) -> ToolCall:
         input=parsed,
         arguments_json=arguments_json,
     )
+
+
+def _joined_arguments(call: AnthropicToolCallAccumulator) -> str:
+    """Join buffered argument fragments, treating a zero-argument call as ``{}``."""
+    joined = "".join(call.argument_fragments)
+    return joined if joined.strip() else "{}"
 
 
 def _response_parts(response: ChatResponse) -> list[ContentPart]:
@@ -504,7 +510,7 @@ class AnthropicReducer:
                 raise AnthropicStreamProtocolError("tool call missing id")
             if not call.name:
                 raise AnthropicStreamProtocolError("tool call missing name")
-            arguments = "".join(call.argument_fragments)
+            arguments = _joined_arguments(call)
             try:
                 parsed = json.loads(arguments)
             except (json.JSONDecodeError, TypeError) as exc:
@@ -528,7 +534,7 @@ class AnthropicReducer:
                     "id": call.tool_id,
                     "function": {
                         "name": call.name,
-                        "arguments": "".join(call.argument_fragments),
+                        "arguments": _joined_arguments(call),
                     },
                 }
             )

--- a/tests/test_anthropic_reducer.py
+++ b/tests/test_anthropic_reducer.py
@@ -215,6 +215,50 @@ def test_tools_are_transactional_and_flush_in_explicit_index_order() -> None:
     assert [block["id"] for block in _reconstruct_blocks(events)] == ["tool-b", "tool-a"]
 
 
+@pytest.mark.parametrize(
+    "arguments",
+    [None, "", "   "],
+    ids=["no-arguments-field", "empty-string", "whitespace-only"],
+)
+def test_stream_zero_argument_tool_call_becomes_empty_object(arguments: str | None) -> None:
+    reducer = AnthropicReducer(response_id="msg_test", model="provider/model")
+    reducer.start()
+    reducer.reduce(
+        ChatStreamChunk(
+            content="",
+            tool_calls=[_tool_call(index=0, tool_id="tool-a", name="alpha", arguments=arguments)],
+        )
+    )
+
+    events = reducer.reduce(ChatStreamChunk(content="", finish_reason="tool_calls"))
+
+    assert _reconstruct_blocks(events) == [
+        {"type": "tool_use", "id": "tool-a", "name": "alpha", "input": {}}
+    ]
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    ["", "   "],
+    ids=["empty-string", "whitespace-only"],
+)
+def test_nonstream_zero_argument_tool_call_becomes_empty_object(arguments: str) -> None:
+    downstream = build_anthropic_response(
+        ChatResponse(
+            content=None,
+            model="upstream-model",
+            finish_reason="tool_calls",
+            tool_calls=[{"id": "tool-a", "function": {"name": "alpha", "arguments": arguments}}],
+        ),
+        response_id="msg_test",
+        model="provider/upstream-model",
+    )
+
+    assert [block.model_dump(exclude_none=True) for block in downstream.content] == [
+        {"type": "tool_use", "id": "tool-a", "name": "alpha", "input": {}}
+    ]
+
+
 def test_malformed_tool_terminal_is_transactional() -> None:
     reducer = AnthropicReducer(response_id="msg_test", model="provider/model")
     reducer.start()


### PR DESCRIPTION
## Problem

A tool call with an empty argument schema aborts the Anthropic stream with a 502:

```
AnthropicStreamProtocolError: tool call arguments must be a valid JSON object
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Upstream (GitHub Copilot) emits only `id` + `name` for a zero-argument tool call and never sends a `function.arguments` fragment. `_accumulate_tool_call` also drops empty-string fragments via `if arguments:`, so `argument_fragments` stays empty. At the terminal, `_validated_tool_calls` joins that empty list and calls `json.loads("")`, which raises. The whole stream is then aborted with `upstream_protocol_error`.

## Fix

Normalize an empty or whitespace-only argument buffer to `"{}"` in both places it is consumed:

1. before terminal validation in `_validated_tool_calls`
2. when building the `input_json_delta` payload

The second site matters independently — even with validation relaxed, forwarding an empty `partial_json` leaves the downstream client with an unparseable `tool_use` block.

The non-streaming path already tolerated this via `json.loads(arguments) if arguments else {}`, so the two paths disagreed on identical upstream data. `_parse_tool_call` now normalizes `arguments_json` the same way instead of passing the empty string through to `partial_json`.

## Tests

Added 5 parametrized cases covering the streaming path (missing `arguments` field, empty string, whitespace-only) and the non-streaming path (empty string, whitespace-only), asserting both produce a `tool_use` block with `input: {}`.

`uv run pytest tests/test_anthropic_reducer.py tests/test_translation_advanced.py` → 102 passed. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)