### PR TITLE
test: pin zero-argument tool call wire format at the Anthropic boundary

### DIFF
--- a/integration_tests/test_controlled_boundaries.py
+++ b/integration_tests/test_controlled_boundaries.py
@@ -862,3 +862,92 @@ def test_responses_reasoning_effort_downgraded_to_catalog_tier(tmp_path: Path):
     assert response.status_code == 200, response.text
     request = select_recorded_request(upstream.requests, method="POST", path="/responses")
     assert request.payload["reasoning"]["effort"] == "high"
+
+
+@pytest.mark.parametrize(
+    "upstream_arguments",
+    [None, "", "   "],
+    ids=["no-arguments-field", "empty-string", "whitespace-only"],
+)
+def test_anthropic_stream_zero_argument_tool_call_emits_empty_object_on_the_wire(
+    tmp_path: Path,
+    upstream_arguments: str | None,
+):
+    """A zero-parameter tool must reach the client as ``partial_json: "{}"``.
+
+    Upstream sends only ``id``/``name`` for a tool whose schema has no
+    properties. Previously the reducer joined an empty fragment buffer to ``""``
+    and ``json.loads("")`` aborted the whole stream with a 502
+    ``upstream_protocol_error``; forwarding the empty buffer verbatim would
+    instead leave the client with an unparseable ``tool_use`` block. This
+    asserts the literal wire bytes, not a re-parsed value.
+    """
+    function: dict[str, Any] = {"name": "get_current_time"}
+    if upstream_arguments is not None:
+        function["arguments"] = upstream_arguments
+
+    def responder(request: RecordedUpstreamRequest):
+        if request.path == "/models":
+            return _models(_catalog_model("tool-model", endpoints=["/chat/completions"]))
+        return _sse_reply(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {"index": 0, "id": "toolu_zero", "function": function},
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+        )
+
+    with _controlled_copilot(
+        tmp_path,
+        responder,
+        priorities=["github-copilot/tool-model"],
+    ) as (client, upstream):
+        response = client.post(
+            "/api/anthropic/v1/messages",
+            json={
+                "model": "router-maestro",
+                "max_tokens": 64,
+                "stream": True,
+                "messages": [{"role": "user", "content": "what time is it"}],
+                "tools": [
+                    {
+                        "name": "get_current_time",
+                        "description": "Return the current time.",
+                        "input_schema": {"type": "object", "properties": {}},
+                    }
+                ],
+                "tool_choice": {"type": "tool", "name": "get_current_time"},
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        events = parse_sse_events(response)
+
+    payloads = [payload for _name, payload in events if isinstance(payload, dict)]
+    assert not [payload for payload in payloads if payload.get("type") == "error"], payloads
+
+    starts = [
+        payload
+        for payload in payloads
+        if payload.get("type") == "content_block_start"
+        and payload["content_block"]["type"] == "tool_use"
+    ]
+    assert [block["content_block"]["name"] for block in starts] == ["get_current_time"]
+
+    deltas = [
+        payload
+        for payload in payloads
+        if payload.get("type") == "content_block_delta"
+        and payload["delta"]["type"] == "input_json_delta"
+    ]
+    assert [delta["delta"]["partial_json"] for delta in deltas] == ["{}"]
+    assert [payload["type"] for payload in payloads].count("message_stop") == 1
+    assert len([r for r in upstream.requests if r.path == "/chat/completions"]) == 1


### PR DESCRIPTION
Follow-up to #162.

That PR fixed the reducer so a zero-parameter tool call becomes `input: {}` instead of aborting the stream with a 502 `upstream_protocol_error`. The tests it shipped exercise `AnthropicReducer` / `build_anthropic_response` directly — nothing asserted what actually reaches the client over the wire.

## Gap

`_reconstruct_blocks` in `tests/test_anthropic_reducer.py` re-parses `partial_json` with `json.loads` before asserting:

https://github.com/MadSkittles/Router-Maestro/blob/ed4dfa78a1b1a7dcd7fa2e51166e235043351b18/tests/test_anthropic_reducer.py#L67-L70

So it verifies "the normalized value parses to `{}`", not "the SSE stream carried the string `"{}"`". If the empty buffer were forwarded verbatim the unit test would still pass while clients received an unparseable `tool_use` block.

## Change

One parametrized test in `integration_tests/test_controlled_boundaries.py` that drives `/api/anthropic/v1/messages` against the scripted upstream and asserts the literal `partial_json` bytes, plus the absence of any `error` event and exactly one `message_stop`.

Parametrized over the three shapes upstream sends for a tool with no properties: no `arguments` field, `""`, `"   "`.

## Verification

Confirmed it's a real regression guard, not a vacuous pass — reverting `anthropic_reducer.py` to `fada284` (pre-fix) fails all three:

```
AssertionError: [... {'error': {'message': 'Invalid tool call from upstream',
                                'type': 'api_error'}, 'type': 'error'}]
```

That is the exact 502 path #162 fixed.

Full local live suite (`uv run pytest integration_tests/`): **81 passed, 3 skipped, 1 failed** in 20m12s. The one failure was `test_anthropic_claude_thinking_budget_matrix` on cell `claude-sonnet-4.6 budget=4096 nonstream` — a transient upstream 502, unrelated to this test-only diff. It passes on re-run in isolation (702s).

## Why scripted upstream, not the live suite

Whether the real backend omits `arguments` for a no-parameter tool depends on which Claude backend GHC load-balances to on that request, so a live assertion on this would be flaky. The scripted upstream pins the wire format deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
