### PR TITLE
fix: harden Copilot Responses and GPT-5 Chat compatibility

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -731,54 +731,122 @@ def gemini_family_models(copilot_models: list[str]) -> list[str]:
     return selected
 
 
+def _chat_capable_models(
+    copilot_models: list[str],
+    copilot_catalog: dict[str, ModelInfo],
+) -> list[str]:
+    """Filter to models whose live catalog permits the Chat transport."""
+    capable = []
+    for model in copilot_models:
+        info = copilot_catalog[model]
+        endpoints = info.supported_endpoints
+        if endpoints is not None:
+            if "/chat/completions" in endpoints:
+                capable.append(model)
+            continue
+        if info.operation_capabilities.get("chat") is False:
+            continue
+        if bare_model(model) not in RESPONSES_ONLY_CHAT_MODELS:
+            capable.append(model)
+    return capable
+
+
 @pytest.fixture(scope="session")
-def chat_model(copilot_models: list[str]) -> str:
+def chat_model(
+    copilot_models: list[str],
+    copilot_catalog: dict[str, ModelInfo],
+) -> str:
     """Model for OpenAI Chat, Anthropic, and Gemini compatibility paths."""
+    chat_capable = _chat_capable_models(copilot_models, copilot_catalog)
     requested = os.environ.get("RM_INTEGRATION_MODEL")
     if requested:
-        if requested in copilot_models:
+        if requested in chat_capable:
             return requested
-        pytest.fail(f"RM_INTEGRATION_MODEL={requested!r} is not in available Copilot models")
+        pytest.fail(
+            f"RM_INTEGRATION_MODEL={requested!r} is not an available Chat-capable Copilot model"
+        )
 
     preferred = (
         "github-copilot/gpt-4o-mini",
         "github-copilot/gpt-4o",
         "github-copilot/claude-haiku-4.5",
         "github-copilot/claude-sonnet-4.5",
-    )
-    return _first_available(copilot_models, preferred) or copilot_models[0]
-
-
-@pytest.fixture(scope="session")
-def tool_model(copilot_models: list[str]) -> str:
-    """Model selected for forced tool-call scenarios.
-
-    Used against ``/chat/completions`` and ``/anthropic/v1/messages``, so it must
-    be a true chat model. Responses-only models (e.g. ``gpt-5.4-mini``) reject
-    those endpoints, so they are excluded from the candidate pool.
-    """
-    requested = os.environ.get("RM_INTEGRATION_TOOL_MODEL")
-    if requested:
-        if requested in copilot_models:
-            return requested
-        pytest.fail(f"RM_INTEGRATION_TOOL_MODEL={requested!r} is not in available Copilot models")
-
-    chat_capable = [
-        model for model in copilot_models if bare_model(model) not in RESPONSES_ONLY_CHAT_MODELS
-    ]
-    preferred = (
-        "github-copilot/gpt-4o",
-        "github-copilot/gpt-4o-mini",
-        "github-copilot/claude-sonnet-4.5",
-        "github-copilot/claude-haiku-4.5",
-        "github-copilot/gpt-4.1",
+        "github-copilot/gpt-5.4",
+        "github-copilot/gemini-3.5-flash",
+        "github-copilot/gemini-3.1-pro-preview",
+        "github-copilot/gemini-3.6-flash",
+        "github-copilot/gpt-5-mini",
     )
     selected = _first_available(chat_capable, preferred)
     if selected:
         return selected
     if chat_capable:
         return chat_capable[0]
+    pytest.skip("No Chat-capable Copilot model is available")
+
+
+@pytest.fixture(scope="session")
+def tool_model(
+    copilot_models: list[str],
+    copilot_catalog: dict[str, ModelInfo],
+) -> str:
+    """Model selected for forced tool-call scenarios.
+
+    Used against ``/chat/completions`` and ``/anthropic/v1/messages``, so it must
+    be a true chat model. Responses-only models (e.g. ``gpt-5.4-mini``) reject
+    those endpoints, so they are excluded from the candidate pool.
+    """
+    chat_capable = _chat_capable_models(copilot_models, copilot_catalog)
+    tool_capable = [
+        model
+        for model in chat_capable
+        if copilot_catalog[model].feature_capabilities.get("tools") is not False
+    ]
+    requested = os.environ.get("RM_INTEGRATION_TOOL_MODEL")
+    if requested:
+        if requested in tool_capable:
+            return requested
+        pytest.fail(
+            f"RM_INTEGRATION_TOOL_MODEL={requested!r} is not an available tool-capable Chat model"
+        )
+    preferred = (
+        "github-copilot/gpt-4o",
+        "github-copilot/gpt-4o-mini",
+        "github-copilot/claude-sonnet-4.5",
+        "github-copilot/claude-haiku-4.5",
+        "github-copilot/gpt-4.1",
+        "github-copilot/gpt-5.4",
+        "github-copilot/gemini-3.5-flash",
+        "github-copilot/gemini-3.1-pro-preview",
+        "github-copilot/gemini-3.6-flash",
+        "github-copilot/gpt-5-mini",
+    )
+    selected = _first_available(tool_capable, preferred)
+    if selected:
+        return selected
+    if tool_capable:
+        return tool_capable[0]
     pytest.skip("No chat-capable Copilot model available for forced tool-call tests")
+
+
+@pytest.fixture(scope="session")
+def gpt5_chat_model(
+    copilot_models: list[str],
+    copilot_catalog: dict[str, ModelInfo],
+) -> str:
+    """One live GPT-5 Chat model for model-specific option validation."""
+    candidates = [
+        model
+        for model in _chat_capable_models(copilot_models, copilot_catalog)
+        if bare_model(model).lower().startswith("gpt-5")
+    ]
+    preferred = ("github-copilot/gpt-5.4", "github-copilot/gpt-5-mini")
+    selected = _first_available(candidates, preferred)
+    if selected:
+        return selected
+    if candidates:
+        return candidates[0]
+    pytest.skip("No GPT-5 Chat model is available")
 
 
 @pytest.fixture(scope="session")
@@ -912,7 +980,6 @@ def anthropic_compat_payload(model: str, *, stream: bool = False) -> dict[str, A
         {
             "system": "Return concise answers.",
             "top_p": 1,
-            "stop_sequences": ["\n\nHuman:"],
             "metadata": {"user_id": "router-maestro-integration"},
         }
     )
@@ -935,7 +1002,6 @@ def openai_chat_usage_payload(model: str, *, stream: bool = False) -> dict[str, 
             "top_p": 1,
             "frequency_penalty": 0,
             "presence_penalty": 0,
-            "stop": ["\n\n"],
             "user": "router-maestro-integration",
         }
     )

--- a/integration_tests/test_live_anthropic_beta.py
+++ b/integration_tests/test_live_anthropic_beta.py
@@ -68,7 +68,7 @@ def test_beta_non_streaming(client: httpx.Client, chat_model: str):
 
 
 def test_beta_non_streaming_compat_fields(client: httpx.Client, chat_model: str):
-    """Beta endpoint handles compat fields (system, top_p, stop_sequences, metadata)."""
+    """Beta endpoint handles compat fields (system, top_p, and metadata)."""
     response = client.post(BETA, json=anthropic_compat_payload(chat_model))
     assert_http_success(response)
     data = response.json()
@@ -84,10 +84,7 @@ def test_beta_non_streaming_compat_fields(client: httpx.Client, chat_model: str)
 @pytest.mark.parametrize(
     ("option_payload", "parameter"),
     [
-        (
-            {"output_config": {"effort": "low", "format": "text"}},
-            "output_config.format",
-        ),
+        ({"output_config": "low"}, "output_config"),
     ],
 )
 def test_beta_rejects_malformed_output_config(

--- a/integration_tests/test_live_anthropic_paths.py
+++ b/integration_tests/test_live_anthropic_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from integration_tests.conftest import (
     anthropic_compat_payload,
@@ -45,6 +46,30 @@ def test_anthropic_messages_non_streaming_api_prefix(
     assert text_blocks, data
     assert_text_response(text_blocks[0]["text"])
     assert_anthropic_usage(data["usage"])
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ("/api/anthropic/v1/messages", "/api/anthropic/beta/v1/messages"),
+)
+@pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
+def test_anthropic_gpt5_rejects_unsupported_stop_sequences(
+    client: httpx.Client,
+    gpt5_chat_model: str,
+    endpoint: str,
+    stream: bool,
+):
+    payload = anthropic_payload(gpt5_chat_model, stream=stream)
+    payload["stop_sequences"] = ["END"]
+
+    response = client.post(endpoint, json=payload)
+
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/json")
+    error = response.json()
+    assert error["type"] == "error"
+    assert error["error"]["type"] == "invalid_request_error"
+    assert "stop_sequences" in error["error"]["message"]
 
 
 def test_anthropic_messages_non_streaming_root_path(

--- a/integration_tests/test_live_openai_paths.py
+++ b/integration_tests/test_live_openai_paths.py
@@ -15,6 +15,7 @@ from integration_tests.conftest import (
     assert_text_response,
     assert_tool_call_name,
     event_payloads,
+    openai_chat_payload,
     openai_chat_tool_payload,
     openai_responses_payload,
     openai_responses_tool_payload,
@@ -73,6 +74,24 @@ def test_openai_chat_completion_streaming_returns_chunks_and_done(
     usage_payloads = [payload for payload in payloads if payload.get("usage")]
     if usage_payloads:
         assert_openai_usage(usage_payloads[-1]["usage"])
+
+
+@pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
+def test_openai_chat_gpt5_rejects_unsupported_stop(
+    client: httpx.Client,
+    gpt5_chat_model: str,
+    stream: bool,
+):
+    payload = openai_chat_payload(gpt5_chat_model, stream=stream)
+    payload["stop"] = ["END"]
+
+    response = client.post("/api/openai/v1/chat/completions", json=payload)
+
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/json")
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "stop"
 
 
 def test_openai_chat_forced_tool_call(client: httpx.Client, tool_model: str):

--- a/integration_tests/test_live_openai_paths.py
+++ b/integration_tests/test_live_openai_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
+import pytest
 
 from integration_tests.conftest import (
     assert_http_success,
@@ -19,6 +20,7 @@ from integration_tests.conftest import (
     openai_responses_tool_payload,
     parse_sse_events,
     post_openai_chat_compat_probe,
+    responses_weather_tool,
     stream_openai_chat_compat_probe,
 )
 
@@ -191,6 +193,58 @@ def test_openai_responses_forced_tool_call(client: httpx.Client, responses_model
 
     assert data["status"] == "completed"
     assert_response_has_function_call(data, "get_weather")
+    assert_responses_usage(data["usage"])
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    (
+        "/api/openai/v1/responses",
+        "/api/openai/beta/v1/responses",
+    ),
+)
+def test_openai_responses_additional_tools_normalizes_empty_namespace_description(
+    client: httpx.Client,
+    responses_model: str,
+    endpoint: str,
+):
+    """Both Responses paths should normalize Codex's empty namespace description."""
+    response = client.post(
+        endpoint,
+        json={
+            "model": responses_model,
+            "input": [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [
+                        {
+                            "type": "namespace",
+                            "name": "functions",
+                            "description": "",
+                            "tools": [responses_weather_tool()],
+                        }
+                    ],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "Reply with exactly the word pong.",
+                        }
+                    ],
+                },
+            ],
+            "max_output_tokens": 512,
+        },
+    )
+    assert_http_success(response)
+    data = response.json()
+
+    assert data["object"] == "response"
+    assert data["status"] == "completed", data
     assert_responses_usage(data["usage"])
 
 

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -510,6 +510,18 @@ class CopilotOutboundContract(OutboundContract):
         """Copilot Responses rejects explicit temperature; Chat forwards it."""
         return operation not in (Operation.RESPONSES, Operation.RESPONSES_STREAM)
 
+    def allows_stop(
+        self,
+        operation: Operation,
+        *,
+        model: str | None = None,
+    ) -> bool:
+        """Copilot's GPT-5 Chat surface rejects the ``stop`` parameter."""
+        if operation not in (Operation.CHAT, Operation.CHAT_STREAM) or model is None:
+            return True
+        bare_model = model.split("/", 1)[-1].lower()
+        return not bare_model.startswith("gpt-5")
+
     # ------------------------------------------------------------------
     # Native Anthropic passthrough normalization (folded in from the beta
     # Anthropic route). These own the outbound wire knowledge; the route keeps
@@ -1643,6 +1655,7 @@ class CopilotProvider(BaseProvider):
             apply_reasoning=apply_copilot_chat_reasoning,
             catalog_effort_values=self._catalog_effort_values(request.model),
             provider_name=self.name,
+            allows_stop=self.outbound_contract.allows_stop,
         )
 
     def validate_chat_request(self, request: ChatRequest, *, stream: bool) -> None:

--- a/src/router_maestro/providers/copilot.py
+++ b/src/router_maestro/providers/copilot.py
@@ -272,6 +272,26 @@ _COPILOT_RESPONSES_FORWARD_FIELDS = frozenset(
 _OUTPUT_CONFIG_REJECTED_BY_UPSTREAM = frozenset({"task_budget"})
 
 
+def _normalize_copilot_tool(tool: Any) -> Any:
+    """Copy one tool definition, filling Copilot-required namespace descriptions."""
+    if not isinstance(tool, dict):
+        return tool
+    normalized = dict(tool)
+    description = normalized.get("description")
+    if normalized.get("type") == "namespace" and (
+        description is None or isinstance(description, str) and not description.strip()
+    ):
+        name = normalized.get("name")
+        if isinstance(name, str) and name:
+            normalized["description"] = f"Tools in the {name} namespace."
+        else:
+            normalized["description"] = "Tools in this namespace."
+    inner_tools = normalized.get("tools")
+    if isinstance(inner_tools, list):
+        normalized["tools"] = [_normalize_copilot_tool(inner) for inner in inner_tools]
+    return normalized
+
+
 class CopilotOutboundContract(OutboundContract):
     """Copilot upstream wire contract.
 
@@ -444,11 +464,11 @@ class CopilotOutboundContract(OutboundContract):
         for tool in tools:
             tool_type = tool.get("type", "function")
             if tool_type == "function":
-                validated.append(tool)
+                validated.append(_normalize_copilot_tool(tool))
             elif tool_type == "namespace":
                 inner = tool.get("tools")
                 if isinstance(inner, list) and inner:
-                    validated.append(tool)
+                    validated.append(_normalize_copilot_tool(tool))
                 else:
                     raise RequestOptionError(
                         "GitHub Copilot requires namespace tools to contain a non-empty tools list",
@@ -457,12 +477,34 @@ class CopilotOutboundContract(OutboundContract):
                         parameter="tools",
                     )
             elif tool_type not in self._RESPONSES_UNSUPPORTED_TOOL_TYPES:
-                validated.append(tool)
+                validated.append(_normalize_copilot_tool(tool))
             # else: silently drop tools Copilot Responses cannot express
             # (web_search, web_search_preview, code_interpreter). Clients like
             # Codex inject these unconditionally; 400-ing the whole request over
             # a tool the backend can't run is worse than dropping it.
         return validated or None
+
+    def normalize_responses_input(
+        self,
+        value: Any,
+        *,
+        operation: Operation,
+        model: str | None = None,
+    ) -> Any:
+        """Sanitize Codex additional_tools registries for Copilot Responses."""
+        if not isinstance(value, list):
+            return value
+        normalized_input = []
+        for item in value:
+            if not isinstance(item, dict) or item.get("type") != "additional_tools":
+                normalized_input.append(item)
+                continue
+            normalized_item = dict(item)
+            tools = normalized_item.get("tools")
+            if isinstance(tools, list):
+                normalized_item["tools"] = [_normalize_copilot_tool(tool) for tool in tools]
+            normalized_input.append(normalized_item)
+        return normalized_input
 
     def allows_temperature(self, operation: Operation) -> bool:
         """Copilot Responses rejects explicit temperature; Chat forwards it."""
@@ -1366,6 +1408,7 @@ class CopilotProvider(BaseProvider):
             resolve_reasoning=self.outbound_contract.resolve_reasoning,
             allows_temperature=self.outbound_contract.allows_temperature,
             filter_tools=self.outbound_contract.filter_tools,
+            normalize_input=self.outbound_contract.normalize_responses_input,
         )
 
     def validate_responses_request(self, request: ResponsesRequest) -> None:

--- a/src/router_maestro/providers/copilot_support/chat_codec.py
+++ b/src/router_maestro/providers/copilot_support/chat_codec.py
@@ -16,6 +16,7 @@ from router_maestro.providers.base import (
     RequestOptionError,
 )
 from router_maestro.providers.tool_parsing import recover_tool_calls_from_content
+from router_maestro.routing.capabilities import Operation
 from router_maestro.utils import get_logger
 from router_maestro.utils.structured_output import output_format_to_response_format
 
@@ -78,6 +79,7 @@ class CopilotChatCodec:
         apply_reasoning: Callable[..., None],
         catalog_effort_values: list[str] | None,
         provider_name: str,
+        allows_stop: Callable[..., bool],
     ) -> dict:
         validate_extensions(request)
         messages, _has_images = self.build_messages_payload(request)
@@ -100,11 +102,16 @@ class CopilotChatCodec:
             payload["response_format"] = response_format
         if request.stop is not None and request.stop_sequences is not None:
             self.reject_option(request, "stop", provider_name=provider_name)
+        stop = request.stop if request.stop is not None else request.stop_sequences
+        operation = Operation.CHAT_STREAM if stream else Operation.CHAT
+        if stop is not None and not allows_stop(operation, model=request.model):
+            parameter = "stop" if request.stop is not None else "stop_sequences"
+            self.reject_option(request, parameter, provider_name=provider_name)
         options = {
             "top_p": request.top_p,
             "frequency_penalty": request.frequency_penalty,
             "presence_penalty": request.presence_penalty,
-            "stop": request.stop if request.stop is not None else request.stop_sequences,
+            "stop": stop,
             "user": request.user,
             "metadata": request.metadata,
             "service_tier": request.service_tier,

--- a/src/router_maestro/providers/copilot_support/responses_codec.py
+++ b/src/router_maestro/providers/copilot_support/responses_codec.py
@@ -69,6 +69,7 @@ class CopilotResponsesCodec:
         resolve_reasoning: Callable[..., Any],
         allows_temperature: Callable[..., bool],
         filter_tools: Callable[..., list[dict] | None],
+        normalize_input: Callable[..., Any],
     ) -> dict:
         from router_maestro.routing.capabilities import Operation
 
@@ -82,7 +83,11 @@ class CopilotResponsesCodec:
             )
         payload: dict = {
             "model": request.model,
-            "input": request.input,
+            "input": normalize_input(
+                request.input,
+                operation=Operation.RESPONSES,
+                model=request.model,
+            ),
             "stream": request.stream,
         }
         if request.instructions:

--- a/src/router_maestro/providers/outbound_contract.py
+++ b/src/router_maestro/providers/outbound_contract.py
@@ -18,6 +18,7 @@ single source of the Copilot wire rules.
 
 from abc import ABC
 from dataclasses import dataclass
+from typing import Any
 
 from router_maestro.routing.capabilities import Operation
 
@@ -72,6 +73,16 @@ class OutboundContract(ABC):
         """Filter tools this upstream cannot express. Default: pass through."""
         return tools
 
+    def normalize_responses_input(
+        self,
+        value: Any,
+        *,
+        operation: Operation,
+        model: str | None = None,
+    ) -> Any:
+        """Normalize provider-specific Responses input items before transport."""
+        return value
+
     def allows_temperature(self, operation: Operation) -> bool:
         """Whether the upstream accepts explicit ``temperature``. Default: yes."""
         return True
@@ -100,7 +111,16 @@ class OutboundContract(ABC):
             for key in set(body) - forwardable:
                 del body[key]
 
-        # 2. Tools — filter_tools may drop unsupported types or raise on malformed.
+        # 2. Input — normalize provider-specific input extensions such as
+        # additional_tools registries before they reach the upstream schema.
+        if "input" in body:
+            body["input"] = self.normalize_responses_input(
+                body["input"],
+                operation=operation,
+                model=model,
+            )
+
+        # 3. Tools — filter_tools may drop unsupported types or raise on malformed.
         if "tools" in body:
             filtered = self.filter_tools(body.get("tools"), operation=operation, model=model)
             if filtered:
@@ -108,7 +128,7 @@ class OutboundContract(ABC):
             else:
                 body.pop("tools", None)
 
-        # 3. Temperature verdict.
+        # 4. Temperature verdict.
         if body.get("temperature") is not None and not self.allows_temperature(operation):
             from router_maestro.providers.base import RequestOptionError  # lazy: base<-contract
 
@@ -118,7 +138,7 @@ class OutboundContract(ABC):
                 parameter="temperature",
             )
 
-        # 4. Reasoning effort — only when the client sent an explicit effort.
+        # 5. Reasoning effort — only when the client sent an explicit effort.
         reasoning = body.get("reasoning")
         if isinstance(reasoning, dict) and isinstance(reasoning.get("effort"), str):
             resolution = self.resolve_reasoning(

--- a/src/router_maestro/providers/outbound_contract.py
+++ b/src/router_maestro/providers/outbound_contract.py
@@ -87,6 +87,15 @@ class OutboundContract(ABC):
         """Whether the upstream accepts explicit ``temperature``. Default: yes."""
         return True
 
+    def allows_stop(
+        self,
+        operation: Operation,
+        *,
+        model: str | None = None,
+    ) -> bool:
+        """Whether the upstream accepts an explicit stop sequence. Default: yes."""
+        return True
+
     def reconcile_passthrough_body(
         self,
         body: dict,

--- a/tests/test_copilot_tool_filter.py
+++ b/tests/test_copilot_tool_filter.py
@@ -1,5 +1,7 @@
 """Tests for Copilot tool-type filtering."""
 
+from copy import deepcopy
+
 import pytest
 
 from router_maestro.providers import CopilotProvider
@@ -104,3 +106,41 @@ class TestFilterUnsupportedTools:
         tools = [{"type": "local_shell", "name": "shell"}]
         result = self.provider._filter_unsupported_tools(tools)
         assert result == tools
+
+    def test_normal_responses_fills_required_additional_namespace_description(self):
+        input_items = [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [
+                    {
+                        "type": "namespace",
+                        "name": "functions",
+                        "description": "",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "wait",
+                                "description": "Wait for work",
+                            },
+                            {
+                                "type": "function",
+                                "name": "poll",
+                                "description": "",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+        original = deepcopy(input_items)
+
+        payload = self.provider._build_responses_payload(
+            ResponsesRequest(model="gpt-5.6-sol", input=input_items)
+        )
+
+        namespace = payload["input"][0]["tools"][0]
+        assert namespace["description"] == "Tools in the functions namespace."
+        assert namespace["tools"][0]["description"] == "Wait for work"
+        assert namespace["tools"][1]["description"] == ""
+        assert input_items == original

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -339,6 +339,19 @@ def test_anthropic_compat_payload_uses_top_p_without_temperature():
 
     assert payload["top_p"] == 1
     assert "temperature" not in payload
+    assert "stop_sequences" not in payload
+    assert payload["stream"] is True
+
+
+def test_openai_chat_compat_payload_does_not_assume_stop_support():
+    conftest = importlib.import_module("integration_tests.conftest")
+
+    payload = conftest.openai_chat_usage_payload(
+        "github-copilot/gpt-5.4",
+        stream=True,
+    )
+
+    assert "stop" not in payload
     assert payload["stream"] is True
 
 
@@ -681,6 +694,38 @@ def test_live_endpoint_selection_does_not_treat_derived_operations_as_raw_http_c
     endpoint = conftest.select_live_http_endpoint(model, {model: info})
 
     assert endpoint is getattr(conftest.LiveHttpEndpoint, "UNKNOWN", None)
+
+
+def test_chat_fixture_uses_catalog_endpoints_and_selects_current_gpt5_chat_model(monkeypatch):
+    conftest = importlib.import_module("integration_tests.conftest")
+    responses_only = "github-copilot/gpt-5.4-mini"
+    luna = "github-copilot/gpt-5.6-luna"
+    chat = "github-copilot/gpt-5.4"
+    models = [responses_only, luna, chat]
+    catalog = {
+        responses_only: ModelInfo(
+            id="gpt-5.4-mini",
+            name="GPT-5.4 Mini",
+            provider="github-copilot",
+            supported_endpoints=("/responses",),
+        ),
+        luna: ModelInfo(
+            id="gpt-5.6-luna",
+            name="GPT-5.6 Luna",
+            provider="github-copilot",
+            supported_endpoints=("/responses",),
+        ),
+        chat: ModelInfo(
+            id="gpt-5.4",
+            name="GPT-5.4",
+            provider="github-copilot",
+            supported_endpoints=("/chat/completions", "/responses"),
+        ),
+    }
+    monkeypatch.delenv("RM_INTEGRATION_MODEL", raising=False)
+
+    assert conftest._chat_capable_models(models, catalog) == [chat]
+    assert conftest.chat_model.__wrapped__(models, catalog) == chat
 
 
 def _chat_matrix_success(model: str = "github-copilot/heuristic-profile") -> httpx.Response:

--- a/tests/test_openai_responses_beta.py
+++ b/tests/test_openai_responses_beta.py
@@ -172,6 +172,89 @@ def test_reconcile_passthrough_body_downgrades_reasoning_effort() -> None:
     assert body["include"] == ["reasoning.encrypted_content"]
 
 
+@pytest.mark.parametrize("operation", [Operation.RESPONSES, Operation.RESPONSES_STREAM])
+def test_reconcile_passthrough_body_fills_required_namespace_descriptions(
+    operation: Operation,
+) -> None:
+    contract = CopilotOutboundContract()
+    body = {
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [
+                    {
+                        "type": "namespace",
+                        "name": "functions",
+                        "description": "",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "undocumented",
+                                "description": "",
+                                "parameters": {"type": "object"},
+                            },
+                            {
+                                "type": "function",
+                                "name": "documented",
+                                "description": "Keep this description",
+                                "parameters": {"type": "object"},
+                            },
+                            {
+                                "type": "function",
+                                "name": "description_omitted",
+                                "parameters": {"type": "object"},
+                            },
+                        ],
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "documented_namespace",
+                        "description": "Keep this namespace description",
+                        "tools": [{"type": "function", "name": "echo"}],
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "description_omitted",
+                        "tools": [{"type": "function", "name": "echo"}],
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "description_null",
+                        "description": None,
+                        "tools": [{"type": "function", "name": "echo"}],
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "description_whitespace",
+                        "description": "  \n",
+                        "tools": [{"type": "function", "name": "echo"}],
+                    },
+                ],
+            }
+        ],
+    }
+
+    contract.reconcile_passthrough_body(
+        body,
+        operation=operation,
+        model="gpt-5.5",
+        catalog_effort_values=None,
+    )
+
+    additional_tools = body["input"][0]["tools"]
+    namespace = additional_tools[0]
+    assert namespace["description"] == "Tools in the functions namespace."
+    assert namespace["tools"][0]["description"] == ""
+    assert namespace["tools"][1]["description"] == "Keep this description"
+    assert "description" not in namespace["tools"][2]
+    assert additional_tools[1]["description"] == "Keep this namespace description"
+    assert additional_tools[2]["description"] == "Tools in the description_omitted namespace."
+    assert additional_tools[3]["description"] == "Tools in the description_null namespace."
+    assert additional_tools[4]["description"] == "Tools in the description_whitespace namespace."
+
+
 # ---------------------------------------------------------------------------
 # Unit tests: guard projection + terminal-outcome mapping
 # ---------------------------------------------------------------------------
@@ -504,6 +587,49 @@ def test_nonstream_passthrough_drops_unsupported_tool(client) -> None:
     assert downstream.status_code == 200
     sent_payload = provider._send_with_auth_retry.await_args.kwargs["json"]
     assert sent_payload["tools"] == [{"type": "function", "name": "echo"}]
+
+
+def test_nonstream_passthrough_replaces_nested_empty_tool_description(client) -> None:
+    provider = _native_provider()
+    plan = _responses_plan_with_efforts(provider)
+    resolution = _native_resolution(provider, plan)
+    with patch(
+        "router_maestro.server.routes.openai_responses_beta._resolve_responses_model",
+        new_callable=AsyncMock,
+        return_value=resolution,
+    ):
+        downstream = client.post(
+            "/api/openai/beta/v1/responses",
+            json={
+                "model": "github-copilot/gpt-5.5",
+                "input": [
+                    {
+                        "type": "additional_tools",
+                        "role": "developer",
+                        "tools": [
+                            {
+                                "type": "namespace",
+                                "name": "functions",
+                                "description": "",
+                                "tools": [
+                                    {
+                                        "type": "function",
+                                        "name": "echo",
+                                        "description": "Echo the input",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert downstream.status_code == 200
+    sent_payload = provider._send_with_auth_retry.await_args.kwargs["json"]
+    namespace = sent_payload["input"][0]["tools"][0]
+    assert namespace["description"] == "Tools in the functions namespace."
+    assert namespace["tools"][0]["description"] == "Echo the input"
 
 
 def test_nonstream_passthrough_rejects_temperature(client) -> None:

--- a/tests/test_provider_option_fidelity.py
+++ b/tests/test_provider_option_fidelity.py
@@ -573,6 +573,37 @@ def test_copilot_chat_payload_forwards_openai_native_options() -> None:
     assert payload["service_tier"] == "default"
 
 
+@pytest.mark.parametrize("model", ["gpt-5.4", "github-copilot/gpt-5-mini"])
+@pytest.mark.parametrize("stream", [False, True], ids=["nonstream", "stream"])
+@pytest.mark.parametrize("parameter", ["stop", "stop_sequences"])
+def test_copilot_gpt5_chat_rejects_unsupported_stop(
+    model: str,
+    stream: bool,
+    parameter: str,
+) -> None:
+    provider = CopilotProvider()
+
+    with pytest.raises(RequestOptionError) as caught:
+        provider._build_chat_payload(
+            _request(model=model, **{parameter: ["END"]}),
+            stream=stream,
+        )
+
+    assert caught.value.parameter == parameter
+    assert caught.value.model == model
+
+
+def test_copilot_gemini_chat_forwards_stop() -> None:
+    provider = CopilotProvider()
+
+    payload = provider._build_chat_payload(
+        _request(model="gemini-3.5-flash", stop=["END"]),
+        stream=False,
+    )
+
+    assert payload["stop"] == ["END"]
+
+
 @pytest.mark.parametrize("parameter", ["top_k", "candidate_count", "response_mime_type"])
 def test_copilot_chat_rejects_non_chat_options(parameter) -> None:
     provider = CopilotProvider()


### PR DESCRIPTION
## Summary

- normalize missing, null, empty, and whitespace-only namespace descriptions before forwarding Copilot Responses requests on both standard and beta paths
- reject unsupported `stop` for Copilot GPT-5 Chat before transport or SSE commitment, preserving OpenAI `stop` and Anthropic `stop_sequences` error parameters
- make live Chat/tool model selection honor catalog endpoints so Responses-only models such as Luna are never used for Chat compatibility probes
- align the stale malformed `output_config` integration case with the established #166 passthrough contract
- add unit and live integration coverage for OpenAI Chat plus Anthropic standard/beta, streaming and non-streaming

## Testing

- `uv run pytest tests/ -v` — 3536 passed
- focused provider/harness tests — 343 passed
- `make integration-test` with all model/reasoning overrides unset — 84 passed, 9 skipped
- Ruff lint, Ruff format check, and `git diff --check` — passed

## Review

- final production and test-coverage reviews found no blocking or actionable issues
- `uv.lock` was an unrelated pre-existing worktree change and is excluded from both commits