### PR TITLE
chore: release v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Router-Maestro are documented here.
 
 ---
 
+## v0.7.8 (2026-07-31)
+
+### Fixes
+
+- **Zero-argument tool calls no longer abort the Anthropic stream.** A tool with
+  an empty argument schema made upstream emit only `id` + `name` and never a
+  `function.arguments` fragment, so the terminal validation in the Anthropic
+  stream reducer ran `json.loads("")` and killed the whole stream with a `502`
+  `upstream_protocol_error`. An empty or whitespace-only argument buffer is now
+  normalized to `"{}"` at both consumption points — before terminal validation
+  and when building the `input_json_delta` payload — so the client receives a
+  well-formed `tool_use` block with `input: {}`. The non-streaming path already
+  tolerated this, so the two paths previously disagreed on identical upstream
+  data; `_parse_tool_call` now normalizes the same way.
+
+### Tests
+
+- **Wire-format regression guard at the Anthropic boundary.** The v0.7.8 fix
+  shipped with unit tests that re-parsed `partial_json` before asserting, so
+  they verified "the value parses to `{}`" rather than "the SSE stream carried
+  the string `"{}"`". Added a parametrized boundary test that drives
+  `/api/anthropic/v1/messages` against the scripted upstream and asserts the
+  literal `partial_json` bytes, no `error` event, and exactly one
+  `message_stop` — over all three shapes upstream sends (no `arguments` field,
+  `""`, `"   "`).
+
 ## v0.7.7 (2026-07-23)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "router-maestro"
-version = "0.7.7"
+version = "0.7.8"
 description = "Multi-model routing and load balancing system with OpenAI-compatible API"
 readme = "README.md"
 license = "MIT"

--- a/src/router_maestro/__init__.py
+++ b/src/router_maestro/__init__.py
@@ -1,3 +1,3 @@
 """Router-Maestro: Multi-model routing and load balancing system."""
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ wheels = [
 
 [[package]]
 name = "router-maestro"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Roll up the changes accumulated since `v0.7.7`.

## Included

- **#162** — `fix: accept zero-argument tool calls in Anthropic stream reducer`
  A tool with an empty argument schema aborted the Anthropic stream with a `502`
  `upstream_protocol_error` (`json.loads("")` at terminal validation). Empty /
  whitespace-only argument buffers are now normalized to `"{}"` at both
  consumption points, and `_parse_tool_call` matches the non-streaming path.
- **#163** — `test: pin zero-argument tool call wire format at the Anthropic boundary`
  Boundary test driving `/api/anthropic/v1/messages` that asserts the literal
  `partial_json` bytes on the wire, not a re-parsed value. Confirmed non-vacuous
  by reverting the reducer to `fada284` — all three cases fail.

## Version bump

- `pyproject.toml` → `0.7.8`
- `src/router_maestro/__init__.py` → `0.7.8`
- `uv.lock` regenerated
- `CHANGELOG.md` — new `v0.7.8` section

## Verification

- `uv run pytest tests/ -q` → **3510 passed**
- `uv run ruff check src/ tests/` → clean
- `uv run ruff format --check src/ tests/` → 201 files already formatted

Tag `v0.7.8` will be pushed after merge, which triggers the Release workflow
(PyPI + Docker + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)