### PR TITLE
fix: treat empty Copilot choices at the output cap as length truncation

### DIFF
--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -959,6 +959,23 @@ class CopilotProvider(BaseProvider):
         """
         return self._catalog.effort_values(model)
 
+    def _claude_reasoning_capable(self, model: str) -> bool:
+        """Whether ``model`` is a Claude model with a reasoning surface.
+
+        ``_claude_supports_reasoning`` only recognizes generations verified at
+        the time the static table was written, so newer families (claude-*-5
+        and beyond) fall through as unknown. When the catalog is warm its
+        advertised effort tiers are authoritative; the static table is only a
+        cold-cache fallback.
+        """
+        bare_lower = (model.split("/", 1)[1] if "/" in model else model).lower()
+        if not bare_lower.startswith("claude-"):
+            return False
+        catalog_effort_values = self._catalog_effort_values(model)
+        if catalog_effort_values is not None:
+            return bool(catalog_effort_values)
+        return _claude_supports_reasoning(bare_lower)
+
     def _get_client(self) -> httpx.AsyncClient:
         """Get or create a reusable HTTP client.
 
@@ -1103,12 +1120,7 @@ class CopilotProvider(BaseProvider):
             except (json.JSONDecodeError, TypeError, ValueError) as e:
                 self._raise_protocol_error(self.name, request.model, e)
 
-            bare_lower = (
-                request.model.split("/", 1)[1] if "/" in request.model else request.model
-            ).lower()
-            reasoning_capable = bare_lower.startswith("claude-") and _claude_supports_reasoning(
-                bare_lower
-            )
+            reasoning_capable = self._claude_reasoning_capable(request.model)
             try:
                 result = self._chat_codec.decode_response(
                     data,

--- a/src/router_maestro/providers/copilot_support/chat_codec.py
+++ b/src/router_maestro/providers/copilot_support/chat_codec.py
@@ -202,7 +202,7 @@ class CopilotChatCodec:
                 and completion_tokens >= max_tokens
             )
             exhausted_implicit_output_cap = (
-                request.thinking_type is None
+                request.thinking_type in (None, "disabled")
                 and has_positive_output_cap
                 and completion_tokens == max_tokens
             )

--- a/tests/test_provider_protocol_errors.py
+++ b/tests/test_provider_protocol_errors.py
@@ -1721,18 +1721,119 @@ async def test_copilot_chat_empty_nonthinking_reasoning_response_at_output_cap_i
 
 
 @pytest.mark.asyncio
+async def test_copilot_chat_empty_at_cap_with_thinking_disabled_is_length() -> None:
+    """Claude Code's Bash prefix probe sends thinking=disabled with a tiny cap.
+
+    Copilot answers a pure truncation with empty choices instead of a
+    ``finish_reason: length`` choice, so an explicit ``disabled`` must reach the
+    same graceful degradation as an absent ``thinking``.
+    """
+    provider = CopilotProvider()
+    provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
+    provider._models_ttl_cache.set(
+        [
+            ModelInfo(
+                id="claude-sonnet-5",
+                name="claude-sonnet-5",
+                provider="github-copilot",
+                reasoning_effort_values=["low", "medium", "high"],
+            )
+        ]
+    )
+    provider._send_with_auth_retry = AsyncMock(  # type: ignore[method-assign]
+        return_value=_response_for_payload(
+            {
+                "choices": [],
+                "usage": {"prompt_tokens": 493, "completion_tokens": 64},
+                "model": "claude-sonnet-5",
+            }
+        )
+    )
+
+    response = await provider.chat_completion(
+        _chat_request(model="claude-sonnet-5", max_tokens=64, thinking_type="disabled")
+    )
+
+    assert response.content == ""
+    assert response.finish_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_copilot_chat_empty_at_cap_uses_catalog_for_unknown_claude_generation() -> None:
+    """A warm catalog outranks the static table, which stops at the 4.x line."""
+    provider = CopilotProvider()
+    provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
+    provider._models_ttl_cache.set(
+        [
+            ModelInfo(
+                id="claude-sonnet-5",
+                name="claude-sonnet-5",
+                provider="github-copilot",
+                reasoning_effort_values=["low", "medium", "high", "xhigh", "max"],
+            )
+        ]
+    )
+    provider._send_with_auth_retry = AsyncMock(  # type: ignore[method-assign]
+        return_value=_response_for_payload(
+            {
+                "choices": [],
+                "usage": {"completion_tokens": 4096},
+                "model": "claude-sonnet-5",
+            }
+        )
+    )
+
+    response = await provider.chat_completion(
+        _chat_request(model="claude-sonnet-5", max_tokens=4096)
+    )
+
+    assert response.finish_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_copilot_chat_empty_at_cap_stays_protocol_error_when_catalog_denies_reasoning() -> (
+    None
+):
+    """A catalog that advertises no reasoning tiers keeps the failure typed."""
+    provider = CopilotProvider()
+    provider.ensure_token = AsyncMock()  # type: ignore[method-assign]
+    provider._models_ttl_cache.set(
+        [
+            ModelInfo(
+                id="claude-sonnet-5",
+                name="claude-sonnet-5",
+                provider="github-copilot",
+                reasoning_effort_values=[],
+            )
+        ]
+    )
+    provider._send_with_auth_retry = AsyncMock(  # type: ignore[method-assign]
+        return_value=_response_for_payload(
+            {
+                "choices": [],
+                "usage": {"completion_tokens": 64},
+                "model": "claude-sonnet-5",
+            }
+        )
+    )
+
+    with pytest.raises(ProviderError) as exc_info:
+        await provider.chat_completion(
+            _chat_request(model="claude-sonnet-5", max_tokens=64, thinking_type="disabled")
+        )
+
+    _assert_protocol_failure(
+        exc_info.value,
+        provider="github-copilot",
+        model="claude-sonnet-5",
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("model", "max_tokens", "thinking_type", "thinking_budget", "completion_tokens"),
     [
         pytest.param("claude-opus-4.8", 4096, None, None, 4097, id="implicit-above-cap"),
-        pytest.param(
-            "claude-opus-4.8",
-            4096,
-            "disabled",
-            None,
-            4096,
-            id="explicitly-disabled-at-cap",
-        ),
         pytest.param("gpt-4o", 4096, None, None, 4096, id="non-reasoning-at-cap"),
         pytest.param(
             "claude-opus-4.8",


### PR DESCRIPTION
## Problem

GitHub Copilot answers a pure truncation with `"choices": []` plus usage, instead of a choice carrying `finish_reason: "length"`. `CopilotChatCodec.decode_response` already degrades that shape gracefully, but two gates kept the most common real-world case out of it, so it surfaced to clients as a 502 `upstream_protocol_error`:

```
ERROR    Copilot API returned empty choices: model=claude-sonnet-5 has_usage=True
WARNING  route_attempt_failed attempt=1 provider=github-copilot model=github-copilot/claude-sonnet-5
         operation=chat kind=upstream_protocol downstream_status=502 upstream_status=200
         retryable=true decision=exhausted
ERROR    Anthropic messages request failed: model=claude-sonnet-5, status=502,
         error=github-copilot returned a malformed upstream response
```

The trigger is Claude Code's Bash command-prefix probe — the request that decides whether a command needs a permission prompt. It has a fixed shape: `max_tokens=64`, `thinking={"type": "disabled"}`, non-streaming, `claude-sonnet-5`. Over three days of local use that shape failed **139 times out of 351 (40%)**, in bursts. Failed requests took ~2× as long as successful ones (median 3.7s vs 1.8s) — the model deliberating right up to the cap.

Upstream is healthy. Replaying the shape directly against Copilot reproduces it:

```json
{"choices": [], "created": 1785292485, "id": "msg_...",
 "usage": {"completion_tokens": 64, "prompt_tokens": 493, "total_tokens": 557},
 "model": "claude-sonnet-5"}
```

`completion_tokens == max_tokens == 64`. The model simply does not finish inside 64 tokens on longer commands (pipes, heredocs, `$(...)`), where it tends to explain before answering.

## Why the existing degradation path did not catch it

1. **`reasoning_capable` was `False` for the entire claude-\*-5 family.** `_known_claude_reasoning_support` returns `None` for anything outside the 4.x line (`if major != 4: return None`), and `_claude_supports_reasoning` treats unknown as unsupported. The static table predates these models — the live catalog advertises `["low", "medium", "high", "xhigh", "max"]` for `claude-sonnet-5`.

2. **`thinking_type` was `"disabled"`, not `None`.** `exhausted_implicit_output_cap` required `thinking_type is None`, and `exhausted_explicit_output_cap` required thinking to be actively requested. An explicit `disabled` matched neither.

## Fix

- **`_claude_reasoning_capable()`** prefers the live catalog's advertised reasoning tiers over the static compatibility table, falling back to the table only when the cache is cold. This matches the catalog-first convention `_resolve_reasoning_chat` already follows, and means future Claude generations no longer need a table edit to be recognized.

- **`exhausted_implicit_output_cap`** accepts `thinking_type="disabled"` alongside `None`. When `completion_tokens == max_tokens` and choices are empty, that is a truncation regardless of whether the client omitted `thinking` or explicitly disabled it.

A catalog that advertises no reasoning tiers still produces a typed protocol error, so this does not blanket-suppress genuinely malformed responses.

## Tests

Drops the `explicitly-disabled-at-cap` parametrization from `test_copilot_chat_empty_implicit_exception_remains_narrow` — it pinned the behavior being corrected. Adds three cases:

- `test_copilot_chat_empty_at_cap_with_thinking_disabled_is_length` — the exact production payload
- `test_copilot_chat_empty_at_cap_uses_catalog_for_unknown_claude_generation` — catalog outranks the static table
- `test_copilot_chat_empty_at_cap_stays_protocol_error_when_catalog_denies_reasoning` — a catalog with no reasoning tiers still 502s

## Verification

- Replaying the exact production payload offline now returns `finish_reason="length"` with empty content, instead of raising.
- Hammering the real Copilot backend with the previously-failing request shape 12× produced **0 failures** (9 `stop`, 3 `length`).
- Running against the live backend for several days since: the `Copilot API returned empty choices` error has not recurred.
- Full suite: 3504 passed. 8 pre-existing failures on Windows (POSIX permission-bit assertions in `test_auth_*`/`test_config.py`, and `test_integration_harness.py`) fail identically on this branch's baseline without the patch.
- `ruff check src/ tests/` passes. `ruff format --check` is clean on the two files I touched fully; it flags `copilot.py:817` (pre-existing, untouched by this PR) where ruff 0.16.0 proposes the syntactically invalid `except json.JSONDecodeError, UnicodeDecodeError:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)